### PR TITLE
Tabs: Remove the null entry from the query

### DIFF
--- a/src/lib/components/tabsv2/Tabsv2.component.js
+++ b/src/lib/components/tabsv2/Tabsv2.component.js
@@ -55,6 +55,10 @@ function Tabs({
   const matchQuery = useCallback(
     (query: Query): boolean => {
       for (const key of Object.keys(query)) {
+        // To support the case of {tab:null}
+        if (queryURL.get(key) === null && !query[key]) {
+          return true;
+        }
         if (
           !(
             queryURL.has(key) &&
@@ -69,7 +73,15 @@ function Tabs({
   );
 
   const serialize = (query?: Query): string => {
-    return !query ? '' : '?' + new URLSearchParams(query).toString();
+    if (!query) {
+      return '';
+    } else {
+      const o = Object.fromEntries(
+        Object.entries(query).filter(([_, v]) => v != null),
+      );
+      //$FlowFixMe
+      return '?' + new URLSearchParams(o).toString();
+    }
   };
 
   const getPushHistoryPath = (path: string, query?: Query): string =>

--- a/stories/tabsv2.stories.js
+++ b/stories/tabsv2.stories.js
@@ -85,7 +85,7 @@ const DefaultTabsDetails = () => {
         <Tab path="/path1" query={{ tab: 'role @' }} label="Roles">
           {details()}
         </Tab>
-        <Tab path="/path1" query={{ tab: '' }} label="Policies">
+        <Tab path="/path1" query={{ tab: null }} label="Policies">
           {details()}
         </Tab>
         <Tab path="/path4" label="Storage Location">
@@ -106,7 +106,7 @@ const DefaultTabsDetails = () => {
         <Tab path="/path1" query={{ tab: 'role @' }} label="Roles">
           {details()}
         </Tab>
-        <Tab path="/path1" query={{ tab: '' }} label="Policies">
+        <Tab path="/path1" query={{ tab: null }} label="Policies">
           {details()}
         </Tab>
         <Tab path="/path4" label="Storage Location">


### PR DESCRIPTION
**Component**:  Tabs

**Description**:
In some cases, we want to add the tab entry in query params. 
The issue is for the default tab, there is no way to hide the query param except delete the tab key in the query object which mutates the object.

So we support this case on Tabs component.

```js
<Tab path="/path1" query={{ tab: null }} label="Policies">
  {details()}
</Tab>
```

**Design**:
The display of the Tabs should be the same as before.

**Breaking Changes**:
no


---

<!-- Declare one or more issues to close once this PR gets merged -->

Closes: #ISSUE_NUMBER

<!-- If you want to refer to an issue while not closing it, use:

See: #ISSUE_NUMBER

-->
