### PR TITLE
Bugfix the default color & width of tooltip

### DIFF
--- a/src/lib/components/tooltip/Tooltip.component.js
+++ b/src/lib/components/tooltip/Tooltip.component.js
@@ -35,45 +35,44 @@ const TooltipOverLayContainer = styled.div`
     getTheme(props).primaryDark2};
   color: ${(props) =>
     (props && props.overlayStyle && props.overlayStyle.color) ||
-    getTheme(props).textPrimary}
+    getTheme(props).textPrimary};
   z-index: ${defaultTheme.zIndex.tooltip};
   border-radius: 4px;
   font-size: ${(props) =>
     (props && props.overlayStyle && props.overlayStyle.fontSize) ||
     defaultTheme.fontSize.small};
-  width:${(props) =>
-    (props && props.overlayStyle && props.overlayStyle.width) || "50px"};
+  width: ${(props) => props && props.overlayStyle && props.overlayStyle.width};
   text-align: center;
   vertical-align: middle;
   padding: ${defaultTheme.padding.smaller};
-    ${(props) => {
-      switch (props.placement) {
-        case LEFT:
-          return css`
-            right: calc(100% + 10px);
-            top: 50%;
-            transform: translateY(-50%);
-          `;
-        case RIGHT:
-          return css`
-            left: calc(100% + 10px);
-            top: 50%;
-            transform: translateY(-50%);
-          `;
-        case BOTTOM:
-          return css`
-            top: calc(100% + 10px);
-            left: 50%;
-            transform: translateX(-50%);
-          `;
-        default:
-          return css`
-            bottom: calc(100% + 10px);
-            left: 50%;
-            transform: translateX(-50%);
-          `;
-      }
-    }};
+  ${(props) => {
+    switch (props.placement) {
+      case LEFT:
+        return css`
+          right: calc(100% + 10px);
+          top: 50%;
+          transform: translateY(-50%);
+        `;
+      case RIGHT:
+        return css`
+          left: calc(100% + 10px);
+          top: 50%;
+          transform: translateY(-50%);
+        `;
+      case BOTTOM:
+        return css`
+          top: calc(100% + 10px);
+          left: 50%;
+          transform: translateX(-50%);
+        `;
+      default:
+        return css`
+          bottom: calc(100% + 10px);
+          left: 50%;
+          transform: translateX(-50%);
+        `;
+    }
+  }};
 `;
 
 function Tooltip({

--- a/stories/tooltip.js
+++ b/stories/tooltip.js
@@ -58,7 +58,7 @@ storiesOf("Tooltip", module).add("Default", () => {
           placement="bottom"
           overlay={
             <div>
-              <i className="fal fa-smile"></i>Helloooooooo
+              <i className="far fa-smile"></i>Helloooooooo
             </div>
           }
         >


### PR DESCRIPTION
**Component**: ui

**Description**:
This PR introduces a bug that causes no default font color and with 50px default tooltip overlay.
https://github.com/scality/core-ui/pull/240

**Design**:
The tooltip should work as before.
If we don't specify the width in `overlayStyle` prop, the default width should take 

**Breaking Changes**:
no
- [] Breaking Changes


---

<!-- Declare one or more issues to close once this PR gets merged -->

Closes: #ISSUE_NUMBER

<!-- If you want to refer to an issue while not closing it, use:

See: #ISSUE_NUMBER

-->
