### PR TITLE
Table: noRowsRenderer should be a prop to be customizable

### DIFF
--- a/.storybook/preview-head.html
+++ b/.storybook/preview-head.html
@@ -40,4 +40,13 @@
         border: 1px solid #E40046;
         padding: 5px;
     }
+
+    .sc-table-noRows-override {
+      display: flex;
+      justify-content: center;
+      align-items: center;
+      height: 100%;
+      font-size: 16px;
+      font-weight: bold;
+    }
 </style>

--- a/dist/components/table/Table.component.js
+++ b/dist/components/table/Table.component.js
@@ -151,9 +151,10 @@ function Table(_ref) {
       onSort = _ref.onSort,
       sortBy = _ref.sortBy,
       sortDirection = _ref.sortDirection,
-      list = _ref.list;
+      list = _ref.list,
+      noRowsRenderer = _ref.noRowsRenderer;
 
-  var _noRowsRenderer = function _noRowsRenderer() {
+  var _defaultNoRowsRenderer = function _defaultNoRowsRenderer() {
     return _react.default.createElement("div", {
       className: "sc-table-noRows"
     }, "No rows");
@@ -207,7 +208,7 @@ function Table(_ref) {
       onHeaderClick: onHeaderClick,
       onRowClick: onRowClick,
       overscanRowCount: overscanRowCount || 5,
-      noRowsRenderer: _noRowsRenderer,
+      noRowsRenderer: noRowsRenderer || _defaultNoRowsRenderer,
       rowClassName: "sc-table-row",
       rowHeight: rowHeight,
       rowGetter: rowGetter,

--- a/src/lib/components/table/Table.component.js
+++ b/src/lib/components/table/Table.component.js
@@ -1,5 +1,6 @@
 //@flow
 import React from "react";
+import type { Node } from "react";
 import styled, { css } from "styled-components";
 import "react-virtualized/styles.css";
 import { lighten, ellipsis } from "polished";
@@ -28,7 +29,8 @@ export type Props = {
   rowHeight: number,
   onSort: () => void,
   sortBy: string,
-  sortDirection: string
+  sortDirection: string,
+  noRowsRenderer: Node
 };
 
 type HeaderProps = {
@@ -177,9 +179,10 @@ function Table({
   onSort,
   sortBy,
   sortDirection,
-  list
+  list,
+  noRowsRenderer
 }: Props) {
-  const _noRowsRenderer = () => {
+  const _defaultNoRowsRenderer = () => {
     return <div className={"sc-table-noRows"}>No rows</div>;
   };
 
@@ -227,7 +230,7 @@ function Table({
             onHeaderClick={onHeaderClick}
             onRowClick={onRowClick}
             overscanRowCount={overscanRowCount || 5}
-            noRowsRenderer={_noRowsRenderer}
+            noRowsRenderer={noRowsRenderer || _defaultNoRowsRenderer}
             rowClassName={"sc-table-row"}
             rowHeight={rowHeight}
             rowGetter={rowGetter}

--- a/stories/table.js
+++ b/stories/table.js
@@ -117,6 +117,10 @@ const ContainerWithClassName = styled.div`
   }
 `;
 
+const _noRowsRenderer = () => {
+  return <div className={"sc-table-noRows-override"}>No rows available</div>;
+};
+
 storiesOf("Table", module)
   .add("Default", () => {
     return (
@@ -199,6 +203,7 @@ storiesOf("Table", module)
           sortDirection={"DESC"}
           onSort={action("Sort Clicked")}
           onRowClick={action("Row Clicked")}
+          noRowsRenderer={_noRowsRenderer}
         />
       </div>
     );


### PR DESCRIPTION
**Component**:Table

<!-- E.g. 'Layout', 'Table', 'build', 'tests'... -->

**Description**:
- Actually, noRowsRenderer is hardcoded, it is not possible to override it.
 
**Design**:

**Breaking Changes**:

- [] Breaking Changes


---

<!-- Declare one or more issues to close once this PR gets merged -->

Closes: https://github.com/scality/core-ui/issues/39

<!-- If you want to refer to an issue while not closing it, use:

See: #ISSUE_NUMBER

-->
