### PR TITLE
Add opacity for disabled button instead of adding lightness

### DIFF
--- a/src/lib/components/button/Button.component.js
+++ b/src/lib/components/button/Button.component.js
@@ -148,7 +148,7 @@ ${props => {
       ? `
           box-shadow: none;
           pointer-events: none;
-          background-color: ${brandLighter};
+          opacity: 0.2;
           border-color: ${brandLighter};
           color: ${defaultTheme.white};
         `

--- a/src/lib/components/button/__snapshots__/Button.component.test.js.snap
+++ b/src/lib/components/button/__snapshots__/Button.component.test.js.snap
@@ -258,7 +258,7 @@ exports[`Storyshots Button Default 1`] = `
     Button Disabled
   </h3>
   <button
-    className="sc-bxivhb dsfYFV sc-button"
+    className="sc-bxivhb ddnOwU sc-button"
     disabled={true}
     onClick={[Function]}
     size="base"
@@ -280,7 +280,51 @@ exports[`Storyshots Button Default 1`] = `
     </span>
   </button>
   <button
-    className="sc-bxivhb diowwC sc-button"
+    className="sc-bxivhb jpzxRX sc-button"
+    disabled={true}
+    onClick={[Function]}
+    size="base"
+    title=""
+    type="button"
+  >
+    <span
+      className="sc-bZQynM iMWVsx"
+    >
+      <span
+        className="sc-button-text"
+      >
+        <span
+          className="sc-EHOje boinrg"
+        >
+          secondary
+        </span>
+      </span>
+    </span>
+  </button>
+  <button
+    className="sc-bxivhb vrodH sc-button"
+    disabled={true}
+    onClick={[Function]}
+    size="base"
+    title=""
+    type="button"
+  >
+    <span
+      className="sc-bZQynM iMWVsx"
+    >
+      <span
+        className="sc-button-text"
+      >
+        <span
+          className="sc-EHOje boinrg"
+        >
+          critical
+        </span>
+      </span>
+    </span>
+  </button>
+  <button
+    className="sc-bxivhb dsiAlN sc-button"
     disabled={true}
     size="larger"
     title=""
@@ -332,7 +376,7 @@ exports[`Storyshots Button Default 1`] = `
     Button Loading
   </h3>
   <button
-    className="sc-bxivhb dsfYFV sc-button"
+    className="sc-bxivhb ddnOwU sc-button"
     disabled={true}
     size="base"
     title=""

--- a/stories/button.js
+++ b/stories/button.js
@@ -39,6 +39,18 @@ storiesOf("Button", module)
           onClick={action("Button Disabled Click")}
         />
         <Button
+          variant="secondary"
+          disabled
+          text="secondary"
+          onClick={action("Button Disabled Click")}
+        />
+        <Button
+          variant="critical"
+          disabled
+          text="critical"
+          onClick={action("Button Disabled Click")}
+        />
+        <Button
           inverted={true}
           size="larger"
           icon={<i className="fas fa-star" />}


### PR DESCRIPTION
**Component**: button

**Description**:
According to the design, we should add opacity for the disabled button instead of adding the lightness of the background color.

**Design**:

![image](https://user-images.githubusercontent.com/18453133/98702008-31989e80-237a-11eb-87fe-20d9f4415160.png)
![image](https://user-images.githubusercontent.com/18453133/98702024-365d5280-237a-11eb-9119-9e209cba851f.png)

---

<!-- Declare one or more issues to close once this PR gets merged -->

Closes: #206

<!-- If you want to refer to an issue while not closing it, use:

See: #ISSUE_NUMBER

-->
