### PR TITLE
Add StatusWrapper component

### DIFF
--- a/src/lib/components/constants.js
+++ b/src/lib/components/constants.js
@@ -74,3 +74,5 @@ export const queryTimeSpansCodes: QueryTimeSpan[] = [
 ];
 
 export const NAN_STRING = 'NAN';
+
+export type Status = 'unknown' | 'healthy' | 'warning' | 'critical';

--- a/src/lib/components/icon/Icon.component.js
+++ b/src/lib/components/icon/Icon.component.js
@@ -81,6 +81,9 @@ export const iconTable = {
   "Dot-circle": "fas faDotCircle",
   "Check-circle": "fas faCheckCircle",
   "Times-circle": "fas faTimesCircle",
+  "Toolbox": "fas faToolbox",
+  "Cubes": "fas faCubes",
+  "File-alt": "fas faFilesAlt",
 };
 
 const IconStyled = styled(FontAwesomeIcon)`

--- a/src/lib/components/statuswrapper/Statuswrapper.component.js
+++ b/src/lib/components/statuswrapper/Statuswrapper.component.js
@@ -1,0 +1,67 @@
+// @flow
+import * as React from 'react';
+import styled, { css } from 'styled-components';
+import { getTheme } from '../../utils';
+import type { Status } from '../constants';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import {
+  faQuestionCircle,
+  faExclamationCircle,
+  faTimesCircle,
+} from '@fortawesome/free-solid-svg-icons';
+
+const BadgeWrapper = styled.span`
+  height: fit-content;
+  width: fit-content;
+  position: relative;
+  margin-right: 0.5rem;
+  display: inline-block;
+`;
+
+const BadgeStyled = styled(FontAwesomeIcon)`
+  ${(props) => {
+    const theme = getTheme(props);
+    return css`
+      background: ${theme.backgroundLevel1};
+      border-radius: 50%;
+      color: ${theme.textSecondary};
+      position: absolute;
+      top: -25%;
+      right: -35%;
+      transform: scale(0.5);
+      box-shadow: 0px 2px 2px rgba(0, 0, 0, 0.25);
+    `;
+  }}
+`;
+
+const getBadgeIcon = (status) => {
+  switch (status) {
+    case 'warning':
+      return faExclamationCircle;
+    case 'critical':
+      return faTimesCircle;
+    case 'unknown':
+      return faQuestionCircle;
+    case 'healthy':
+    default:
+      return null;
+  }
+};
+
+type Props = {
+  status: Status,
+  children: React.Node,
+};
+
+function StatusWrapper({ status, children }: Props) {
+  const icon = getBadgeIcon(status);
+
+  return (
+    <BadgeWrapper>
+      {children}
+      {icon !== null && <BadgeStyled icon={icon} />}
+    </BadgeWrapper>
+  );
+}
+
+export default StatusWrapper;

--- a/src/lib/index.js
+++ b/src/lib/index.js
@@ -59,6 +59,7 @@ import {
 import Card from './components/card/Card.component';
 import PrettyBytes from './components/prettybytes/PrettyBytes.component';
 import Icon from './components/icon/Icon.component';
+import StatusWrapper from './components/statuswrapper/Statuswrapper.component';
 
 export {
   LOADER_SIZE,
@@ -104,6 +105,7 @@ export {
   ErrorPage500,
   ErrorPageAuth,
   Icon,
+  StatusWrapper,
   TextBadge,
   BasicText,
   SecondaryText,

--- a/stories/statuswrapper.stories.js
+++ b/stories/statuswrapper.stories.js
@@ -1,0 +1,97 @@
+// @flow
+import React from 'react';
+import StatusWrapper from '../src/lib/components/statuswrapper/Statuswrapper.component';
+import { Wrapper, Title } from './common';
+import styled from 'styled-components';
+import Icon from '../src/lib/components/icon/Icon.component';
+
+import {
+  BasicText,
+  SecondaryText,
+  LargerText,
+  EmphaseText,
+  StatusText,
+  SmallerText,
+  ChartTitleText,
+} from '../src/lib/components/text/Text.component';
+
+const PreviewWrapper = styled(Wrapper)`
+  min-height: 0;
+`;
+
+export default {
+  title: 'Components/StatusWrapper',
+  component: StatusWrapper,
+};
+
+export const Default = () => {
+  return (
+    <Wrapper>
+      <Title>Status Wrapper</Title>
+
+      <PreviewWrapper>
+        <BasicText>
+          <StatusWrapper status="healthy">
+            <Icon name={"Network"} color={"statusHealthy"}/>
+          </StatusWrapper>
+          This is a text
+        </BasicText>
+      </PreviewWrapper>
+
+      <PreviewWrapper>
+        <SecondaryText>
+          <StatusWrapper status="unknown">
+            <Icon name={"Network"} color={"infoPrimary"}/>
+          </StatusWrapper>
+          This is a text
+        </SecondaryText>
+      </PreviewWrapper>
+
+      <PreviewWrapper>
+        <LargerText>
+          <StatusWrapper status="warning">
+            <Icon name={"Network"} color={"statusWarning"}/>
+          </StatusWrapper>
+          This is a text
+        </LargerText>
+      </PreviewWrapper>
+
+      <PreviewWrapper>
+        <EmphaseText>
+          <StatusWrapper status="critical">
+            <Icon name={"Network"} color={"statusCritical"}/>
+          </StatusWrapper>
+          This is a text
+        </EmphaseText>
+      </PreviewWrapper>
+
+      <PreviewWrapper>
+        <StatusText>
+          <StatusWrapper status="unknown">
+            <Icon name={"Node-backend"} color={"infoPrimary"}/>
+          </StatusWrapper>
+          This is a text
+        </StatusText>
+      </PreviewWrapper>
+
+      <PreviewWrapper>
+        <SmallerText>
+          <StatusWrapper status="warning">
+            <Icon name={"Volume-backend"} color={"statusWarning"}/>
+          </StatusWrapper>
+          This is a text
+        </SmallerText>
+      </PreviewWrapper>
+
+      <PreviewWrapper>
+        <ChartTitleText>
+          <StatusWrapper status="critical">
+            <Icon name={"Toolbox"} color={"statusCritical"}/>
+          </StatusWrapper>
+          This is a text
+        </ChartTitleText>
+      </PreviewWrapper>
+
+    </Wrapper>
+  );
+};


### PR DESCRIPTION
**Component**:

StatusWrapper

**Description**:

This PR adds `StatusWrapper` component, a wrapper adding a status badge to components.

`StatusWrapper` props:
- `status` (Used to define badge to show)

**Design**:

![image](https://user-images.githubusercontent.com/1793678/140899337-dda0e725-7d95-4b22-940b-216455004497.png)
(Proposal 5 has been implemented)

---

See: ARTESCA-2404
