### PR TITLE
linetemporalchart: Fix the alignment for first and last label in xAxis

### DIFF
--- a/src/lib/components/linetemporalchart/LineTemporalChart.component.js
+++ b/src/lib/components/linetemporalchart/LineTemporalChart.component.js
@@ -345,7 +345,7 @@ function LineTemporalChart({
       ticks: true,
       tickCount: 5,
       labelColor: theme.textSecondary,
-      labelFlush: 20,
+      labelFlush: false,
       // TODO: labelFontSize is not responsiveness
       labelSeparation: 12,
       // The minimum separation that must be between label bounding boxes for them to be considered non-overlapping (default 0). This property is ignored if labelOverlap resolution is not enabled.


### PR DESCRIPTION
**Component**: Line temporal chart

**Description**:
labelFlush:
 Flush alignment for a horizontal axis will left-align the first label
and right-align the last label.

**Design**:

**Breaking Changes**:

no

---

<!-- Declare one or more issues to close once this PR gets merged -->

Closes: #ISSUE_NUMBER

<!-- If you want to refer to an issue while not closing it, use:

See: #ISSUE_NUMBER

-->
