### PR TITLE
VegaChart: Remove the useless callback

### DIFF
--- a/src/lib/components/linechart/LineChart.component.js
+++ b/src/lib/components/linechart/LineChart.component.js
@@ -85,12 +85,12 @@ function LineChart({
   };
 
   const spec = {
-    $schema: "https://vega.github.io/schema/vega-lite/v4.json",
     data: { values: data },
     encoding: {
       x: xAxis,
       color,
-      tooltip: tooltip && [xAxis, ...yAxis],
+      // To disable tooltips for a particular single view specification, you can set the "tooltip" property of a mark definition block to null.
+      tooltip: tooltip ? [xAxis, ...yAxis] : null,
     },
     height,
     width,

--- a/src/lib/components/linechart/LineChart.component.js
+++ b/src/lib/components/linechart/LineChart.component.js
@@ -11,7 +11,7 @@ type Props = {
   lineConfig?: Object,
   width?: number,
   height?: number,
-  displayTrendLine?: boolean
+  displayTrendLine?: boolean,
 };
 
 function LineChart({
@@ -35,25 +35,25 @@ function LineChart({
         type: "single",
         on: "mousemove",
         encodings: ["x"],
-        nearest: true
-      }
+        nearest: true,
+      },
     },
     encoding: {
       color: {
         condition: {
           selection: { not: "index" },
-          value: "transparent"
-        }
-      }
-    }
+          value: "transparent",
+        },
+      },
+    },
   };
 
-  const lines = yAxis.map(y => ({
+  const lines = yAxis.map((y) => ({
     mark: {
       type: "line",
-      ...lineConfig
+      ...lineConfig,
     },
-    encoding: { y }
+    encoding: { y },
   }));
 
   const currentTimeTrendline = {
@@ -61,13 +61,13 @@ function LineChart({
       type: "rule",
       style: "ruleCurrentTime",
       color: "white",
-      opacity: 0.2
+      opacity: 0.2,
     },
     encoding: {
       x: { value: width / 2 },
       y: { value: height },
-      y2: { value: 0 }
-    }
+      y2: { value: 0 },
+    },
   };
 
   const topTrendline = {
@@ -75,26 +75,27 @@ function LineChart({
       type: "rule",
       style: "ruleTop",
       color: "orange",
-      opacity: 0.2
+      opacity: 0.2,
     },
     encoding: {
       y: { aggregate: "max", field: "capacity", type: "quantitative" },
       x: { value: 0 },
-      x2: { value: width }
-    }
+      x2: { value: width },
+    },
   };
 
   const spec = {
+    $schema: "https://vega.github.io/schema/vega-lite/v4.json",
     data: { values: data },
     encoding: {
       x: xAxis,
       color,
-      tooltip: tooltip && [xAxis, ...yAxis]
+      tooltip: tooltip && [xAxis, ...yAxis],
     },
     height,
     width,
     layer: [...lines],
-    ...rest
+    ...rest,
   };
   if (tooltip) {
     spec.layer.push(trendline);

--- a/src/lib/components/vegachart/VegaChart.component.js
+++ b/src/lib/components/vegachart/VegaChart.component.js
@@ -48,7 +48,7 @@ function VegaChart({ id, spec, theme = "light" }: Props) {
         color: brandText,
         font: "Lato",
       },
-      // the up,bottom trend line and verticle line when hover
+      // the up, bottom trend line and verticle line when hover
       rule: {
         color: brandText,
       },
@@ -70,11 +70,8 @@ function VegaChart({ id, spec, theme = "light" }: Props) {
       // If the value is true, all action links will be shown and none if the value is false.
       actions: false,
     })
-      .then(({ spec, view }) => {
-        // Access the Vega view instance (https://vega.github.io/vega/docs/api/view/)
-        view.addEventListener("click", function (event, item) {
-          // Event Handling refer to: https://github.com/vega/vega-view#event-handling
-        });
+      .then(function (result) {
+        // Access the Vega view instance (https://vega.github.io/vega/docs/api/view/) as result.view
       })
       .catch(console.error);
   }, [id, themedSpec, theme]);


### PR DESCRIPTION
**Component**: VegaChart

**Description**:
- Remove the action of the promise which causes the bug when using the line chart in the application.
- Fix`WARN Dropping false from channel "tooltip" since it does not contain data field or value.`
( I added the action for `vega-lite` status bar so that I can jump to another URL by hyperlink when clicking on the bar.)
