### PR TITLE
bugfix: unclickable checkbox

### DIFF
--- a/src/__snapshots__/checkbox.stories.storyshot
+++ b/src/__snapshots__/checkbox.stories.storyshot
@@ -13,14 +13,14 @@ exports[`Storyshots Components/Checkbox Default 1`] = `
     checked={true}
     className="sc-bkzZxe ksGRRC sc-checkbox"
   >
+    <i
+      className="fas fa-check"
+    />
     <input
       checked={true}
       data-cy="checked_checkbox"
       onChange={[Function]}
       type="checkbox"
-    />
-    <i
-      className="fas fa-check"
     />
     <span
       className="sc-fFubgz kTNXQm text"
@@ -37,13 +37,13 @@ exports[`Storyshots Components/Checkbox Default 1`] = `
     checked={false}
     className="sc-bkzZxe bnReLL sc-checkbox"
   >
+    <i
+      className="fas fa-check"
+    />
     <input
       checked={false}
       onChange={[Function]}
       type="checkbox"
-    />
-    <i
-      className="fas fa-check"
     />
     <span
       className="sc-fFubgz kTNXQm text"
@@ -61,14 +61,14 @@ exports[`Storyshots Components/Checkbox Default 1`] = `
     className="sc-bkzZxe gBDEMn sc-checkbox"
     disabled={true}
   >
+    <i
+      className="fas fa-check"
+    />
     <input
       checked={false}
       disabled={true}
       onChange={[Function]}
       type="checkbox"
-    />
-    <i
-      className="fas fa-check"
     />
     <span
       className="sc-fFubgz kTNXQm text"
@@ -86,14 +86,14 @@ exports[`Storyshots Components/Checkbox Default 1`] = `
     className="sc-bkzZxe hfNiZf sc-checkbox"
     disabled={true}
   >
+    <i
+      className="fas fa-check"
+    />
     <input
       checked={true}
       disabled={true}
       onChange={[Function]}
       type="checkbox"
-    />
-    <i
-      className="fas fa-check"
     />
     <span
       className="sc-fFubgz kTNXQm text"

--- a/src/__snapshots__/input.stories.storyshot
+++ b/src/__snapshots__/input.stories.storyshot
@@ -151,15 +151,15 @@ exports[`Storyshots Components/Input/Input Default 1`] = `
         checked={false}
         className="sc-bkzZxe bnReLL sc-checkbox"
       >
+        <i
+          className="fas fa-check"
+        />
         <input
           checked={false}
           id="id4"
           onChange={[Function]}
           type="checkbox"
           value="value"
-        />
-        <i
-          className="fas fa-check"
         />
       </label>
     </div>
@@ -186,15 +186,15 @@ exports[`Storyshots Components/Input/Input Default 1`] = `
         checked={false}
         className="sc-bkzZxe bnReLL sc-checkbox"
       >
+        <i
+          className="fas fa-check"
+        />
         <input
           checked={false}
           id="id5"
           onChange={[Function]}
           type="checkbox"
           value="value"
-        />
-        <i
-          className="fas fa-check"
         />
       </label>
       <span

--- a/src/__snapshots__/multiselect.stories.storyshot
+++ b/src/__snapshots__/multiselect.stories.storyshot
@@ -171,13 +171,13 @@ exports[`Storyshots Components/Selector/MultiSelect Default 1`] = `
             checked={true}
             className="sc-bkzZxe ksGRRC sc-checkbox"
           >
+            <i
+              className="fas fa-check"
+            />
             <input
               checked={true}
               onChange={[Function]}
               type="checkbox"
-            />
-            <i
-              className="fas fa-check"
             />
           </label>
           <button
@@ -270,13 +270,13 @@ exports[`Storyshots Components/Selector/MultiSelect Default 1`] = `
             checked={false}
             className="sc-bkzZxe bnReLL sc-checkbox"
           >
+            <i
+              className="fas fa-check"
+            />
             <input
               checked={false}
               onChange={[Function]}
               type="checkbox"
-            />
-            <i
-              className="fas fa-check"
             />
           </label>
           <button
@@ -387,13 +387,13 @@ exports[`Storyshots Components/Selector/MultiSelect Default 1`] = `
             checked={true}
             className="sc-bkzZxe ksGRRC sc-checkbox"
           >
+            <i
+              className="fas fa-check"
+            />
             <input
               checked={true}
               onChange={[Function]}
               type="checkbox"
-            />
-            <i
-              className="fas fa-check"
             />
           </label>
           <button
@@ -486,13 +486,13 @@ exports[`Storyshots Components/Selector/MultiSelect Default 1`] = `
             checked={false}
             className="sc-bkzZxe bnReLL sc-checkbox"
           >
+            <i
+              className="fas fa-check"
+            />
             <input
               checked={false}
               onChange={[Function]}
               type="checkbox"
-            />
-            <i
-              className="fas fa-check"
             />
           </label>
           <button
@@ -744,13 +744,13 @@ exports[`Storyshots Components/Selector/MultiSelect Default 1`] = `
             checked={true}
             className="sc-bkzZxe ksGRRC sc-checkbox"
           >
+            <i
+              className="fas fa-check"
+            />
             <input
               checked={true}
               onChange={[Function]}
               type="checkbox"
-            />
-            <i
-              className="fas fa-check"
             />
           </label>
         </div>
@@ -813,13 +813,13 @@ exports[`Storyshots Components/Selector/MultiSelect Default 1`] = `
             checked={false}
             className="sc-bkzZxe bnReLL sc-checkbox"
           >
+            <i
+              className="fas fa-check"
+            />
             <input
               checked={false}
               onChange={[Function]}
               type="checkbox"
-            />
-            <i
-              className="fas fa-check"
             />
           </label>
         </div>

--- a/src/lib/components/checkbox/Checkbox.component.js
+++ b/src/lib/components/checkbox/Checkbox.component.js
@@ -26,6 +26,7 @@ function Checkbox({
       disabled={disabled}
       className="sc-checkbox"
     >
+      <i className="fas fa-check" />
       <input
         type="checkbox"
         checked={checked}
@@ -34,7 +35,6 @@ function Checkbox({
         onChange={onChange}
         {...rest}
       />
-      <i className="fas fa-check" />
       {label && (
         <StyledCheckboxLabel className="text">{label}</StyledCheckboxLabel>
       )}


### PR DESCRIPTION
**Component**: Checkbox

**Description**:

There is a very specific bug when several checkboxes are in a react-table and the table row allow to toggle the checkbox when clicked. They can't be clickable anymore. It seems that changing the icon of the checkbox to the top would fix the bug.

**Breaking Changes**:

- [NO] Breaking Changes