### PR TITLE
Global Health: Update the theme with the design

### DIFF
--- a/src/lib/components/globalhealthbar/GlobalHealthBar.component.js
+++ b/src/lib/components/globalhealthbar/GlobalHealthBar.component.js
@@ -71,7 +71,7 @@ function GlobalHealthBar({
       // Paint the entire bar with green
       {
         mark: { type: 'rect', cornerRadius: 6 },
-        encoding: { color: { value: theme.healthyLight } },
+        encoding: { color: { value: theme.statusHealthy } },
       },
       // Paint the timespan as x-axis
       {
@@ -101,7 +101,7 @@ function GlobalHealthBar({
             },
           },
           x2: { field: 'endsAt' },
-          color: { value: theme.healthyLight },
+          color: { value: theme.statusHealthy },
         },
       },
       {
@@ -131,7 +131,7 @@ function GlobalHealthBar({
             field: 'severity',
             type: 'nominal',
             title: 'null',
-            scale: { range: [theme.critical, theme.alert] },
+            scale: { range: [theme.statusCritical, theme.statusWarning] },
             legend: null,
           },
           tooltip: [

--- a/src/lib/components/globalhealthbar/GlobalHealthBar.component.js
+++ b/src/lib/components/globalhealthbar/GlobalHealthBar.component.js
@@ -131,7 +131,10 @@ function GlobalHealthBar({
             field: 'severity',
             type: 'nominal',
             title: 'null',
-            scale: { range: [theme.statusCritical, theme.statusWarning] },
+            scale: { 
+              domain: ['critical','unavailable','warning'],
+              range: [theme.statusCritical, theme.textSecondary, theme.statusWarning] 
+            },
             legend: null,
           },
           tooltip: [

--- a/src/lib/components/globalhealthbar/GlobalHealthBar.component.js
+++ b/src/lib/components/globalhealthbar/GlobalHealthBar.component.js
@@ -95,8 +95,8 @@ function GlobalHealthBar({
               format: '%d%b %H:%M',
               ticks: true,
               grid: false,
-              domainWidth: 0,
-              tickCount: 7,
+              tickCount: 5, //A desired number of ticks, for axes visualizing quantitative scales. The resulting number may be different so that values are “nice” (multiples of 2, 5, 10) and lie within the underlying scale’s range.
+              labelFlush: false, // Indicates if the first and last axis labels should be aligned flush with the scale range.
               labelColor: theme.textSecondary,
             },
           },

--- a/stories/globalhealthbar.stories.js
+++ b/stories/globalhealthbar.stories.js
@@ -77,6 +77,13 @@ const alertsLast24h = [
     endsAt: '2021-02-01T20:00:00Z',
     description: 'Global health warning',
   },
+  {
+    id: '6',
+    severity: 'unavailable',
+    startsAt: '2021-02-01T02:00:00Z',
+    endsAt: '2021-02-01T03:00:00Z',
+    description: 'unavailable',
+  },
 ];
 
 const emptyAlert = [];


### PR DESCRIPTION
**Component**: Global Health Component

**Description**:
Two issues we had: 
We used the deprecated color in Global Health Component.
The first and last labels don't display in the middle of the tick, so it's a bit confusing. 

**Design**:
![image](https://user-images.githubusercontent.com/18453133/129765749-186c7405-a452-4260-a8a2-e602856b023b.png)

---

<!-- Declare one or more issues to close once this PR gets merged -->

Closes: #ISSUE_NUMBER

<!-- If you want to refer to an issue while not closing it, use:

See: #ISSUE_NUMBER

-->
