### PR TITLE
[Jest] Set maxWorkers to 1 in the CI to avoid tests randomly failing

### DIFF
--- a/eve/main.yml
+++ b/eve/main.yml
@@ -26,7 +26,7 @@ stages:
           workdir: build/core-ui
           command: >
             npm ci &&
-            npm run test &&
+            npm run test -- -w 1 &&
             npm run flow &&
             npm run lint
           haltOnFailure: false


### PR DESCRIPTION
**Component**: tests, CI

**Description**:
We encoutered tests randomly failling on CI
ENOMEM: not enough memory, read

      at ScriptTransformer._transformAndBuildScript (node_modules/@jest/transform/build/ScriptTransformer.js:509:43)
      at ScriptTransformer.transform (node_modules/@jest/transform/build/ScriptTransformer.js:579:25)

Try the solution:
https://github.com/dequelabs/cauldron-react/issues/190#issuecomment-569962657

> For this issue, I think we should explore the maxWorkers jest cli option. After quick googling it appears that tons of people have "fixed" this issue by running the tests like with the flag -w 1 to allow for only 1 worker