### PR TITLE
Improvement/table v2 with textconstrained

### DIFF
--- a/src/lib/components/tablev2/SingleSelectableContent.js
+++ b/src/lib/components/tablev2/SingleSelectableContent.js
@@ -16,6 +16,7 @@ import { useTableContext } from './Tablev2.component';
 import { convertRemToPixels } from './TableUtil';
 import { Row } from 'react-table'; // may not import the type correctly
 import Tooltip from '../tooltip/Tooltip.component.js';
+import ConstrainedText from '../constrainedtext/Constrainedtext.component';
 
 export const tableRowHeight = {
   // in rem unit
@@ -117,7 +118,18 @@ export default function SingleSelectableContent({
 
             return (
               <div {...cellProps} className="td">
-                {cell.render('Cell')}
+                {
+                  // if cell.column.cell is defined that means we have a custom cell renderer
+                  // otherwise it should be just a string and we can use the constrainted text component
+                  !cell.column.cell && typeof cell.value === 'string' ? (
+                    <ConstrainedText
+                      text={cell.value}
+                      tooltipPlacement={index === 0 ? 'bottom' : 'top'}
+                    />
+                  ) : (
+                    cell.render('Cell')
+                  )
+                }
               </div>
             );
           })}

--- a/src/lib/components/tablev2/SingleSelectableContent.js
+++ b/src/lib/components/tablev2/SingleSelectableContent.js
@@ -106,7 +106,7 @@ export default function SingleSelectableContent({
               return (
                 <div {...cellProps} className="td">
                   <Tooltip
-                    placement="top"
+                    placement={index === 0 ? 'bottom' : 'top'}
                     overlay={<TooltipContent>unknown</TooltipContent>}
                   >
                     <UnknownIcon className="fas fa-minus"></UnknownIcon>

--- a/src/lib/components/tablev2/Tablestyle.js
+++ b/src/lib/components/tablev2/Tablestyle.js
@@ -2,6 +2,8 @@ import styled, { css } from 'styled-components';
 import { getTheme } from '../../utils';
 import { spacing } from '../../style/theme.js';
 
+const borderSize = '4px';
+
 export const SortIncentive = styled.span`
   position: absolute;
   display: none;
@@ -26,7 +28,10 @@ export const TableHeader = styled.div`
 
 export const HeadRow = styled.div`
   height: 2.286rem;
-  width: 100% !important;
+  width: ${(props) =>
+    props.hasScrollBar
+      ? `calc(100% - ${props.scrollBarWidth}px - ${borderSize} )!important;` // -4px for border
+      : '100% !important;'} 
   table-layout: fixed;
   cursor: pointer;
   color: ${(props) => getTheme(props).textPrimary};
@@ -62,11 +67,12 @@ export const TableRow = styled.div`
     if (props.selectedId && props.selectedId === props.row.id) {
       return css`
         background-color: ${(props) => getTheme(props).highlight};
-        border-right: 4px solid ${(props) => getTheme(props).selectedActive};
+        border-right: ${borderSize} solid
+          ${(props) => getTheme(props).selectedActive};
       `;
     } else {
       return css`
-        border-right: 4px solid
+        border-right: ${borderSize} solid
           ${(props) => getTheme(props)[props.backgroundVariant]};
       `;
     }


### PR DESCRIPTION
**Component**:

TableV2
<!-- E.g. 'Layout', 'Table', 'build', 'tests'... -->

**Description**:

use textConstrained component to add ellipsis when no customCell is used
![Capture d’écran du 2021-12-16 17-06-00](https://user-images.githubusercontent.com/9944133/146409091-34a83dc8-b119-4291-96d3-082cc29b1744.png)

It also fix the issue with table Head not being the same width as the rest of the table when the scroll bar is displayed

**Design**:
no changes / better allignement when the scroll bar is displayed

**Breaking Changes**:

Ellipsis on default cell


