### PR TITLE
Move the Constrainedtext to coreui

### DIFF
--- a/src/lib/components/constrainedtext/Constrainedtext.component.js
+++ b/src/lib/components/constrainedtext/Constrainedtext.component.js
@@ -1,0 +1,46 @@
+//@flow
+import React from "react";
+import type { Node } from "react";
+import styled from "styled-components";
+import Tooltip from "../tooltip/Tooltip.component.js";
+import type { Props as TooltipProps } from "../tooltip/Tooltip.component.js";
+type Props = {
+  text: string,
+  tooltipStyle?: $PropertyType<TooltipProps, "overlayStyle">,
+  tooltipPlacement?: $PropertyType<TooltipProps, "placement">,
+};
+
+const ConstrainedTextContainer = styled.div`
+  overflow: hidden;
+  text-overflow: ellipsis;
+  word-wrap: break-word;
+  white-space: nowrap;
+`;
+
+const BlockTooltip = styled.div`
+  & > .sc-tooltip {
+    display: block;
+  }
+`;
+
+function ConstrainedText({
+  text,
+  tooltipStyle,
+  tooltipPlacement,
+}: Props): Node {
+  return (
+    <BlockTooltip>
+      <Tooltip
+        overlay={text}
+        overlayStyle={tooltipStyle}
+        placement={tooltipPlacement}
+      >
+        <ConstrainedTextContainer className="sc-constrainedtext">
+          {text}
+        </ConstrainedTextContainer>
+      </Tooltip>
+    </BlockTooltip>
+  );
+}
+
+export default ConstrainedText;

--- a/src/lib/components/constrainedtext/Constrainedtext.component.test.js
+++ b/src/lib/components/constrainedtext/Constrainedtext.component.test.js
@@ -1,0 +1,5 @@
+import initStoryshots from "@storybook/addon-storyshots";
+
+initStoryshots({
+  configPath: "src/lib/components/constrainedtext/__snapshots__"
+});

--- a/src/lib/components/constrainedtext/__snapshots__/Constrainedtext.component.test.js.snap
+++ b/src/lib/components/constrainedtext/__snapshots__/Constrainedtext.component.test.js.snap
@@ -1,0 +1,66 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Storyshots Constrainedtext Default 1`] = `
+<div
+  className="sc-ifAKCX ugGGx"
+>
+  <h3
+    className="sc-EHOje ftwWfK"
+  >
+    Constrained Text
+  </h3>
+  <div
+    style={
+      Object {
+        "color": "#0F7FFF",
+        "width": "100px",
+      }
+    }
+  >
+    <div
+      className="sc-bxivhb fJlOgN"
+    >
+      <div
+        className="sc-bdVaJa jCeSos sc-tooltip"
+        onMouseEnter={[Function]}
+        onMouseLeave={[Function]}
+      >
+        <div
+          className="sc-htpNat hRShHO sc-constrainedtext"
+        >
+          This is a long phrase
+        </div>
+      </div>
+    </div>
+  </div>
+  <h3
+    className="sc-EHOje ftwWfK"
+  >
+    With the ability to customize the style of tooltip
+  </h3>
+  <div
+    style={
+      Object {
+        "color": "#0F7FFF",
+        "width": "100px",
+      }
+    }
+  >
+    <div
+      className="sc-bxivhb fJlOgN"
+    >
+      <div
+        className="sc-bdVaJa jCeSos sc-tooltip"
+        onMouseEnter={[Function]}
+        onMouseLeave={[Function]}
+      >
+        <div
+          className="sc-htpNat hRShHO sc-constrainedtext"
+        >
+          This is a long phrase
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;

--- a/src/lib/components/constrainedtext/__snapshots__/config.js
+++ b/src/lib/components/constrainedtext/__snapshots__/config.js
@@ -1,0 +1,7 @@
+import { configure } from "@storybook/react";
+
+function loadStories() {
+  require("../../../../../stories/constrainedtext");
+}
+
+configure(loadStories, module);

--- a/src/lib/components/tooltip/Tooltip.component.js
+++ b/src/lib/components/tooltip/Tooltip.component.js
@@ -10,11 +10,16 @@ export const BOTTOM = "bottom";
 export const LEFT = "left";
 export const RIGHT = "right";
 type Position = typeof TOP | typeof BOTTOM | typeof LEFT | typeof RIGHT;
-type Props = {
+export type Props = {
   placement?: Position,
-  overlaystyle?: Node,
+  overlayStyle?: {
+    backgroundColor?: string,
+    color?: string,
+    fontSize?: string,
+    width?: string,
+  },
   overlay?: Node,
-  children?: Node
+  children?: Node,
 };
 
 const TooltipContainer = styled.div`
@@ -25,21 +30,23 @@ const TooltipContainer = styled.div`
 const TooltipOverLayContainer = styled.div`
   display: flex;
   position: absolute;
-  background-color: ${props =>
-    (props && props.overlaystyle && props.overlaystyle.backgroundColor) ||
+  background-color: ${(props) =>
+    (props && props.overlayStyle && props.overlayStyle.backgroundColor) ||
     getTheme(props).primaryDark2};
-  color: ${props =>
-    (props && props.overlaystyle && props.overlaystyle.color) ||
+  color: ${(props) =>
+    (props && props.overlayStyle && props.overlayStyle.color) ||
     getTheme(props).textPrimary}
   z-index: ${defaultTheme.zIndex.tooltip};
   border-radius: 4px;
-  font-size: ${props =>
-    (props && props.overlaystyle && props.overlaystyle.fontSize) ||
+  font-size: ${(props) =>
+    (props && props.overlayStyle && props.overlayStyle.fontSize) ||
     defaultTheme.fontSize.small};
+  width:${(props) =>
+    (props && props.overlayStyle && props.overlayStyle.width) || "50px"};
   text-align: center;
   vertical-align: middle;
   padding: ${defaultTheme.padding.smaller};
-    ${props => {
+    ${(props) => {
       switch (props.placement) {
         case LEFT:
           return css`
@@ -71,7 +78,7 @@ const TooltipOverLayContainer = styled.div`
 
 function Tooltip({
   placement = TOP,
-  overlaystyle,
+  overlayStyle,
   children,
   overlay,
   ...rest
@@ -88,7 +95,7 @@ function Tooltip({
         <TooltipOverLayContainer
           className="sc-tooltip-overlay"
           placement={placement}
-          overlaystyle={overlaystyle}
+          overlayStyle={overlayStyle}
         >
           <div className="sc-tooltip-overlay-text">{overlay}</div>
         </TooltipOverLayContainer>

--- a/src/lib/index.js
+++ b/src/lib/index.js
@@ -1,5 +1,6 @@
 //@flow
 import "@fortawesome/fontawesome-free/css/all.css";
+import "./index.css";
 
 import Banner from "./components/banner/Banner.component";
 import Breadcrumb from "./components/breadcrumb/Breadcrumb.component";
@@ -36,7 +37,7 @@ import CollapsiblePanel from "./components/collapsiblepanel/CollapsiblePanel.com
 import LateralNavbarLayout from "./components/lateralnavbarlayout/LateralNavbarLayout.component";
 import StatusBar from "./components/statusbar/StatusBar.component";
 import Healthselector from "./components/healthselector/Healthselector.component";
-import "./index.css";
+import ConstrainedText from "./components/constrainedtext/Constrainedtext.component";
 
 export {
   LOADER_SIZE,
@@ -74,4 +75,5 @@ export {
   LateralNavbarLayout,
   StatusBar,
   Healthselector,
+  ConstrainedText,
 };

--- a/stories/constrainedtext.js
+++ b/stories/constrainedtext.js
@@ -1,0 +1,37 @@
+//@flow
+import React from "react";
+import { storiesOf } from "@storybook/react";
+import Constrainedtext from "../src/lib/components/constrainedtext/Constrainedtext.component";
+import { Wrapper, Title } from "./common";
+
+storiesOf("Constrainedtext", module).add("Default", () => {
+  return (
+    <Wrapper>
+      <Title>Constrained Text</Title>
+      <div
+        style={{
+          width: "100px",
+          color: "#0F7FFF",
+        }}
+      >
+        <Constrainedtext
+          text={"This is a long phrase"}
+          tooltipStyle={{ width: "100px" }}
+        />
+      </div>
+      <Title>With the ability to customize the style of tooltip</Title>
+      <div
+        style={{
+          width: "100px",
+          color: "#0F7FFF",
+        }}
+      >
+        <Constrainedtext
+          text={"This is a long phrase"}
+          tooltipStyle={{ width: "100px" }}
+          tooltipPlacement="right"
+        />
+      </div>
+    </Wrapper>
+  );
+});

--- a/stories/index.js
+++ b/stories/index.js
@@ -34,3 +34,4 @@ import "./colorPalette";
 import "./lateralnavbarlayout";
 import "./statusbar";
 import "./healthselector";
+import "./constrainedtext";

--- a/stories/tooltip.js
+++ b/stories/tooltip.js
@@ -36,7 +36,11 @@ storiesOf("Tooltip", module).add("Default", () => {
         <Title>Customize your tooltip style</Title>
         <Tooltip
           placement="right"
-          overlaystyle={{ backgroundColor: "green", fontSize: "20px" }}
+          overlayStyle={{
+            backgroundColor: "green",
+            fontSize: "20px",
+            width: "120px",
+          }}
           overlay="Helloooooo"
         >
           <SubTitle>Hover here!</SubTitle>


### PR DESCRIPTION
**Component**: Constrained text

**Description**:
The constrained text should locate in core-ui rather than the application.
So that we can reuse it inside any component to display the long text when there is no enough space for it, e.g. Table
![image](https://user-images.githubusercontent.com/18453133/107980533-bec64180-6fc0-11eb-98a8-d11a2203caa6.png)

**Design**:
![image](https://user-images.githubusercontent.com/18453133/107980600-dc93a680-6fc0-11eb-8df4-7feb3da25d86.png)


