### PR TITLE
tooltip: fix tooltip displaying even with empty overlay

### DIFF
--- a/src/lib/components/tooltip/Tooltip.component.js
+++ b/src/lib/components/tooltip/Tooltip.component.js
@@ -121,18 +121,16 @@ function Tooltip({
         setIsTooltipVisible(false);
       }}
     >
-      {isTooltipVisible ? (
+      {isTooltipVisible && overlay ? (
         <TooltipOverLayContainer
           ref={tooltipRef}
           className="sc-tooltip-overlay"
           placement={placement}
           overlayStyle={overlayStyle}
         >
-          {overlay && (
-            <TooltipText className="sc-tooltip-overlay-text">
-              {overlay}
-            </TooltipText>
-          )}
+          <TooltipText className="sc-tooltip-overlay-text">
+            {overlay}
+          </TooltipText>
         </TooltipOverLayContainer>
       ) : null}
       <div ref={childrenRef}>{children}</div>


### PR DESCRIPTION
**Component**:

Tooltip
<!-- E.g. 'Layout', 'Table', 'build', 'tests'... -->

**Description**:

bugfix, button were displaying empty tooltip. 

**Design**:

**Breaking Changes**:

- [] Breaking Changes

