### PR TITLE
dependency: Bump the node.js version to v14 for eve worker

### DIFF
--- a/eve/workers/pod-unit-tests/Dockerfile
+++ b/eve/workers/pod-unit-tests/Dockerfile
@@ -1,12 +1,12 @@
 FROM centos:7
 
-ARG BUILDBOT_VERSION=0.9.12
+ARG BUILDBOT_VERSION=2.0.1
 
 ENV LANG=en_US.utf8
 
 WORKDIR /home/eve/workspace
 
-RUN curl -sL https://rpm.nodesource.com/setup_10.x | bash -
+RUN curl -sL https://rpm.nodesource.com/setup_14.x | bash -
 RUN yum install -y epel-release \
     && yum install -y gcc \
     make \
@@ -19,4 +19,5 @@ RUN yum install -y epel-release \
     nodejs \
     && adduser -u 1042 --home /home/eve eve \
     && chown -R eve:eve /home/eve \
-    && pip install buildbot-worker==${BUILDBOT_VERSION}
+    && python3.6 -m pip install \
+       buildbot-worker==${BUILDBOT_VERSION}


### PR DESCRIPTION
**Component**: dependency

**Description**:
Node is dropping maintenance support of v10 by the end of April and we are using this version to build UI projects.
We should bump the Node.js to the current LTS v14.16.0

I've tested locally that with node.js v14.16.0 the storybook can run correctly locally.

**Design**:

**Breaking Changes**:

no

---

<!-- Declare one or more issues to close once this PR gets merged -->

Closes: #279 

<!-- If you want to refer to an issue while not closing it, use:

See: #ISSUE_NUMBER

-->
