### PR TITLE
story: add control simple control feature for banner

### DIFF
--- a/src/__snapshots__/banner.stories.storyshot
+++ b/src/__snapshots__/banner.stories.storyshot
@@ -28,6 +28,30 @@ exports[`Storyshots Components/Notification/Banner Error Banner 1`] = `
 </div>
 `;
 
+exports[`Storyshots Components/Notification/Banner Playground 1`] = `
+<div
+  className="sc-jSgupP hXxpKg sc-banner"
+>
+  <i
+    className="fas fa-exclamation-triangle"
+  />
+  <div
+    className="sc-gKsewC ehdtkM"
+  >
+    <div
+      className="sc-fubCfw jmSQlc"
+    >
+      Man
+    </div>
+    <span
+      className="sc-iBPRYJ iWUlck"
+    >
+      There is a success
+    </span>
+  </div>
+</div>
+`;
+
 exports[`Storyshots Components/Notification/Banner Success Banner 1`] = `
 <div
   className="sc-gsTCUz dUzLYl"

--- a/src/lib/components/banner/Banner.component.js
+++ b/src/lib/components/banner/Banner.component.js
@@ -6,7 +6,7 @@ import * as defaultTheme from "../../style/theme";
 import { getThemePropSelector, getThemeVariantSelector } from "../../utils";
 import type { Variant } from "../constants";
 
-type Props = {
+export type Props = {
   icon?: Object,
   title?: string,
   children: Node,

--- a/stories/banner.stories.js
+++ b/stories/banner.stories.js
@@ -1,11 +1,38 @@
 //@flow
 import React from 'react';
 import Banner from '../src/lib/components/banner/Banner.component';
+import type { Props } from '../src/lib/components/banner/Banner.component';
 import { Wrapper } from './common';
 
 export default {
   title: 'Components/Notification/Banner',
   component: Banner,
+  argTypes: {
+    children: {
+      control: {
+        disable: true,
+      },
+    },
+    variant: {
+      control: {
+        type: 'select',
+        options: [
+          'base',
+          'secondary',
+          'healthy',
+          'warning',
+          'danger',
+          'success',
+        ],
+      },
+    },
+    title: {},
+    icon: {
+      control: {
+        disable: true,
+      },
+    },
+  },
 };
 
 export const ErrorBanner = () => (
@@ -20,9 +47,6 @@ export const ErrorBanner = () => (
   </Wrapper>
 );
 
-ErrorBanner.args = {
-  variant: 'danger',
-};
 export const WarningBanner = () => (
   <Wrapper>
     <Banner
@@ -46,3 +70,14 @@ export const SuccessBanner = () => (
     </Banner>
   </Wrapper>
 );
+
+const Template = (args: Props) => <Banner {...args} />;
+
+export const Playground: { args?: Props } = Template.bind({});
+
+Playground.args = {
+  variant: 'success',
+  icon: <i className="fas fa-exclamation-triangle" />,
+  title: 'Man',
+  children: 'There is a success',
+};


### PR DESCRIPTION
**Component**: Banner

**Description**:
Add example of playground for Banner story.
You can change the `title` and the `variant` like this : ![alt text](https://puu.sh/HnhC3/006ca6f683.png)

Please note that I choose to remove the possibility to change the `children` and the `icon` because storybook crash very easily if you put something wrong.

However we will be able to have some predefined components in a future version of storybook (6.2):
- https://github.com/storybookjs/storybook/issues/13888
- https://github.com/storybookjs/storybook/pull/14100

It will look like this : 
```javascript
argTypes: {
  label: {
    control: {
      type: 'select',
      options: ['Normal', 'Bold', 'Italic'],
    },
    mapping: {
      Bold: <b>Bold</b>,
      Italic: <i>Italic</i>,
    },
  },
},
```