### PR TITLE
bugfix: Add FontAwesome modules as peerdependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -72,6 +72,10 @@
   },
   "peerDependencies": {
     "@fortawesome/fontawesome-free": "5.7.2",
+    "@fortawesome/react-fontawesome": "^0.1.14",
+    "@fortawesome/fontawesome-svg-core": "^1.2.35",
+    "@fortawesome/free-regular-svg-icons": "^5.15.3",
+    "@fortawesome/free-solid-svg-icons": "^5.15.3",
     "polished": "3.4.1",
     "react": "^16.8.0",
     "react-dom": "^16.8.0",


### PR DESCRIPTION
Since we don't really use this icon wrapper and it causes the increase of bundle assets size. 
We should remove the index of the icon wrapper for the moment.

**Component**:

<!-- E.g. 'Layout', 'Table', 'build', 'tests'... -->


**Description**:

**Design**:

**Breaking Changes**:

- [] Breaking Changes


---

<!-- Declare one or more issues to close once this PR gets merged -->

Closes: #ISSUE_NUMBER

<!-- If you want to refer to an issue while not closing it, use:

See: #ISSUE_NUMBER

-->
