### PR TITLE
CI: Add post-merge stage to deploy Storybook

### DIFF
--- a/eve/main.yml
+++ b/eve/main.yml
@@ -4,6 +4,8 @@ version: "0.2"
 branches:
   user/*, feature/*, improvement/*, bugfix/*, w/*, q/*, hotfix/*, dependabot/*:
     stage: pre-merge
+  development/*:
+    stage: post-merge
 
 stages:
   pre-merge:
@@ -36,4 +38,35 @@ stages:
           command: >
             npm install -g yarn &&
             yarn && yarn test
+          haltOnFailure: false
+  post-merge:
+    worker:
+      type: local
+    steps:
+      - TriggerStages:
+          name: Trigger storybook_deploy
+          stage_names:
+            - storybook_deploy
+          haltOnFailure: true
+  storybook_deploy:
+    worker:
+      type: kube_pod
+      path: eve/workers/pod-unit-tests/pod.yaml
+      images:
+        docker-unit-tests:
+          context: '.'
+          dockerfile: eve/workers/pod-unit-tests/Dockerfile
+    steps:
+      - Git: &git_pull
+          name: git pull
+          repourl: "%(prop:git_reference)s"
+          method: clobber
+          retryFetch: true
+          haltOnFailure: true
+      - ShellCommand:
+          name: Deploy storybook
+          workdir: build/core-ui
+          command: >
+            npm install -g yarn &&
+            yarn && yarn deploy-storybook -- --ci --host-token-env-variable=%(secret:github_token)s
           haltOnFailure: false


### PR DESCRIPTION
**Component**:CI

<!-- E.g. 'Layout', 'Table', 'build', 'tests'... -->

**Description**:
- We currently deploy Storybook manually after each merge, we should execute it in the CI's post-merge stage.
- Wait for https://scality.atlassian.net/browse/RELENG-3237 to have the github access token available in the CI

**Design**:

**Breaking Changes**:

- [] Breaking Changes


---

<!-- Declare one or more issues to close once this PR gets merged -->

Closes: #ISSUE_NUMBER

<!-- If you want to refer to an issue while not closing it, use:

See: #ISSUE_NUMBER

-->
