### PR TITLE
global health: Lower interval precision to the seconds instead of the day

### DIFF
--- a/src/lib/components/globalhealthbar/GlobalHealthBar.component.js
+++ b/src/lib/components/globalhealthbar/GlobalHealthBar.component.js
@@ -29,6 +29,9 @@ function convert2TimeObject(time) {
     date: date.getDate(),
     month: date.getMonth() + 1,
     year: date.getFullYear(),
+    hours: date.getHours(),
+    minutes: date.getMinutes(),
+    seconds: date.getSeconds(),
   };
 }
 
@@ -96,9 +99,8 @@ function GlobalHealthBar({
             axis: {
               format: '%d%b %H:%M',
               ticks: true,
-              grid: false,
               tickCount: 5, //A desired number of ticks, for axes visualizing quantitative scales. The resulting number may be different so that values are “nice” (multiples of 2, 5, 10) and lie within the underlying scale’s range.
-              labelFlush: false, // Indicates if the first and last axis labels should be aligned flush with the scale range.
+              labelFlush: 20,
               labelColor: theme.textSecondary,
             },
           },


### PR DESCRIPTION
**Component**:

Global health

**Description**:

Before hands the Global health component was rounding start and end time to the previous midnight. This PR changes this behaviour and round it to the previous seconds so that we can display the history between 2 precise dates.
