### PR TITLE
refactor: add an option to hide ok health status

### DIFF
--- a/src/lib/components/healthselector/HealthSelector.test.js
+++ b/src/lib/components/healthselector/HealthSelector.test.js
@@ -1,0 +1,108 @@
+import HealthSelector from './Healthselector.component'
+import React from 'react';
+import { fireEvent, render } from '@testing-library/react';
+
+describe('HealthSelector', () => {
+
+ test('it should display the default health selector', () => { 
+
+    const warningAction = jest.fn();
+
+    const items = [
+        {
+          label: 'All',
+          onClick: () => {},
+          selected: true,
+        },
+        {
+          label: 'Ok',
+          onClick: () => {},
+          selected: false,
+        },
+        {
+          label: 'Warning',
+          onClick: warningAction,
+          selected: false,
+        },
+        {
+          label: 'Critical',
+          onClick: () => {},
+          selected: false,
+        },
+      ];
+
+      // verify that the default text is displayed
+    const { getByText, queryByText } = render(<HealthSelector items={items} />);
+    const selectorText = getByText(/all/i);
+    expect(selectorText).toBeInTheDocument();
+
+    // verify that the dropdown is not displayed
+    let warningText = queryByText(/warning/i);
+    let OkText = queryByText(/ok/i);
+    expect(warningText).not.toBeInTheDocument();
+    expect(OkText).not.toBeInTheDocument();
+    // click on button and verify that the dropdown is displayed
+    fireEvent.click(selectorText);
+    warningText = getByText(/warning/i);
+    OkText = getByText(/ok/i);
+    expect(warningText).toBeInTheDocument();
+    expect(OkText).toBeInTheDocument();
+
+    // verify that action are called on click
+    expect(warningAction).not.toHaveBeenCalled();
+    fireEvent.click(warningText);
+    expect(warningAction).toHaveBeenCalled();
+ })
+
+ test('it should display the default health selector without the ok item if the isOkHided on', () => { 
+
+    const warningAction = jest.fn();
+
+    const items = [
+        {
+          label: 'All',
+          onClick: () => {},
+          selected: true,
+        },
+        {
+          label: 'Ok',
+          onClick: () => {},
+          selected: false,
+        },
+        {
+          label: 'Warning',
+          onClick: warningAction,
+          selected: false,
+        },
+        {
+          label: 'Critical',
+          onClick: () => {},
+          selected: false,
+        },
+      ];
+
+      // verify that the default text is displayed
+    const { getByText, queryByText } = render(<HealthSelector items={items} isOkHided />);
+    const selectorText = getByText(/all/i);
+    expect(selectorText).toBeInTheDocument();
+
+    // verify that the dropdown is not displayed
+    let warningText = queryByText(/warning/i);
+    let OkText = queryByText(/ok/i);
+    expect(warningText).not.toBeInTheDocument();
+    expect(OkText).not.toBeInTheDocument();
+    // click on button and verify that the dropdown is displayed without the ok item
+    fireEvent.click(selectorText);
+    warningText = getByText(/warning/i);
+    OkText = queryByText(/ok/i);
+    expect(warningText).toBeInTheDocument();
+    expect(OkText).not.toBeInTheDocument();
+
+    // verify that action are called on click
+    expect(warningAction).not.toHaveBeenCalled();
+    fireEvent.click(warningText);
+    expect(warningAction).toHaveBeenCalled();
+ })
+
+
+});

--- a/src/lib/components/healthselector/Healthselector.component.js
+++ b/src/lib/components/healthselector/Healthselector.component.js
@@ -15,6 +15,7 @@ type Items = Array<Item>;
 type Props = {
   size?: string,
   items: Items,
+  isOkHided?: boolean,
 };
 
 const HealthselectorContainer = styled.div`
@@ -222,7 +223,7 @@ const HealthSelectorMenuItem = styled.li`
 `;
 
 function Healthselector(props: Props) {
-  const { size, items, ...rest } = props;
+  const { size, items, isOkHided = false, ...rest } = props;
   const [open, setOpen] = useState(false);
   const [menuSize, setMenuSize] = useState();
   const [triggerSize, setTriggerSize] = useState();
@@ -288,7 +289,7 @@ function Healthselector(props: Props) {
                 <RightRowWrapper>{items[0].label || 'All'}</RightRowWrapper>
               </HealthSelectorMenuItem>
             )}
-            {!items[1].selected && (
+            {!items[1].selected && !isOkHided &&(
               <HealthSelectorMenuItem onClick={items[1].onClick}>
                 <LeftRowWrapper>{icons[1]}</LeftRowWrapper>
                 <RightRowWrapper>{items[1].label || 'Ok'}</RightRowWrapper>

--- a/stories/healthselector.stories.js
+++ b/stories/healthselector.stories.js
@@ -120,6 +120,9 @@ export const Default = () => {
 
       <Title>With custom labels (Triggering StoryBook actions)</Title>
       <Healthselector items={itemsCustomLabel} />
+
+      <Title>With the healthy items being hided</Title>
+      <Healthselector items={items} isOkHided />
     </Wrapper>
   );
 };


### PR DESCRIPTION


**Component**:

HealthSelector

<!-- E.g. 'Layout', 'Table', 'build', 'tests'... -->

**Description**:

in order to avoid having an healthy option on alert. We need to add an option to hide the ok value.

**Design**:

**Breaking Changes**:

- [] Breaking Changes


---

<!-- Declare one or more issues to close once this PR gets merged -->

Closes: #ISSUE_NUMBER

<!-- If you want to refer to an issue while not closing it, use:

See: #ISSUE_NUMBER

-->
