### PR TITLE
tsconfig: change target from es2021 to es2019

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@scality/core-ui",
-  "version": "0.38.9",
+  "version": "0.38.10",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@scality/core-ui",
-  "version": "0.38.9",
+  "version": "0.38.10",
   "description": "Scality common React component library",
   "author": "Scality Engineering",
   "license": "SEE LICENSE IN LICENSE",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,7 +6,7 @@
       "declaration": true, // Generate d.ts files
       "allowSyntheticDefaultImports": true, // Allow import React from 'react'
       "jsx": "react-jsx",
-      "target": "es2021",
+      "target": "es2019",
       "outDir": "dist",
       "declarationMap": true, // go to js file when using IDE functions like "Go to Definition" in VSCode
       "lib": ["ESNext", "dom"],


### PR DESCRIPTION
We choose to reduce the target to es2019 because in some project, we are
still using webpack4 which does not handle the optional chaining
correctly. We will bump back the target when all projects use webpack5.

**Component**:

<!-- E.g. 'Layout', 'Table', 'build', 'tests'... -->

**Description**:

**Design**:

**Breaking Changes**:

- [] Breaking Changes


---

<!-- Declare one or more issues to close once this PR gets merged -->

Closes: #ISSUE_NUMBER

<!-- If you want to refer to an issue while not closing it, use:

See: #ISSUE_NUMBER

-->
