### PR TITLE
Fix the tooltip for the disabled button

### DIFF
--- a/src/lib/components/tooltip/Tooltip.component.tsx
+++ b/src/lib/components/tooltip/Tooltip.component.tsx
@@ -66,8 +66,8 @@ const TooltipOverLayContainer = styled.div`
   width: ${(props) => props && props.overlayStyle && props.overlayStyle.width};
   vertical-align: middle;
   padding: ${defaultTheme.padding.smaller};
-  }};
 `;
+
 const TooltipText = styled.div`
   width: 100%;
 `;
@@ -105,10 +105,10 @@ function Tooltip({
   return (
     <TooltipContainer
       className="sc-tooltip"
-      onMouseEnter={() => {
+      onPointerEnter={() => {
         setIsTooltipVisible(true);
       }}
-      onMouseLeave={() => {
+      onPointerLeave={() => {
         setIsTooltipVisible(false);
       }}
     >

--- a/stories/tooltip.stories.tsx
+++ b/stories/tooltip.stories.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { Tooltip } from '../src/lib/components/tooltip/Tooltip.component';
-import { Button } from '../src/lib/components/button/Button.component';
+import { Button } from '../src/lib/components/buttonv2/Buttonv2.component';
 import { Wrapper, Title, SubTitle } from './common';
 export default {
   title: 'Components/Notification/Tooltip',
@@ -59,9 +59,28 @@ export const Default = () => {
       </div>
       <div>
         <Title>Tooltip with button</Title>
-        <Tooltip placement="bottom" overlay="Helloooooo">
-          <Button size="small" text="Hover here" />
-        </Tooltip>
+        <Button
+          icon={<i className="fas fa-trash" />}
+          label=""
+          tooltip={{
+            placement: 'top',
+            overlay: `Hello, this is the button tooltip!`,
+            overlayStyle: { width: '8rem' },
+          }}
+        />
+      </div>
+      <div>
+        <Title>Tooltip with disabled button</Title>
+        <Button
+          disabled={true}
+          icon={<i className="fas fa-trash" />}
+          label=""
+          tooltip={{
+            placement: 'top',
+            overlay: `You can't delete it :(`,
+            overlayStyle: { width: '8rem' },
+          }}
+        />
       </div>
       <div>
         <Title>add icon in the overlay of tooltip</Title>


### PR DESCRIPTION
**Component**: Tooltip

**Description**:

**Disabled elements don't fire mouse events**
So the `onMouseLeave` didn't trigger for the disabled button.
We replaced `onMouseLeave` with `onPointerLeave` event.

---

<!-- Declare one or more issues to close once this PR gets merged -->

Closes: #ISSUE_NUMBER

<!-- If you want to refer to an issue while not closing it, use:

See: #ISSUE_NUMBER

-->
