### PR TITLE
fix the bugs for the color misuse

### DIFF
--- a/src/lib/components/table/Table.component.js
+++ b/src/lib/components/table/Table.component.js
@@ -61,7 +61,7 @@ const TableContainer = styled.div`
   }
 
   .ReactVirtualized__Table__headerRow {
-    background-color: ${getThemePropSelector("background")};
+    background-color: ${getThemePropSelector("primary")};
     border-bottom: 2px solid ${getThemePropSelector("borderLight")};
     color: ${getThemePropSelector("textPrimary")};
 

--- a/src/lib/components/tooltip/Tooltip.component.js
+++ b/src/lib/components/tooltip/Tooltip.component.js
@@ -27,10 +27,10 @@ const TooltipOverLayContainer = styled.div`
   position: absolute;
   background-color: ${props =>
     (props && props.overlaystyle && props.overlaystyle.backgroundColor) ||
-    getTheme(props).primaryDark1};
+    getTheme(props).primaryDark2};
   color: ${props =>
     (props && props.overlaystyle && props.overlaystyle.color) ||
-    getTheme(props).text}
+    getTheme(props).textPrimary}
   z-index: ${defaultTheme.zIndex.tooltip};
   border-radius: 4px;
   font-size: ${props =>


### PR DESCRIPTION
**Component**: tooltip

**Description**:
Forgot to update the font color for tooltip

**Design**:
- set the font color to textPrimary, instead of text( we removed this prop)
- set the background color to primaryDark2, in order to have a better view

**Breaking Changes**:

- [] Breaking Changes


---

<!-- Declare one or more issues to close once this PR gets merged -->

Closes: #ISSUE_NUMBER

<!-- If you want to refer to an issue while not closing it, use:

See: #ISSUE_NUMBER

-->
