### PR TITLE
Blur the SelectV2 when search enabled

### DIFF
--- a/src/lib/components/selectv2/Selectv2.component.tsx
+++ b/src/lib/components/selectv2/Selectv2.component.tsx
@@ -303,11 +303,7 @@ function SelectBox({
     }
 
     if (options && options.length > NOPT_SEARCH) {
-      setSearchSelection(option ? option.value : '');
-      // @ts-ignore
-      setPlaceholder(option ? option.label : '');
-      // @ts-ignore
-      setSearchValue(option ? option.label : '');
+      selectRef.current.blur();
     }
   };
 


### PR DESCRIPTION
**Component**:

SelectV2. To conform with the new behavior of not being in search after clicking an item in the dropdown when search is enabled.