### PR TITLE
linetemporalchart: Fix the bug that we miss the last data point

### DIFF
--- a/src/lib/components/linetemporalchart/ChartUtil.js
+++ b/src/lib/components/linetemporalchart/ChartUtil.js
@@ -109,7 +109,7 @@ export function addMissingDataPoint(
   }
 
   const newValues = [];
-  const numberOfDataPoints = sampleDuration / sampleFrequency;
+  const numberOfDataPoints = sampleDuration / sampleFrequency + 1;
   let samplingPointTime = startingTimeStamp;
 
   // initialize the array with all "NAN" value, in order for the tooltip to display dash(-)

--- a/src/lib/components/linetemporalchart/ChartUtil.test.js
+++ b/src/lib/components/linetemporalchart/ChartUtil.test.js
@@ -175,7 +175,7 @@ const originalValue = [
   [10, 10],
 ];
 const startingTimeStamp = 0;
-const sampleDuration = 11;
+const sampleDuration = 10;
 const sampleFrequency = 1;
 const newValues = [
   [0, 0],


### PR DESCRIPTION
**Component**: Line temporal chart

**Description**:

**Design**:

**Breaking Changes**:

- [] Breaking Changes


---

<!-- Declare one or more issues to close once this PR gets merged -->

Closes: #ISSUE_NUMBER

<!-- If you want to refer to an issue while not closing it, use:

See: #ISSUE_NUMBER

-->
