### PR TITLE
Remove the `aria-label` in Error page

### DIFF
--- a/src/__snapshots__/errorpage404.stories.storyshot
+++ b/src/__snapshots__/errorpage404.stories.storyshot
@@ -26,13 +26,11 @@ exports[`Storyshots Components/Navigation/ErrorPages/404 Default 1`] = `
         className="sc-khAkjo kePGAr"
       >
         <p
-          aria-label="page not found"
           className="sc-hTZhsR iEVfKB"
         >
           It might be the wrong address or the page has moved.
         </p>
         <p
-          aria-label="check url or contact administrator"
           className="sc-hTZhsR iEVfKB"
         >
           You might check the url, or contact your admin if the error remains.
@@ -82,13 +80,11 @@ exports[`Storyshots Components/Navigation/ErrorPages/404 With Locale 1`] = `
         className="sc-khAkjo kePGAr"
       >
         <p
-          aria-label="page not found"
           className="sc-hTZhsR iEVfKB"
         >
           Il se peut que ce soit une mauvaise adresse ou que la page ait été déplacée.
         </p>
         <p
-          aria-label="check url or contact administrator"
           className="sc-hTZhsR iEVfKB"
         >
           Vous pouvez vérifier l'url, ou contacter votre administrateur si l'erreur persiste.

--- a/src/__snapshots__/errorpage500.stories.storyshot
+++ b/src/__snapshots__/errorpage500.stories.storyshot
@@ -26,13 +26,11 @@ exports[`Storyshots Components/Navigation/ErrorPages/500 Default 1`] = `
         className="sc-jeGSBP gtqGta"
       >
         <p
-          aria-label="unexpected error"
           className="sc-eJMQSu gldhqr"
         >
           An error occured and your request cannot be completed.
         </p>
         <p
-          aria-label="check url or contact administrator"
           className="sc-eJMQSu gldhqr"
         >
           You might check the url, or contact your admin if the error remains.
@@ -82,19 +80,16 @@ exports[`Storyshots Components/Navigation/ErrorPages/500 With Locale 1`] = `
         className="sc-jeGSBP gtqGta"
       >
         <p
-          aria-label="unexpected error"
           className="sc-eJMQSu gldhqr"
         >
           Une erreur s'est produite et votre demande ne peut être complétée.
         </p>
         <p
-          aria-label="check url or contact administrator"
           className="sc-eJMQSu gldhqr"
         >
           Vous pouvez vérifier l'url, ou contacter votre administrateur si l'erreur persiste.
         </p>
         <p
-          aria-label="support link"
           className="sc-eJMQSu gldhqr"
         >
           Vous pouvez également contacter le 
@@ -154,19 +149,16 @@ exports[`Storyshots Components/Navigation/ErrorPages/500 With Support Link 1`] =
         className="sc-jeGSBP gtqGta"
       >
         <p
-          aria-label="unexpected error"
           className="sc-eJMQSu gldhqr"
         >
           An error occured and your request cannot be completed.
         </p>
         <p
-          aria-label="check url or contact administrator"
           className="sc-eJMQSu gldhqr"
         >
           You might check the url, or contact your admin if the error remains.
         </p>
         <p
-          aria-label="support link"
           className="sc-eJMQSu gldhqr"
         >
           You may also contact 

--- a/src/__snapshots__/errorpageauth.stories.storyshot
+++ b/src/__snapshots__/errorpageauth.stories.storyshot
@@ -26,13 +26,11 @@ exports[`Storyshots Components/Navigation/ErrorPages/Auth Default 1`] = `
         className="sc-clsHhM giUgiK"
       >
         <p
-          aria-label="authenticating"
           className="sc-fbkhIv bvaRoK"
         >
           The authentication is in progress.
         </p>
         <p
-          aria-label="if message persist please refresh"
           className="sc-fbkhIv bvaRoK"
         >
           If this message persist please try refreshing your page.
@@ -69,19 +67,16 @@ exports[`Storyshots Components/Navigation/ErrorPages/Auth With Locale 1`] = `
         className="sc-clsHhM giUgiK"
       >
         <p
-          aria-label="authenticating"
           className="sc-fbkhIv bvaRoK"
         >
           Authentification en cours.
         </p>
         <p
-          aria-label="if message persist please refresh"
           className="sc-fbkhIv bvaRoK"
         >
           Si ce message persiste, vous pouvez essayer d'actualiser cette page.
         </p>
         <p
-          aria-label="support link"
           className="sc-fbkhIv bvaRoK"
         >
           Vous pouvez également contacter le 
@@ -128,19 +123,16 @@ exports[`Storyshots Components/Navigation/ErrorPages/Auth With Support Link 1`] 
         className="sc-clsHhM giUgiK"
       >
         <p
-          aria-label="authenticating"
           className="sc-fbkhIv bvaRoK"
         >
           The authentication is in progress.
         </p>
         <p
-          aria-label="if message persist please refresh"
           className="sc-fbkhIv bvaRoK"
         >
           If this message persist please try refreshing your page.
         </p>
         <p
-          aria-label="support link"
           className="sc-fbkhIv bvaRoK"
         >
           You may also contact 

--- a/src/lib/components/error-pages/ErrorPage404.component.js
+++ b/src/lib/components/error-pages/ErrorPage404.component.js
@@ -77,10 +77,10 @@ function ErrorPage404({ btnLink = '/', locale = 'en', ...rest }: Props) {
       </Row>
       <Row>
         <Description>
-          <DescriptionContent aria-label="page not found">
+          <DescriptionContent>
             {translations[locale].error_desc}
           </DescriptionContent>
-          <DescriptionContent aria-label="check url or contact administrator">
+          <DescriptionContent>
             {translations[locale].should_do}
           </DescriptionContent>
         </Description>

--- a/src/lib/components/error-pages/ErrorPage500.component.js
+++ b/src/lib/components/error-pages/ErrorPage500.component.js
@@ -92,14 +92,14 @@ function ErrorPage500({
       </Row>
       <Row>
         <Description>
-          <DescriptionContent aria-label="unexpected error">
+          <DescriptionContent>
             {translations[locale].error_desc}
           </DescriptionContent>
-          <DescriptionContent aria-label="check url or contact administrator">
+          <DescriptionContent>
             {translations[locale].should_do}
           </DescriptionContent>
           {supportLink && (
-            <DescriptionContent aria-label="support link">
+            <DescriptionContent>
               {translations[locale].may_also_contact}
               <Link href={supportLink}>
                 support <i className="fas fa-external-link-alt" />

--- a/src/lib/components/error-pages/ErrorPageAuth.component.js
+++ b/src/lib/components/error-pages/ErrorPageAuth.component.js
@@ -81,14 +81,14 @@ function ErrorPageAuth({ supportLink = null, locale = 'en', ...rest }: Props) {
       </Row>
       <Row>
         <Description>
-          <DescriptionContent aria-label="authenticating">
+          <DescriptionContent>
             {translations[locale].error_desc}
           </DescriptionContent>
-          <DescriptionContent aria-label="if message persist please refresh">
+          <DescriptionContent>
             {translations[locale].should_do}
           </DescriptionContent>
           {supportLink && (
-            <DescriptionContent aria-label="support link">
+            <DescriptionContent>
               {translations[locale].may_also_contact}
               <Link href={supportLink}>
                 support <i className="fas fa-external-link-alt" />


### PR DESCRIPTION
**Component**: Error Pages

**Description**:
When label text is visible on screen, we should use `aria-labelledby` instead of `aria-label`.
And the value of `aria-labelledby` should not link to the content

**Design**:

**Breaking Changes**:

- [] Breaking Changes
no

---

<!-- Declare one or more issues to close once this PR gets merged -->

Closes: #ISSUE_NUMBER

<!-- If you want to refer to an issue while not closing it, use:

See: #ISSUE_NUMBER

-->
