### PR TITLE
Add 401 not authorized error page

### DIFF
--- a/src/lib/components/error-pages/ErrorPage401.component.js
+++ b/src/lib/components/error-pages/ErrorPage401.component.js
@@ -29,17 +29,15 @@ const translations = {
 };
 
 type Props = {
-  btnLink?: string,
   supportLink?: string,
   locale?: string,
-  history?: Object,
+  onReturnHomeClick?: (event: SyntheticMouseEvent<HTMLButtonElement>) => void,
 };
 
 function ErrorPage401({
-  btnLink = '/',
   supportLink = null,
   locale = 'en',
-  history,
+  onReturnHomeClick,
   ...rest
 }: Props) {
   if (!translations[locale]) locale = 'en';
@@ -69,11 +67,11 @@ function ErrorPage401({
         </Description>
       </Row>
 
-      {history && (
+      {onReturnHomeClick && (
         <Button
           label={translations[locale].return_home}
           variant="secondary"
-          onClick={() => history.push(btnLink)}
+          onClick={onReturnHomeClick}
         />
       )}
     </ErrorPageContainer>

--- a/src/lib/components/error-pages/ErrorPage401.component.js
+++ b/src/lib/components/error-pages/ErrorPage401.component.js
@@ -1,0 +1,83 @@
+//@flow
+import React from 'react';
+import {
+  ErrorPageContainer,
+  Row,
+  WarningIcon,
+  Title,
+  Description,
+  DescriptionContent,
+  Link,
+} from './ErrorPageStyle';
+import Button from '../buttonv2/Buttonv2.component';
+
+const translations = {
+  en: {
+    unexpected_error: 'Not authorized',
+    error_desc: `You don't have permission to view this page using the credentials that you supplied.`,
+    may_also_contact: 'You may contact ',
+    to_report_issue: ' to report this issue.',
+    return_home: 'Return Home',
+  },
+  fr: {
+    unexpected_error: `Vous n'êtes pas autorisé`,
+    error_desc: `Vous n'êtes pas autorisé à afficher cette page en utilisant les informations d'identification que vous avez fournies.`,
+    may_also_contact: 'Vous pouvez contacter le ',
+    to_report_issue: ' pour signaler ce problème.',
+    return_home: "Retour à l'accueil",
+  },
+};
+
+type Props = {
+  btnLink?: string,
+  supportLink?: string,
+  locale?: string,
+  history?: Object,
+};
+
+function ErrorPage401({
+  btnLink = '/',
+  supportLink = null,
+  locale = 'en',
+  history,
+  ...rest
+}: Props) {
+  if (!translations[locale]) locale = 'en';
+  // Ensure the locale formatting is consistent
+  locale = locale.toLowerCase();
+
+  return (
+    <ErrorPageContainer className="sc-error-page401" {...rest}>
+      <Row>
+        <WarningIcon className="fas fa-exclamation-triangle fa-2x" />
+        <Title>{translations[locale].unexpected_error}</Title>
+      </Row>
+      <Row>
+        <Description>
+          <DescriptionContent>
+            {translations[locale].error_desc}
+          </DescriptionContent>
+          {supportLink && (
+            <DescriptionContent>
+              {translations[locale].may_also_contact}
+              <Link href={supportLink}>
+                support <i className="fas fa-external-link-alt" />
+              </Link>
+              {translations[locale].to_report_issue}
+            </DescriptionContent>
+          )}
+        </Description>
+      </Row>
+
+      {history && (
+        <Button
+          label={translations[locale].return_home}
+          variant="secondary"
+          onClick={() => history.push(btnLink)}
+        />
+      )}
+    </ErrorPageContainer>
+  );
+}
+
+export default ErrorPage401;

--- a/src/lib/components/error-pages/ErrorPage404.component.js
+++ b/src/lib/components/error-pages/ErrorPage404.component.js
@@ -29,17 +29,11 @@ const translations = {
 };
 
 type Props = {
-  btnLink?: string,
   locale?: string,
-  history?: Object,
+  onReturnHomeClick?: (event: SyntheticMouseEvent<HTMLButtonElement>) => void,
 };
 
-function ErrorPage404({
-  btnLink = '/',
-  locale = 'en',
-  history,
-  ...rest
-}: Props) {
+function ErrorPage404({ locale = 'en', onReturnHomeClick, ...rest }: Props) {
   if (!translations[locale]) locale = 'en';
   // Ensure the locale formatting is consistent
   locale = locale.toLowerCase();
@@ -60,11 +54,11 @@ function ErrorPage404({
           </DescriptionContent>
         </Description>
       </Row>
-      {history && (
+      {onReturnHomeClick && (
         <Button
           label={translations[locale].return_home}
           variant="secondary"
-          onClick={() => history.push(btnLink)}
+          onReturnHomeClick={onReturnHomeClick}
         />
       )}
     </ErrorPageContainer>

--- a/src/lib/components/error-pages/ErrorPage404.component.js
+++ b/src/lib/components/error-pages/ErrorPage404.component.js
@@ -1,45 +1,14 @@
 //@flow
 import React from 'react';
-import styled from 'styled-components';
-import * as defaultTheme from '../../style/theme';
-import { getThemePropSelector } from '../../utils';
-import Button from '../button/Button.component';
-
-const ErrorPageContainer = styled.div`
-  background-color: ${getThemePropSelector('backgroundLevel1')};
-  display: flex;
-  flex-direction: column;
-  justify-content: center;
-  align-items: center;
-  height: 100vh;
-`;
-
-const Title = styled.h2`
-  color: ${getThemePropSelector('textPrimary')};
-  margin: 0;
-  margin-left: ${defaultTheme.padding.large};
-`;
-
-const Description = styled.div`
-  color: ${getThemePropSelector('textPrimary')};
-  font-size: ${defaultTheme.fontSize.larger};
-  text-align: center;
-  padding: ${defaultTheme.padding.larger};
-`;
-
-const DescriptionContent = styled.p`
-  margin: 0;
-  padding: ${defaultTheme.padding.smaller};
-`;
-
-const Row = styled.div`
-  display: flex;
-  align-items: baseline;
-`;
-
-const WarningIcon = styled.i`
-  color: ${getThemePropSelector('statusWarning')};
-`;
+import {
+  ErrorPageContainer,
+  Row,
+  WarningIcon,
+  Title,
+  Description,
+  DescriptionContent,
+} from './ErrorPageStyle';
+import Button from '../buttonv2/Buttonv2.component';
 
 const translations = {
   en: {
@@ -62,9 +31,15 @@ const translations = {
 type Props = {
   btnLink?: string,
   locale?: string,
+  history?: Object,
 };
 
-function ErrorPage404({ btnLink = '/', locale = 'en', ...rest }: Props) {
+function ErrorPage404({
+  btnLink = '/',
+  locale = 'en',
+  history,
+  ...rest
+}: Props) {
   if (!translations[locale]) locale = 'en';
   // Ensure the locale formatting is consistent
   locale = locale.toLowerCase();
@@ -85,13 +60,13 @@ function ErrorPage404({ btnLink = '/', locale = 'en', ...rest }: Props) {
           </DescriptionContent>
         </Description>
       </Row>
-      <Button
-        text={translations[locale].return_home}
-        size="large"
-        type="button"
-        variant="buttonSecondary"
-        href={btnLink}
-      />
+      {history && (
+        <Button
+          label={translations[locale].return_home}
+          variant="secondary"
+          onClick={() => history.push(btnLink)}
+        />
+      )}
     </ErrorPageContainer>
   );
 }

--- a/src/lib/components/error-pages/ErrorPage500.component.js
+++ b/src/lib/components/error-pages/ErrorPage500.component.js
@@ -34,17 +34,15 @@ const translations = {
 };
 
 type Props = {
-  btnLink?: string,
   supportLink?: string,
   locale?: string,
-  history?: Object,
+  onReturnHomeClick?: (event: SyntheticMouseEvent<HTMLButtonElement>) => void,
 };
 
 function ErrorPage500({
-  btnLink = '/',
   supportLink = null,
   locale = 'en',
-  history,
+  onReturnHomeClick,
   ...rest
 }: Props) {
   if (!translations[locale]) locale = 'en';
@@ -76,11 +74,11 @@ function ErrorPage500({
           )}
         </Description>
       </Row>
-      {history && (
+      {onReturnHomeClick && (
         <Button
           label={translations[locale].return_home}
           variant="secondary"
-          onClick={() => history.push(btnLink)}
+          onReturnHomeClick={onReturnHomeClick}
         />
       )}
     </ErrorPageContainer>

--- a/src/lib/components/error-pages/ErrorPage500.component.js
+++ b/src/lib/components/error-pages/ErrorPage500.component.js
@@ -1,50 +1,15 @@
 //@flow
 import React from 'react';
-import styled from 'styled-components';
-import * as defaultTheme from '../../style/theme';
-import { getThemePropSelector } from '../../utils';
-import Button from '../button/Button.component';
-
-const ErrorPageContainer = styled.div`
-  background-color: ${getThemePropSelector('backgroundLevel1')};
-  display: flex;
-  flex-direction: column;
-  justify-content: center;
-  align-items: center;
-  height: 100vh;
-`;
-
-const Title = styled.h2`
-  color: ${getThemePropSelector('textPrimary')};
-  margin: 0;
-  margin-left: ${defaultTheme.padding.large};
-`;
-
-const Description = styled.div`
-  color: ${getThemePropSelector('textPrimary')};
-  font-size: ${defaultTheme.fontSize.larger};
-  text-align: center;
-  padding: ${defaultTheme.padding.larger};
-`;
-
-const DescriptionContent = styled.p`
-  margin: 0;
-  padding: ${defaultTheme.padding.smaller};
-`;
-
-const Row = styled.div`
-  display: flex;
-  align-items: baseline;
-`;
-
-const WarningIcon = styled.i`
-  color: ${getThemePropSelector('statusWarning')};
-`;
-
-const Link = styled.a`
-  color: ${getThemePropSelector('textLink')};
-  text-decoration: none;
-`;
+import {
+  ErrorPageContainer,
+  Row,
+  WarningIcon,
+  Title,
+  Description,
+  DescriptionContent,
+  Link,
+} from './ErrorPageStyle';
+import Button from '../buttonv2/Buttonv2.component';
 
 const translations = {
   en: {
@@ -72,12 +37,14 @@ type Props = {
   btnLink?: string,
   supportLink?: string,
   locale?: string,
+  history?: Object,
 };
 
 function ErrorPage500({
   btnLink = '/',
   supportLink = null,
   locale = 'en',
+  history,
   ...rest
 }: Props) {
   if (!translations[locale]) locale = 'en';
@@ -109,13 +76,13 @@ function ErrorPage500({
           )}
         </Description>
       </Row>
-      <Button
-        text={translations[locale].return_home}
-        size="large"
-        type="button"
-        variant="buttonSecondary"
-        href={btnLink}
-      />
+      {history && (
+        <Button
+          label={translations[locale].return_home}
+          variant="secondary"
+          onClick={() => history.push(btnLink)}
+        />
+      )}
     </ErrorPageContainer>
   );
 }

--- a/src/lib/components/error-pages/ErrorPageAuth.component.js
+++ b/src/lib/components/error-pages/ErrorPageAuth.component.js
@@ -1,49 +1,14 @@
 //@flow
 import React from 'react';
-import styled from 'styled-components';
-import * as defaultTheme from '../../style/theme';
-import { getThemePropSelector } from '../../utils';
-
-const ErrorPageContainer = styled.div`
-  background-color: ${getThemePropSelector('backgroundLevel1')};
-  display: flex;
-  flex-direction: column;
-  justify-content: center;
-  align-items: center;
-  height: 100vh;
-`;
-
-const Title = styled.h2`
-  color: ${getThemePropSelector('textPrimary')};
-  margin: 0;
-  margin-left: ${defaultTheme.padding.large};
-`;
-
-const Description = styled.div`
-  color: ${getThemePropSelector('textPrimary')};
-  font-size: ${defaultTheme.fontSize.larger};
-  text-align: center;
-  padding: ${defaultTheme.padding.larger};
-`;
-
-const DescriptionContent = styled.p`
-  margin: 0;
-  padding: ${defaultTheme.padding.smaller};
-`;
-
-const Row = styled.div`
-  display: flex;
-  align-items: baseline;
-`;
-
-const InfoIcon = styled.i`
-  color: ${getThemePropSelector('textPrimary')};
-`;
-
-const Link = styled.a`
-  color: ${getThemePropSelector('textLink')};
-  text-decoration: none;
-`;
+import {
+  ErrorPageContainer,
+  Row,
+  InfoIcon,
+  Title,
+  Description,
+  DescriptionContent,
+  Link,
+} from './ErrorPageStyle';
 
 const translations = {
   en: {

--- a/src/lib/components/error-pages/ErrorPageStyle.jsx
+++ b/src/lib/components/error-pages/ErrorPageStyle.jsx
@@ -1,0 +1,48 @@
+import styled from 'styled-components';
+import { spacing, fontSize } from '../../style/theme';
+import { getThemePropSelector } from '../../utils';
+
+export const ErrorPageContainer = styled.div`
+  background-color: ${getThemePropSelector('backgroundLevel1')};
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  height: 100vh;
+`;
+
+export const Title = styled.h2`
+  color: ${getThemePropSelector('textPrimary')};
+  margin: 0;
+  margin-left: ${spacing.sp20};
+`;
+
+export const Description = styled.div`
+  color: ${getThemePropSelector('textPrimary')};
+  font-size: ${fontSize.larger};
+  text-align: center;
+  padding: ${spacing.sp24};
+`;
+
+export const DescriptionContent = styled.p`
+  margin: 0;
+  padding: ${spacing.sp4};
+`;
+
+export const Row = styled.div`
+  display: flex;
+  align-items: baseline;
+`;
+
+export const WarningIcon = styled.i`
+  color: ${getThemePropSelector('statusWarning')};
+`;
+
+export const InfoIcon = styled.i`
+  color: ${getThemePropSelector('textPrimary')};
+`;
+
+export const Link = styled.a`
+  color: ${getThemePropSelector('textLink')};
+  text-decoration: none;
+`;

--- a/src/lib/components/error-pages/ErrorPageStyle.jsx
+++ b/src/lib/components/error-pages/ErrorPageStyle.jsx
@@ -8,7 +8,7 @@ export const ErrorPageContainer = styled.div`
   flex-direction: column;
   justify-content: center;
   align-items: center;
-  height: 100vh;
+  height: 100%;
 `;
 
 export const Title = styled.h2`

--- a/src/lib/index.js
+++ b/src/lib/index.js
@@ -41,6 +41,7 @@ import ConstrainedText from './components/constrainedtext/Constrainedtext.compon
 import EmptyState from './components/emptystate/Emptystate.component';
 import EmptyTable from './components/emptytable/Emptytable.component';
 import ScrollbarWrapper from './components/scrollbarwrapper/ScrollbarWrapper.component';
+import ErrorPage401 from './components/error-pages/ErrorPage401.component';
 import ErrorPage404 from './components/error-pages/ErrorPage404.component';
 import ErrorPage500 from './components/error-pages/ErrorPage500.component';
 import ErrorPageAuth from './components/error-pages/ErrorPageAuth.component';
@@ -101,6 +102,7 @@ export {
   EmptyState,
   EmptyTable,
   ScrollbarWrapper,
+  ErrorPage401,
   ErrorPage404,
   ErrorPage500,
   ErrorPageAuth,

--- a/stories/errorpage401.stories.js
+++ b/stories/errorpage401.stories.js
@@ -1,0 +1,34 @@
+//@flow
+import React from 'react';
+import ErrorPage401 from '../src/lib/components/error-pages/ErrorPage401.component';
+import { Wrapper } from './common';
+
+export default {
+  title: 'Components/Navigation/ErrorPages/401',
+  component: ErrorPage401,
+};
+
+export const Default = () => {
+  return (
+    <Wrapper>
+      <ErrorPage401
+        btnLink="/"
+        supportLink="https://www.scality.com/support/"
+        history={{ push: () => {} }}
+      />
+    </Wrapper>
+  );
+};
+
+export const WithLocale = () => {
+  return (
+    <Wrapper>
+      <ErrorPage401
+        btnLink="/"
+        locale="fr"
+        supportLink="https://www.scality.com/support/"
+        history={{ push: () => {} }}
+      />
+    </Wrapper>
+  );
+};

--- a/stories/errorpage401.stories.js
+++ b/stories/errorpage401.stories.js
@@ -11,10 +11,12 @@ export default {
 export const Default = () => {
   return (
     <Wrapper>
-      <ErrorPage401
-        supportLink="https://www.scality.com/support/"
-        onReturnHomeClick={() => {}}
-      />
+      <div style={{ height: '100vh' }}>
+        <ErrorPage401
+          supportLink="https://www.scality.com/support/"
+          onReturnHomeClick={() => {}}
+        />
+      </div>
     </Wrapper>
   );
 };
@@ -22,11 +24,13 @@ export const Default = () => {
 export const WithLocale = () => {
   return (
     <Wrapper>
-      <ErrorPage401
-        locale="fr"
-        supportLink="https://www.scality.com/support/"
-        onReturnHomeClick={() => {}}
-      />
+      <div style={{ height: '100vh' }}>
+        <ErrorPage401
+          locale="fr"
+          supportLink="https://www.scality.com/support/"
+          onReturnHomeClick={() => {}}
+        />
+      </div>
     </Wrapper>
   );
 };

--- a/stories/errorpage401.stories.js
+++ b/stories/errorpage401.stories.js
@@ -12,9 +12,8 @@ export const Default = () => {
   return (
     <Wrapper>
       <ErrorPage401
-        btnLink="/"
         supportLink="https://www.scality.com/support/"
-        history={{ push: () => {} }}
+        onReturnHomeClick={() => {}}
       />
     </Wrapper>
   );
@@ -24,10 +23,9 @@ export const WithLocale = () => {
   return (
     <Wrapper>
       <ErrorPage401
-        btnLink="/"
         locale="fr"
         supportLink="https://www.scality.com/support/"
-        history={{ push: () => {} }}
+        onReturnHomeClick={() => {}}
       />
     </Wrapper>
   );

--- a/stories/errorpage404.stories.js
+++ b/stories/errorpage404.stories.js
@@ -11,7 +11,7 @@ export default {
 export const Default = () => {
   return (
     <Wrapper>
-      <ErrorPage404 btnLink="/"/>
+      <ErrorPage404 btnLink="/" history={{ push: () => {} }} />
     </Wrapper>
   );
 };
@@ -19,7 +19,7 @@ export const Default = () => {
 export const WithLocale = () => {
   return (
     <Wrapper>
-      <ErrorPage404 btnLink="/" locale="fr"/>
+      <ErrorPage404 btnLink="/" locale="fr" history={{ push: () => {} }} />
     </Wrapper>
   );
 };

--- a/stories/errorpage404.stories.js
+++ b/stories/errorpage404.stories.js
@@ -11,7 +11,9 @@ export default {
 export const Default = () => {
   return (
     <Wrapper>
-      <ErrorPage404 onReturnHomeClick={() => {}} />
+      <div style={{ height: '100vh' }}>
+        <ErrorPage404 onReturnHomeClick={() => {}} />
+      </div>
     </Wrapper>
   );
 };
@@ -19,7 +21,9 @@ export const Default = () => {
 export const WithLocale = () => {
   return (
     <Wrapper>
-      <ErrorPage404 locale="fr" onReturnHomeClick={() => {}} />
+      <div style={{ height: '100vh' }}>
+        <ErrorPage404 locale="fr" onReturnHomeClick={() => {}} />
+      </div>
     </Wrapper>
   );
 };

--- a/stories/errorpage404.stories.js
+++ b/stories/errorpage404.stories.js
@@ -11,7 +11,7 @@ export default {
 export const Default = () => {
   return (
     <Wrapper>
-      <ErrorPage404 btnLink="/" history={{ push: () => {} }} />
+      <ErrorPage404 onReturnHomeClick={() => {}} />
     </Wrapper>
   );
 };
@@ -19,7 +19,7 @@ export const Default = () => {
 export const WithLocale = () => {
   return (
     <Wrapper>
-      <ErrorPage404 btnLink="/" locale="fr" history={{ push: () => {} }} />
+      <ErrorPage404 locale="fr" onReturnHomeClick={() => {}} />
     </Wrapper>
   );
 };

--- a/stories/errorpage500.stories.js
+++ b/stories/errorpage500.stories.js
@@ -11,7 +11,7 @@ export default {
 export const Default = () => {
   return (
     <Wrapper>
-      <ErrorPage500 btnLink="/"/>
+      <ErrorPage500 onReturnHomeClick={() => {}} />
     </Wrapper>
   );
 };
@@ -19,7 +19,10 @@ export const Default = () => {
 export const WithSupportLink = () => {
   return (
     <Wrapper>
-      <ErrorPage500 btnLink="/" supportLink="https://www.scality.com/support/"/>
+      <ErrorPage500
+        supportLink="https://www.scality.com/support/"
+        onReturnHomeClick={() => {}}
+      />
     </Wrapper>
   );
 };
@@ -27,7 +30,11 @@ export const WithSupportLink = () => {
 export const WithLocale = () => {
   return (
     <Wrapper>
-      <ErrorPage500 btnLink="/" supportLink="https://www.scality.com/support/" locale="fr"/>
+      <ErrorPage500
+        supportLink="https://www.scality.com/support/"
+        locale="fr"
+        onReturnHomeClick={() => {}}
+      />
     </Wrapper>
   );
 };

--- a/stories/errorpage500.stories.js
+++ b/stories/errorpage500.stories.js
@@ -11,7 +11,9 @@ export default {
 export const Default = () => {
   return (
     <Wrapper>
-      <ErrorPage500 onReturnHomeClick={() => {}} />
+      <div style={{ height: '100vh' }}>
+        <ErrorPage500 onReturnHomeClick={() => {}} />
+      </div>
     </Wrapper>
   );
 };
@@ -19,10 +21,12 @@ export const Default = () => {
 export const WithSupportLink = () => {
   return (
     <Wrapper>
-      <ErrorPage500
-        supportLink="https://www.scality.com/support/"
-        onReturnHomeClick={() => {}}
-      />
+      <div style={{ height: '100vh' }}>
+        <ErrorPage500
+          supportLink="https://www.scality.com/support/"
+          onReturnHomeClick={() => {}}
+        />
+      </div>
     </Wrapper>
   );
 };
@@ -30,11 +34,13 @@ export const WithSupportLink = () => {
 export const WithLocale = () => {
   return (
     <Wrapper>
-      <ErrorPage500
-        supportLink="https://www.scality.com/support/"
-        locale="fr"
-        onReturnHomeClick={() => {}}
-      />
+      <div style={{ height: '100vh' }}>
+        <ErrorPage500
+          supportLink="https://www.scality.com/support/"
+          locale="fr"
+          onReturnHomeClick={() => {}}
+        />
+      </div>
     </Wrapper>
   );
 };

--- a/stories/errorpageauth.stories.js
+++ b/stories/errorpageauth.stories.js
@@ -11,7 +11,9 @@ export default {
 export const Default = () => {
   return (
     <Wrapper>
-      <ErrorPageAuth onReturnHomeClick={() => {}} />
+      <div style={{ height: '100vh' }}>
+        <ErrorPageAuth onReturnHomeClick={() => {}} />
+      </div>
     </Wrapper>
   );
 };
@@ -19,10 +21,12 @@ export const Default = () => {
 export const WithSupportLink = () => {
   return (
     <Wrapper>
-      <ErrorPageAuth
-        supportLink="https://www.scality.com/support/"
-        onReturnHomeClick={() => {}}
-      />
+      <div style={{ height: '100vh' }}>
+        <ErrorPageAuth
+          supportLink="https://www.scality.com/support/"
+          onReturnHomeClick={() => {}}
+        />
+      </div>
     </Wrapper>
   );
 };
@@ -30,11 +34,13 @@ export const WithSupportLink = () => {
 export const WithLocale = () => {
   return (
     <Wrapper>
-      <ErrorPageAuth
-        btnLink="/"
-        supportLink="https://www.scality.com/support/"
-        locale="fr"
-      />
+      <div style={{ height: '100vh' }}>
+        <ErrorPageAuth
+          btnLink="/"
+          supportLink="https://www.scality.com/support/"
+          locale="fr"
+        />
+      </div>
     </Wrapper>
   );
 };

--- a/stories/errorpageauth.stories.js
+++ b/stories/errorpageauth.stories.js
@@ -11,7 +11,7 @@ export default {
 export const Default = () => {
   return (
     <Wrapper>
-      <ErrorPageAuth btnLink="/" />
+      <ErrorPageAuth onReturnHomeClick={() => {}} />
     </Wrapper>
   );
 };
@@ -20,8 +20,8 @@ export const WithSupportLink = () => {
   return (
     <Wrapper>
       <ErrorPageAuth
-        btnLink="/"
         supportLink="https://www.scality.com/support/"
+        onReturnHomeClick={() => {}}
       />
     </Wrapper>
   );


### PR DESCRIPTION
**Component**: 401 error page

**Description**:
- Generlize the ErrorPageStyle
- Update the `Return Home` Button with Buttonv2
- Pass onReturnHomeClick instead of `btnlink` and `history`

**Design**:
EN:
![image](https://user-images.githubusercontent.com/18453133/145976623-23f225c6-a26c-47dc-9c19-0caa23c140bb.png)
FR:
![image](https://user-images.githubusercontent.com/18453133/145976663-5d054b61-8a53-4c47-ad95-f6f4d0ba0ace.png)

**Breaking Changes**:
We may have breaking changes if we pass btnLink and history as props to the error pages.
But after checking MetalK8s UI and XCore UI, there is no **Return Home** button on the current implementation.

