### PR TITLE
Added hasScrollbar prop for table v2 and fixed the 'flying' sorting arrow

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@scality/core-ui",
-  "version": "0.39.0",
+  "version": "0.39.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@scality/core-ui",
-      "version": "0.39.0",
+      "version": "0.39.1",
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
         "@floating-ui/dom": "^0.1.10"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@scality/core-ui",
-  "version": "0.39.0",
+  "version": "0.39.1",
   "description": "Scality common React component library",
   "author": "Scality Engineering",
   "license": "SEE LICENSE IN LICENSE",

--- a/src/lib/components/tablev2/MultiSelectableContent.tsx
+++ b/src/lib/components/tablev2/MultiSelectableContent.tsx
@@ -210,7 +210,7 @@ export const MultiSelectableContent = ({
             {headerGroup.headers.map((column) => {
               const headerStyleProps = column.getHeaderProps(
                 Object.assign(column.getSortByToggleProps(), {
-                  style: column?.cellStyle,
+                  style: { ...column?.cellStyle, position: 'relative' },
                 }),
               );
 

--- a/src/lib/components/tablev2/MultiSelectableContent.tsx
+++ b/src/lib/components/tablev2/MultiSelectableContent.tsx
@@ -43,6 +43,7 @@ type MultiSelectableContentProps<DATA_ROW extends Record<string, unknown> = Reco
   backgroundVariant?: TableVariantType;
   locale?: TableLocalType;
   customItemKey?: (index: number, data: DATA_ROW) => string;
+  hasScrollbar?: boolean;
   children?: (rows: JSX.Element) => JSX.Element;
 };
 
@@ -69,6 +70,7 @@ export const MultiSelectableContent = ({
   backgroundVariant = 'backgroundLevel1',
   locale = 'en',
   customItemKey,
+  hasScrollbar: tableHasScrollbar,
   children,
 }: MultiSelectableContentProps) => {
   const {
@@ -249,6 +251,7 @@ export const MultiSelectableContent = ({
               itemKey={itemKey}
               rowHeight={rowHeight}
               setHasScrollbar={setHasScrollbar}
+              hasScrollbar={tableHasScrollbar}
               onBottom={onBottom}
               onBottomOffset={onBottomOffset}
               RenderRow={RenderRow}
@@ -260,6 +263,7 @@ export const MultiSelectableContent = ({
             itemKey={itemKey}
             rowHeight={rowHeight}
             setHasScrollbar={setHasScrollbar}
+            hasScrollbar={tableHasScrollbar}
             onBottom={onBottom}
             onBottomOffset={onBottomOffset}
             RenderRow={RenderRow}

--- a/src/lib/components/tablev2/SingleSelectableContent.tsx
+++ b/src/lib/components/tablev2/SingleSelectableContent.tsx
@@ -31,6 +31,7 @@ export type SingleSelectableContentProps = {
   locale?: TableLocalType;
   customItemKey?: (index: Number, data: any) => string;
   isLoading?: boolean;
+  hasScrollbar?: boolean;
   children?: (rows: JSX.Element) => JSX.Element;
 };
 
@@ -56,6 +57,7 @@ export function SingleSelectableContent({
   selectedId,
   onRowSelected,
   customItemKey,
+  hasScrollbar: tableHasScrollbar,
   children,
 }: SingleSelectableContentProps) {
   if (selectedId && !onRowSelected) {
@@ -152,13 +154,13 @@ export function SingleSelectableContent({
         {headerGroups.map((headerGroup) => (
           <HeadRow
             {...headerGroup.getHeaderGroupProps()}
-            hasScrollBar={hasScrollbar}
+            hasScrollBar={tableHasScrollbar ?? hasScrollbar}
             scrollBarWidth={scrollBarWidth}
           >
             {headerGroup.headers.map((column) => {
               const headerStyleProps = column.getHeaderProps(
                 Object.assign(column.getSortByToggleProps(), {
-                  style: column.cellStyle,
+                  style: { ...column.cellStyle, position: 'relative' },
                 }),
               );
               return (
@@ -181,6 +183,7 @@ export function SingleSelectableContent({
               itemKey={itemKey}
               rowHeight={rowHeight}
               setHasScrollbar={setHasScrollbar}
+              hasScrollbar={tableHasScrollbar}
               onBottom={onBottom}
               onBottomOffset={onBottomOffset}
               RenderRow={RenderRow}
@@ -192,6 +195,7 @@ export function SingleSelectableContent({
             itemKey={itemKey}
             rowHeight={rowHeight}
             setHasScrollbar={setHasScrollbar}
+            hasScrollbar={tableHasScrollbar}
             onBottom={onBottom}
             onBottomOffset={onBottomOffset}
             RenderRow={RenderRow}

--- a/src/lib/components/tablev2/TableCommon.tsx
+++ b/src/lib/components/tablev2/TableCommon.tsx
@@ -13,6 +13,7 @@ type VirtualizedRowsType<DATA_ROW extends Record<string, unknown> = Record<strin
   RenderRow: ComponentType<ListChildComponentProps<Row<DATA_ROW>[]>>;
   rowHeight: TableHeightKeyType;
   setHasScrollbar: React.Dispatch<React.SetStateAction<boolean>>;
+  hasScrollbar?: boolean;
   itemKey?: ListItemKeySelector<Row<DATA_ROW>[]>;
   onBottom?: (rowLength: number) => void;
   onBottomOffset?: number;
@@ -22,6 +23,7 @@ export const VirtualizedRows = ({
   rows,
   rowHeight,
   setHasScrollbar,
+  hasScrollbar,
   onBottom,
   onBottomOffset,
   RenderRow,
@@ -29,6 +31,7 @@ export const VirtualizedRows = ({
 }: VirtualizedRowsType) => (
   <AutoSizer>
     {({ height, width }) => {
+      const style = hasScrollbar === false ? { overflow: 'visible'} : null;
       return (
         <List
           height={height}
@@ -37,14 +40,17 @@ export const VirtualizedRows = ({
           width={width}
           itemKey={itemKey}
           itemData={rows}
+          style={style}
           onItemsRendered={({
             visibleStartIndex,
             visibleStopIndex,
             overscanStopIndex,
           }) => {
-            setHasScrollbar(
-              visibleStartIndex - visibleStopIndex <= overscanStopIndex,
-            );
+            if (hasScrollbar !== false) {
+              setHasScrollbar(
+                visibleStartIndex - visibleStopIndex <= overscanStopIndex,
+              );
+            }
 
             if (
               onBottom &&


### PR DESCRIPTION

**Component**: Table V2

<!-- E.g. 'Layout', 'Table', 'build', 'tests'... -->

**Description**:
Added a `hasScrollbar` prop in table V2 which can be used either to enable or disable the scrolling
Also fixed the "flying" sorting arrow (it was set as position absolute, but didn't have a parent with position relative)
---

<!-- Declare one or more issues to close once this PR gets merged -->

Closes: #ISSUE_NUMBER

<!-- If you want to refer to an issue while not closing it, use:

See: #ISSUE_NUMBER

-->
