### PR TITLE
Remove react-virtualised as peer dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -70,7 +70,6 @@
     "react": "^16.8.0",
     "react-dom": "^16.8.0",
     "react-debounce-input": "3.2.2",
-    "react-virtualized": "9.21.0",
     "react-select": "3.0.3",
     "styled-components": "^4.1.2",
     "vega": "^5.7.3",


### PR DESCRIPTION
**Component**:

<!-- E.g. 'Layout', 'Table', 'build', 'tests'... -->

**Description**:

Uncaught ReferenceError: CellMeasurer is not defined

**Design**:

**Breaking Changes**:

- [] Breaking Changes


---

<!-- Declare one or more issues to close once this PR gets merged -->

Closes: #ISSUE_NUMBER

<!-- If you want to refer to an issue while not closing it, use:

See: #ISSUE_NUMBER

-->
