### PR TITLE
Progressbar: Fill the progress bar in the correct percentage

### DIFF
--- a/src/lib/components/progressbar/ProgressBar.component.js
+++ b/src/lib/components/progressbar/ProgressBar.component.js
@@ -20,13 +20,11 @@ export type ProgressBarProps = {
   isAnimation?: boolean,
 };
 
-const Container = styled.div`
-  /* margin: ${defaultTheme.padding.small}; */
-`;
+const Container = styled.div``;
 
 const ProgressBarContainer = styled.div`
   display: flex;
-  border-radius: 12px;
+  border-radius: 4px;
   justify-content: space-between;
   align-items: center;
 
@@ -41,12 +39,13 @@ const ProgressBarContainer = styled.div`
       case "base":
         return css`
           height: 12px;
-          font-size: ${defaultTheme.fontSize.base};
+          font-size: ${defaultTheme.fontSize.small};
         `;
 
       case "large":
         return css`
           height: 15px;
+          font-size: ${defaultTheme.fontSize.base};
         `;
 
       case "larger":
@@ -106,7 +105,9 @@ const BottomLabelsContainer = styled(TopLabelsContainer)`
 `;
 
 const FilledAreaContainer = styled.div`
-  border-radius: 12px;
+  display: flex;
+  justify-content: flex-start;
+  border-radius: 4px;
   height: 100%;
   ${(props) => {
     if (props.isAnimation) {
@@ -135,9 +136,10 @@ const FilledAreaContainer = styled.div`
   }}
 `;
 
-const BuildinLabel = styled.span`
-  color: ${getThemePropSelector("textPrimary")}};
-  padding-right:5px;
+const BuildinLabel = styled.div`
+  color: ${getThemePropSelector("textPrimary")};
+  padding-left: 5px;
+  white-space: nowrap;
 `;
 
 function ProgressBar({
@@ -178,8 +180,9 @@ function ProgressBar({
           color={color}
           width={percentage}
           isAnimation={isAnimation}
-        ></FilledAreaContainer>
-        <BuildinLabel>{buildinLabel}</BuildinLabel>
+        >
+          <BuildinLabel>{buildinLabel}</BuildinLabel>
+        </FilledAreaContainer>
       </ProgressBarContainer>
 
       {(bottomLeftLabel || bottomRightLabel) && (

--- a/src/lib/components/progressbar/__snapshots__/ProgressBar.component.test.js.snap
+++ b/src/lib/components/progressbar/__snapshots__/ProgressBar.component.test.js.snap
@@ -17,7 +17,7 @@ exports[`Storyshots ProgressBar Default 1`] = `
       Smaller
     </h3>
     <div
-      className="sc-bdVaJa hEPghN sc-progressbar"
+      className="sc-bdVaJa bDWFJH sc-progressbar"
     >
       <div
         className="sc-EHOje kvGeEx"
@@ -34,18 +34,19 @@ exports[`Storyshots ProgressBar Default 1`] = `
         </span>
       </div>
       <div
-        className="sc-bwzfXH idGPbB sc-progressbarcontainer"
+        className="sc-bwzfXH jDAtdl sc-progressbarcontainer"
         size="smaller"
       >
         <div
-          className="sc-gzVnrw juUkfm"
+          className="sc-gzVnrw bCqEum"
           width={50}
-        />
-        <span
-          className="sc-htoDjs fuCEEC"
         >
-          50%
-        </span>
+          <div
+            className="sc-htoDjs jwlwyp"
+          >
+            50%
+          </div>
+        </div>
       </div>
       <div
         className="sc-EHOje sc-bZQynM dgHRVU"
@@ -68,7 +69,7 @@ exports[`Storyshots ProgressBar Default 1`] = `
       Base
     </h3>
     <div
-      className="sc-bdVaJa hEPghN sc-progressbar"
+      className="sc-bdVaJa bDWFJH sc-progressbar"
     >
       <div
         className="sc-EHOje kvGeEx"
@@ -85,18 +86,19 @@ exports[`Storyshots ProgressBar Default 1`] = `
         </span>
       </div>
       <div
-        className="sc-bwzfXH iXyyMs sc-progressbarcontainer"
+        className="sc-bwzfXH ipOTRh sc-progressbarcontainer"
         size="base"
       >
         <div
-          className="sc-gzVnrw juUkfm"
+          className="sc-gzVnrw bCqEum"
           width={50}
-        />
-        <span
-          className="sc-htoDjs fuCEEC"
         >
-          50%
-        </span>
+          <div
+            className="sc-htoDjs jwlwyp"
+          >
+            50%
+          </div>
+        </div>
       </div>
       <div
         className="sc-EHOje sc-bZQynM dgHRVU"
@@ -119,7 +121,7 @@ exports[`Storyshots ProgressBar Default 1`] = `
       Large with animation
     </h3>
     <div
-      className="sc-bdVaJa hEPghN sc-progressbar"
+      className="sc-bdVaJa bDWFJH sc-progressbar"
     >
       <div
         className="sc-EHOje kvGeEx"
@@ -136,18 +138,19 @@ exports[`Storyshots ProgressBar Default 1`] = `
         </span>
       </div>
       <div
-        className="sc-bwzfXH AeOY sc-progressbarcontainer"
+        className="sc-bwzfXH fzVZHc sc-progressbarcontainer"
         size="large"
       >
         <div
-          className="sc-gzVnrw iOmtUz"
+          className="sc-gzVnrw kSvHQq"
           width={50}
-        />
-        <span
-          className="sc-htoDjs fuCEEC"
         >
-          50%
-        </span>
+          <div
+            className="sc-htoDjs jwlwyp"
+          >
+            50%
+          </div>
+        </div>
       </div>
       <div
         className="sc-EHOje sc-bZQynM dgHRVU"
@@ -170,7 +173,7 @@ exports[`Storyshots ProgressBar Default 1`] = `
       Larger
     </h3>
     <div
-      className="sc-bdVaJa hEPghN sc-progressbar"
+      className="sc-bdVaJa bDWFJH sc-progressbar"
     >
       <div
         className="sc-EHOje kvGeEx"
@@ -187,18 +190,19 @@ exports[`Storyshots ProgressBar Default 1`] = `
         </span>
       </div>
       <div
-        className="sc-bwzfXH gbmaUX sc-progressbarcontainer"
+        className="sc-bwzfXH jOIsqe sc-progressbarcontainer"
         size="larger"
       >
         <div
-          className="sc-gzVnrw juUkfm"
+          className="sc-gzVnrw bCqEum"
           width={50}
-        />
-        <span
-          className="sc-htoDjs fuCEEC"
         >
-          50%
-        </span>
+          <div
+            className="sc-htoDjs jwlwyp"
+          >
+            50%
+          </div>
+        </div>
       </div>
       <div
         className="sc-EHOje sc-bZQynM dgHRVU"
@@ -221,7 +225,7 @@ exports[`Storyshots ProgressBar Default 1`] = `
       Different colors
     </h3>
     <div
-      className="sc-bdVaJa hEPghN sc-progressbar"
+      className="sc-bdVaJa bDWFJH sc-progressbar"
     >
       <div
         className="sc-EHOje kvGeEx"
@@ -238,19 +242,20 @@ exports[`Storyshots ProgressBar Default 1`] = `
         </span>
       </div>
       <div
-        className="sc-bwzfXH idGPbB sc-progressbarcontainer"
+        className="sc-bwzfXH jDAtdl sc-progressbarcontainer"
         size="smaller"
       >
         <div
-          className="sc-gzVnrw fApfET"
+          className="sc-gzVnrw gGYPDN"
           color="#2f67ac"
           width={50}
-        />
-        <span
-          className="sc-htoDjs fuCEEC"
         >
-          50%
-        </span>
+          <div
+            className="sc-htoDjs jwlwyp"
+          >
+            50%
+          </div>
+        </div>
       </div>
       <div
         className="sc-EHOje sc-bZQynM dgHRVU"
@@ -268,7 +273,7 @@ exports[`Storyshots ProgressBar Default 1`] = `
       </div>
     </div>
     <div
-      className="sc-bdVaJa hEPghN sc-progressbar"
+      className="sc-bdVaJa bDWFJH sc-progressbar"
     >
       <div
         className="sc-EHOje kvGeEx"
@@ -280,23 +285,24 @@ exports[`Storyshots ProgressBar Default 1`] = `
         </span>
       </div>
       <div
-        className="sc-bwzfXH idGPbB sc-progressbarcontainer"
+        className="sc-bwzfXH jDAtdl sc-progressbarcontainer"
         size="smaller"
       >
         <div
-          className="sc-gzVnrw jiAxeB"
+          className="sc-gzVnrw fUmQMm"
           color="#ff5722"
           width={10}
-        />
-        <span
-          className="sc-htoDjs fuCEEC"
         >
-          10%
-        </span>
+          <div
+            className="sc-htoDjs jwlwyp"
+          >
+            10%
+          </div>
+        </div>
       </div>
     </div>
     <div
-      className="sc-bdVaJa hEPghN sc-progressbar"
+      className="sc-bdVaJa bDWFJH sc-progressbar"
     >
       <div
         className="sc-EHOje kvGeEx"
@@ -313,19 +319,20 @@ exports[`Storyshots ProgressBar Default 1`] = `
         </span>
       </div>
       <div
-        className="sc-bwzfXH idGPbB sc-progressbarcontainer"
+        className="sc-bwzfXH jDAtdl sc-progressbarcontainer"
         size="smaller"
       >
         <div
-          className="sc-gzVnrw gIYNeu"
+          className="sc-gzVnrw kVMAsv"
           color="#982803"
           width={90}
-        />
-        <span
-          className="sc-htoDjs fuCEEC"
         >
-          90%
-        </span>
+          <div
+            className="sc-htoDjs jwlwyp"
+          >
+            90%
+          </div>
+        </div>
       </div>
     </div>
   </div>


### PR DESCRIPTION
**Component**: Progress bar

**Description**:
Problems we had before:
The percentage of the progress bar was not correct because of the `text` inside.
When the percentage number is small(1%) the filled part is outside of the container.

Fixed the 2 issues above.

**Design**:
![image](https://user-images.githubusercontent.com/18453133/93983812-58c3ee00-fd83-11ea-85b8-cf0aaca66539.png)


