### PR TITLE
Fix Sidebar height when hovered

### DIFF
--- a/src/lib/components/sidebar/Sidebar.component.js
+++ b/src/lib/components/sidebar/Sidebar.component.js
@@ -50,7 +50,8 @@ const Wrapper = styled.div`
     if (props.hoverable && props.hovered && !props.expanded) {
       return css`
         .sc-sidebar {
-          position: absolute;
+          position: relative;
+          width: fit-content;
           height: 100%;
           background-color: ${backgroundLevel1};
           z-index: ${defaultTheme.zIndex.sidebar};


### PR DESCRIPTION
**Component**:

Sidebar

**Description**:

When hovered, `Sidebar` wrapper height is taller than expected, causing page to be scrollable.