### PR TITLE
Add defaultOptionRenderer  in Select component

### DIFF
--- a/src/lib/components/input/__snapshots__/Input.component.test.js.snap
+++ b/src/lib/components/input/__snapshots__/Input.component.test.js.snap
@@ -200,7 +200,7 @@ exports[`Storyshots Input Default 1`] = `
       className="sc-input-wrapper sc-bZQynM AMncx"
     >
       <div
-        className="sc-select sc-htpNat dyKhmK"
+        className="sc-select sc-htpNat hkyUAN"
       >
         <div
           className="Select has-value is-clearable is-searchable Select--single"

--- a/src/lib/components/select/Select.component.js
+++ b/src/lib/components/select/Select.component.js
@@ -2,9 +2,10 @@
 import React from "react";
 import styled from "styled-components";
 import Select from "react-virtualized-select";
+import type { Node } from "react";
+import { lighten } from "polished";
 import * as defaultTheme from "../../style/theme";
 import { mergeTheme } from "../../utils";
-import { lighten } from "polished";
 
 export type Item = {
   label: string,
@@ -13,7 +14,8 @@ export type Item = {
 type Items = Array<Item>;
 
 type Props = {
-  options: Items
+  options: Items,
+  optionRenderer?: any => Node
 };
 
 const SelectContainer = styled.div`
@@ -30,9 +32,13 @@ const SelectContainer = styled.div`
     outline: none;
   }
 
-  .VirtualizedSelectFocusedOption {
+  .VirtualizedSelectOption:hover {
     background-color: ${props =>
       lighten(0.3, mergeTheme(props.theme, defaultTheme).primary)};
+  }
+
+  .VirtualizedSelectSelectedOption {
+    background-color: ${defaultTheme.white};
   }
 
   .Select-menu-outer {
@@ -56,10 +62,64 @@ const SelectContainer = styled.div`
   }
 `;
 
-function SelectBox({ options, ...rest }: Props) {
+const defaultOptionRenderer = ({
+  focusedOption,
+  focusOption,
+  key,
+  labelKey,
+  option,
+  selectValue,
+  style,
+  valueArray
+}) => {
+  const classNames = ["sc-select-option", "VirtualizedSelectOption"];
+  const { disabled, className, title, ...rest } = option;
+
+  if (option === focusedOption) {
+    classNames.push("VirtualizedSelectFocusedOption");
+  }
+
+  if (disabled) {
+    classNames.push("VirtualizedSelectDisabledOption");
+  }
+
+  if (valueArray && valueArray.indexOf(option) >= 0) {
+    classNames.push("VirtualizedSelectSelectedOption");
+  }
+
+  if (className) {
+    classNames.push(className);
+  }
+
+  const events = disabled
+    ? {}
+    : {
+        onClick: () => selectValue(option),
+        onMouseEnter: () => focusOption(option)
+      };
+
+  return (
+    <div
+      className={classNames.join(" ")}
+      key={key}
+      style={style}
+      title={title}
+      {...events}
+      {...rest}
+    >
+      {option[labelKey]}
+    </div>
+  );
+};
+
+function SelectBox({ options, optionRenderer, ...rest }: Props) {
   return (
     <SelectContainer className="sc-select">
-      <Select options={options} {...rest} />
+      <Select
+        options={options}
+        optionRenderer={optionRenderer || defaultOptionRenderer}
+        {...rest}
+      />
     </SelectContainer>
   );
 }

--- a/src/lib/components/select/__snapshots__/Select.component.test.js.snap
+++ b/src/lib/components/select/__snapshots__/Select.component.test.js.snap
@@ -13,7 +13,7 @@ exports[`Storyshots Select Default 1`] = `
     }
   >
     <div
-      className="sc-select sc-bdVaJa gPWWsl"
+      className="sc-select sc-bdVaJa dXjhLN"
     >
       <div
         className="Select has-value is-clearable is-searchable Select--single"
@@ -123,6 +123,126 @@ exports[`Storyshots Select Default 1`] = `
     </div>
   </div>
   <h3>
+    Default with custom optionRenderer
+  </h3>
+  <div
+    style={
+      Object {
+        "width": "200px",
+      }
+    }
+  >
+    <div
+      className="sc-select sc-bdVaJa dXjhLN"
+    >
+      <div
+        className="Select has-value is-clearable is-searchable Select--single"
+      >
+        <input
+          disabled={false}
+          name="default_select"
+          type="hidden"
+          value="0"
+        />
+        <div
+          className="Select-control"
+          onKeyDown={[Function]}
+          onMouseDown={[Function]}
+          onTouchEnd={[Function]}
+          onTouchMove={[Function]}
+          onTouchStart={[Function]}
+        >
+          <div
+            className="Select-multi-value-wrapper"
+            id="react-select-3--value"
+          >
+            <div
+              className="Select-value"
+            >
+              <span
+                aria-selected="true"
+                className="Select-value-label"
+                id="react-select-3--value-item"
+                role="option"
+              >
+                Item 0
+              </span>
+            </div>
+            <div
+              className="Select-input"
+              style={
+                Object {
+                  "display": "inline-block",
+                }
+              }
+            >
+              <input
+                aria-activedescendant="react-select-3--value"
+                aria-expanded="false"
+                aria-haspopup="false"
+                aria-owns=""
+                onBlur={[Function]}
+                onChange={[Function]}
+                onFocus={[Function]}
+                required={false}
+                role="combobox"
+                style={
+                  Object {
+                    "boxSizing": "content-box",
+                    "width": "5px",
+                  }
+                }
+                value=""
+              />
+              <div
+                style={
+                  Object {
+                    "height": 0,
+                    "left": 0,
+                    "overflow": "scroll",
+                    "position": "absolute",
+                    "top": 0,
+                    "visibility": "hidden",
+                    "whiteSpace": "pre",
+                  }
+                }
+              >
+                
+              </div>
+            </div>
+          </div>
+          <span
+            aria-label="Clear value"
+            className="Select-clear-zone"
+            onMouseDown={[Function]}
+            onTouchEnd={[Function]}
+            onTouchMove={[Function]}
+            onTouchStart={[Function]}
+            title="Clear value"
+          >
+            <span
+              className="Select-clear"
+              dangerouslySetInnerHTML={
+                Object {
+                  "__html": "&times;",
+                }
+              }
+            />
+          </span>
+          <span
+            className="Select-arrow-zone"
+            onMouseDown={[Function]}
+          >
+            <span
+              className="Select-arrow"
+              onMouseDown={[Function]}
+            />
+          </span>
+        </div>
+      </div>
+    </div>
+  </div>
+  <h3>
     Multi Select
   </h3>
   <div
@@ -133,7 +253,7 @@ exports[`Storyshots Select Default 1`] = `
     }
   >
     <div
-      className="sc-select sc-bdVaJa gPWWsl"
+      className="sc-select sc-bdVaJa dXjhLN"
     >
       <div
         className="Select has-value is-clearable is-searchable Select--multi"
@@ -160,7 +280,7 @@ exports[`Storyshots Select Default 1`] = `
         >
           <div
             className="Select-multi-value-wrapper"
-            id="react-select-3--value"
+            id="react-select-4--value"
           >
             <div
               className="Select-value"
@@ -178,7 +298,7 @@ exports[`Storyshots Select Default 1`] = `
               <span
                 aria-selected="true"
                 className="Select-value-label"
-                id="react-select-3--value-0"
+                id="react-select-4--value-0"
                 role="option"
               >
                 Item 0
@@ -205,7 +325,7 @@ exports[`Storyshots Select Default 1`] = `
               <span
                 aria-selected="true"
                 className="Select-value-label"
-                id="react-select-3--value-1"
+                id="react-select-4--value-1"
                 role="option"
               >
                 Item 1
@@ -225,7 +345,7 @@ exports[`Storyshots Select Default 1`] = `
               }
             >
               <input
-                aria-activedescendant="react-select-3--value"
+                aria-activedescendant="react-select-4--value"
                 aria-expanded="false"
                 aria-haspopup="false"
                 aria-owns=""

--- a/stories/input.js
+++ b/stories/input.js
@@ -6,7 +6,8 @@ import { action } from "@storybook/addon-actions";
 import styled from "styled-components";
 const options = Array.from(new Array(1000), (_, index) => ({
   label: `Item ${index}`,
-  value: index
+  value: index,
+  "data-cy": `Item_${index}`
 }));
 
 const ExampleInput = () => {

--- a/stories/select.js
+++ b/stories/select.js
@@ -8,6 +8,57 @@ const options = Array.from(new Array(1000), (_, index) => ({
   value: index
 }));
 
+const customOptionRenderer = ({
+  focusedOption,
+  focusOption,
+  key,
+  labelKey,
+  option,
+  selectValue,
+  style,
+  valueArray
+}) => {
+  const classNames = ["sc-select-option", "VirtualizedSelectOption"];
+  const { disabled, className, title, ...rest } = option;
+
+  if (option === focusedOption) {
+    classNames.push("VirtualizedSelectFocusedOption");
+  }
+
+  if (disabled) {
+    classNames.push("VirtualizedSelectDisabledOption");
+  }
+
+  if (valueArray && valueArray.indexOf(option) >= 0) {
+    classNames.push("VirtualizedSelectSelectedOption");
+  }
+
+  if (className) {
+    classNames.push(className);
+  }
+
+  const events = disabled
+    ? {}
+    : {
+        onClick: () => selectValue(option),
+        onMouseEnter: () => focusOption(option)
+      };
+
+  return (
+    <div
+      className={classNames.join(" ")}
+      key={key}
+      style={style}
+      title={title}
+      {...events}
+      {...rest}
+    >
+      {option[labelKey]}&nbsp;
+      {option.value % 2 === 0 ? <i className="fas fa-flag-usa"></i> : null}
+    </div>
+  );
+};
+
 storiesOf("Select", module).add("Default", () => {
   return (
     <div>
@@ -20,6 +71,18 @@ storiesOf("Select", module).add("Default", () => {
           placeholder="Select an item..."
           noResultsText="Not found"
           value={options[0]}
+        />
+      </div>
+      <h3>Default with custom optionRenderer</h3>
+      <div style={{ width: "200px" }}>
+        <Select
+          name="default_select"
+          options={options}
+          onChange={e => console.log(e)}
+          placeholder="Select an item..."
+          noResultsText="Not found"
+          value={options[0]}
+          optionRenderer={customOptionRenderer}
         />
       </div>
       <h3>Multi Select</h3>


### PR DESCRIPTION
**Component**:Select/Input

<!-- E.g. 'Layout', 'Table', 'build', 'tests'... -->

**Description**:
- Add ```defaultOptionRenderer``` in Select component so we can add more fields for select such as data-cy for integration tests
- Add ```optionRenderer``` in the props to override the ```defaultOptionRenderer``` if needed

**Design**:

**Breaking Changes**:

- [] Breaking Changes


---

<!-- Declare one or more issues to close once this PR gets merged -->

Closes: #ISSUE_NUMBER

<!-- If you want to refer to an issue while not closing it, use:

See: #ISSUE_NUMBER

-->
