### PR TITLE
constrainedText: add the possibility to have a lineClamp

### DIFF
--- a/src/lib/components/constrainedtext/Constrainedtext.component.js
+++ b/src/lib/components/constrainedtext/Constrainedtext.component.js
@@ -1,20 +1,32 @@
 //@flow
-import React from "react";
-import type { Node } from "react";
-import styled from "styled-components";
-import Tooltip from "../tooltip/Tooltip.component.js";
-import type { Props as TooltipProps } from "../tooltip/Tooltip.component.js";
+import React from 'react';
+import type { Node } from 'react';
+import styled from 'styled-components';
+import Tooltip from '../tooltip/Tooltip.component.js';
+import type { Props as TooltipProps } from '../tooltip/Tooltip.component.js';
 type Props = {
   text: string,
-  tooltipStyle?: $PropertyType<TooltipProps, "overlayStyle">,
-  tooltipPlacement?: $PropertyType<TooltipProps, "placement">,
+  tooltipStyle?: $PropertyType<TooltipProps, 'overlayStyle'>,
+  tooltipPlacement?: $PropertyType<TooltipProps, 'placement'>,
+  lineClamp?: Number,
 };
 
+// for lineClamp cf https://css-tricks.com/almanac/properties/l/line-clamp/
+// it should work on all major navigator, despite the --webkit prefix
+// just in case if we don't use line clamp we can just use the classic way
 const ConstrainedTextContainer = styled.div`
   overflow: hidden;
   text-overflow: ellipsis;
-  word-wrap: break-word;
-  white-space: nowrap;
+
+  ${(props) =>
+    props.lineClamp > 1
+      ? `
+  display: -webkit-box;
+  -webkit-line-clamp: ${props.lineClamp};
+  -webkit-box-orient: vertical;
+  `
+      : `word-wrap: break-word;
+      white-space: nowrap;`}};
 `;
 
 const BlockTooltip = styled.div`
@@ -27,6 +39,7 @@ function ConstrainedText({
   text,
   tooltipStyle,
   tooltipPlacement,
+  lineClamp = 1,
 }: Props): Node {
   return (
     <BlockTooltip>
@@ -35,7 +48,10 @@ function ConstrainedText({
         overlayStyle={tooltipStyle}
         placement={tooltipPlacement}
       >
-        <ConstrainedTextContainer className="sc-constrainedtext">
+        <ConstrainedTextContainer
+          className="sc-constrainedtext"
+          lineClamp={lineClamp}
+        >
           {text}
         </ConstrainedTextContainer>
       </Tooltip>

--- a/stories/constrainedtext.stories.js
+++ b/stories/constrainedtext.stories.js
@@ -36,6 +36,20 @@ export const Default = () => {
           tooltipPlacement="right"
         />
       </div>
+
+      <Title>With the ability to customize the number of line</Title>
+      <div
+        style={{
+          width: '100px',
+          color: '#0F7FFF',
+        }}
+      >
+        <Constrainedtext
+          text={'This is a long phrase that should get into 2 lines'}
+          tooltipStyle={{ width: '100px' }}
+          lineClamp={2}
+        />
+      </div>
     </Wrapper>
   );
 };


### PR DESCRIPTION
**Component**:

ConstrainedText
<!-- E.g. 'Layout', 'Table', 'build', 'tests'... -->

**Description**:

Allow constrained text to work on multiple line. 

It's usefull for long text like the description text in the alert on metalk8's

with multi line : 
![Capture d’écran du 2022-01-19 11-48-01](https://user-images.githubusercontent.com/9944133/150116209-3e927f52-fa0c-4649-b6bb-8e5593304bb1.png)

without
![Capture d’écran du 2022-01-19 11-48-33](https://user-images.githubusercontent.com/9944133/150116257-66be8de7-e348-4263-b9dc-777707cb99c4.png)



**Design**:

**Breaking Changes**:

- [] Breaking Changes


---

<!-- Declare one or more issues to close once this PR gets merged -->

Closes: #ISSUE_NUMBER

<!-- If you want to refer to an issue while not closing it, use:

See: #ISSUE_NUMBER

-->
