### PR TITLE
linetemporalchart: Add the domain for color scale

### DIFF
--- a/src/lib/components/linetemporalchart/ChartUtil.js
+++ b/src/lib/components/linetemporalchart/ChartUtil.js
@@ -137,3 +137,10 @@ export function addMissingDataPoint(
 export const getRelativeValue = (value: number, base: number) => {
   return value / (base || 1);
 };
+
+// extract the labels from getTooltipLabel function to define the domain in color
+export const getColorDomains = (series: Serie[]): string[] => {
+  return series.map((serie) => {
+    return serie.getTooltipLabel(serie.metricPrefix, serie.resource);
+  });
+};

--- a/src/lib/components/linetemporalchart/LineTemporalChart.component.js
+++ b/src/lib/components/linetemporalchart/LineTemporalChart.component.js
@@ -22,6 +22,7 @@ import {
   convertDataBaseValue,
   addMissingDataPoint,
   getRelativeValue,
+  getColorDomains,
 } from './ChartUtil.js';
 import { useMetricsTimeSpan } from './MetricTimespanProvider';
 import { spacing } from '../../style/theme';
@@ -369,8 +370,8 @@ function LineTemporalChart({
     field: 'label',
     type: 'nominal',
     scale: {
-      //if there is no customized color range, we will use the default the line colors
-      range: customizedColorRange.length ? customizedColorRange : colorRange,
+      domain: getColorDomains(series), // the order of the domain should be the same as the order of colorRange, otherwise the colors will be assigned to the line base on the alphabetical order
+      range: customizedColorRange.length ? customizedColorRange : colorRange, //if there is no customized color range, we will use the default the line color
     },
     legend: null,
   };


### PR DESCRIPTION
**Component**: Line temporal chart

**Description**:
We have to define the order of the line color by adding the domain scale. Otherwise, the colors would assign to the series base on the alphabetical order of the tooltip label.

**Design**:

**Breaking Changes**:

- [] Breaking Changes


---

<!-- Declare one or more issues to close once this PR gets merged -->

Closes: #ISSUE_NUMBER

<!-- If you want to refer to an issue while not closing it, use:

See: #ISSUE_NUMBER

-->
