### PR TITLE
TabsV2: Remove box-sizing: content-box

### DIFF
--- a/src/lib/components/tabsv2/StyledTabs.js
+++ b/src/lib/components/tabsv2/StyledTabs.js
@@ -59,9 +59,6 @@ export const TabsContainer = styled.div`
   flex-direction: column;
   background-color: ${(props) =>
     props.tabLineColor || getTheme(props).backgroundLevel3};
-  * {
-    box-sizing: content-box;
-  }
 
   & ${TabItem} {
     display: flex;


### PR DESCRIPTION
**Component**: TabsV2

**Description**: Remove a CSS rule that was applied to all component in Tab Content 