### PR TITLE
Fix the global health component to support any timespan selector

### DIFF
--- a/src/lib/components/globalhealthbar/GlobalHealthBar.component.js
+++ b/src/lib/components/globalhealthbar/GlobalHealthBar.component.js
@@ -38,7 +38,7 @@ function GlobalHealthBar({
   start,
   end,
   height = 8,
-  width = 400,
+  width = 482,
   tooltipPosition = TOP,
 }: GlobalHealthProps) {
   const theme = useTheme();
@@ -70,12 +70,12 @@ function GlobalHealthBar({
     layer: [
       // Paint the entire bar with green
       {
-        mark: { type: 'rect', cornerRadius: 10 },
+        mark: { type: 'rect', cornerRadius: 6 },
         encoding: { color: { value: theme.healthyLight } },
       },
       // Paint the timespan as x-axis
       {
-        mark: { type: 'rect', cursor: 'pointer', cornerRadius: 10 },
+        mark: { type: 'rect', cursor: 'pointer', cornerRadius: 6 },
         encoding: {
           x: {
             field: 'startsAt',
@@ -92,13 +92,11 @@ function GlobalHealthBar({
               domain: [startTimeObject, endTimeObject],
             },
             axis: {
-              format: '%d %b',
+              format: '%d%b %H:%M',
               ticks: true,
               grid: false,
               domainWidth: 0,
               tickCount: 7,
-              labelExpr:
-                "[timeFormat(datum.value, '%d'), timeFormat(datum.value, '%d') == '01' || datum.index == 0 ? timeFormat(datum.value, '%b') : '']",
               labelColor: theme.textSecondary,
             },
           },
@@ -110,7 +108,7 @@ function GlobalHealthBar({
         mark: {
           type: 'rect',
           tooltip: true,
-          cornerRadius: 10,
+          cornerRadius: 6,
           cursor: 'pointer',
           clip: true,
         },
@@ -166,7 +164,6 @@ function GlobalHealthBar({
       className="sc-globalhealthbar"
       id={id}
       spec={spec}
-      theme={theme}
       tooltipPosition={tooltipPosition}
     ></VegaChart>
   );

--- a/src/lib/components/vegachart/VegaChart.component.js
+++ b/src/lib/components/vegachart/VegaChart.component.js
@@ -42,7 +42,7 @@ function VegaChart({
   id,
   spec,
   tooltipPosition = BOTTOM,
-  theme = 'light',
+  theme = 'custom',
 }: Props) {
   const themeContext = useContext(ThemeContext);
 

--- a/stories/globalhealthbar.stories.js
+++ b/stories/globalhealthbar.stories.js
@@ -41,6 +41,44 @@ const alerts = [
   },
 ];
 
+const alertsLast24h = [
+  {
+    id: '1',
+    severity: 'warning',
+    startsAt: '2021-02-01T07:00:00Z',
+    endsAt: '2021-02-01T08:00:00Z',
+    description: 'Global health warning',
+  },
+  {
+    id: '2',
+    severity: 'warning',
+    startsAt: '2021-02-01T12:00:00Z',
+    endsAt: '2021-02-01T15:00:00Z',
+    description: 'Global health warning',
+  },
+  {
+    id: '3',
+    severity: 'critical',
+    startsAt: '2021-02-01T16:00:00Z',
+    endsAt: '2021-02-01T18:00:00Z',
+    description: 'Global health critical',
+  },
+  {
+    id: '4',
+    severity: 'warning',
+    startsAt: '2021-02-01T19:00:00Z',
+    endsAt: '2021-02-01T20:00:00Z',
+    description: 'Global health warning',
+  },
+  {
+    id: '5',
+    severity: 'warning',
+    startsAt: '2021-02-01T10:00:00Z',
+    endsAt: '2021-02-01T20:00:00Z',
+    description: 'Global health warning',
+  },
+];
+
 const emptyAlert = [];
 const alertRetrieveBefore = [
   {
@@ -84,6 +122,9 @@ export default {
 const start = '2021-01-31T23:00:00Z'; // UTC time
 const end = '2021-02-06T23:00:00Z';
 
+const startLast24h = '2021-02-01T00:00:00Z';
+const endLast24h = '2021-02-02T00:00:00Z';
+
 const startNotFirstDay = '2021-02-23T23:00:00Z';
 const endNotFirstDay = '2021-03-01T23:00:00Z';
 
@@ -97,6 +138,15 @@ export const Default = () => {
           alerts={alerts}
           start={start}
           end={end}
+        />
+      </div>
+      <Title>Global Health Component - Last 24 hours</Title>
+      <div style={{ paddingTop: '50px' }}>
+        <GlobalHealthBar
+          id={'vis_globalhealth_24h'}
+          alerts={alertsLast24h}
+          start={startLast24h}
+          end={endLast24h}
         />
       </div>
       <Title>No alert</Title>


### PR DESCRIPTION
**Component**: Global Health Component

**Description**:
The Global Health Component by default display the health of the last 7 days. 
However, we want to change the timespan base on the current global timespan selector.


**Design**:



---

<!-- Declare one or more issues to close once this PR gets merged -->

Closes: #ISSUE_NUMBER

<!-- If you want to refer to an issue while not closing it, use:

See: #ISSUE_NUMBER

-->
