### PR TITLE
linetemporalchart: Normalize vega field string to avoid empty data in the tooltip

### DIFF
--- a/src/lib/components/linetemporalchart/ChartUtil.js
+++ b/src/lib/components/linetemporalchart/ChartUtil.js
@@ -9,6 +9,14 @@ export type VegaData = {
   isDashed: boolean,
 }[];
 
+//Given a field containing dots ".", vega is interpreting this as an accessor
+//for nested objects, breaking then the internal mechnism to retrieve tooltip
+//data from the mouse position. We are fixing it by replacing the dots by a
+//well-known string that we expect no one would use to label a serie.
+export function normlizeVegaFieldName(fieldName: string) {
+  return fieldName.replace(/(\.)/g, 'VEGADOESNTSUPPORTDOTINFIELDNAME');
+}
+
 export function convert2VegaData(
   addedMissingDataPointSeries: Serie[],
 ): VegaData {
@@ -17,7 +25,7 @@ export function convert2VegaData(
     line.data.forEach((datum) => {
       const obj = {
         timestamp: datum[0] * 1000, // convert to million second
-        label: line.getTooltipLabel(line.metricPrefix, line.resource),
+        label: normlizeVegaFieldName(line.getTooltipLabel(line.metricPrefix, line.resource)),
         resource: line.resource,
         value:
           datum[1] && datum[1] !== NAN_STRING ? Number(datum[1]) : NAN_STRING,

--- a/src/lib/components/linetemporalchart/LineTemporalChart.component.js
+++ b/src/lib/components/linetemporalchart/LineTemporalChart.component.js
@@ -30,6 +30,7 @@ import {
   getRelativeValue,
   getColorDomains,
   relativeDatumToOriginalDatum,
+  normlizeVegaFieldName,
 } from './ChartUtil.js';
 import { useMetricsTimeSpan } from './MetricTimespanProvider';
 import { spacing } from '../../style/theme';
@@ -477,7 +478,7 @@ function LineTemporalChart({
           const res = [];
           tooltipLabels.forEach((label) => {
             res.push({
-              field: `${label.replace('.', '\\.')}`,
+              field: `${normlizeVegaFieldName(label)}`,
               type: 'quantitative',
               title: `${label}`,
               format: '.2f',


### PR DESCRIPTION
**Component**:

linetemporalchart

**Description**:

If a serie tooltip label contains a dot ".", vega considers it as a child accessor.

**Design**:

We need to normalize serie tooltip labels to remove dots.
