### PR TITLE
table: Enhance default cell renderer with constrained text in column …

### DIFF
--- a/src/lib/components/constrainedtext/Constrainedtext.component.tsx
+++ b/src/lib/components/constrainedtext/Constrainedtext.component.tsx
@@ -61,12 +61,9 @@ function ConstrainedText({
   lineClamp = 1,
 }: Props): JSX.Element {
   const [displayToolTip, setDisplayToolTip] = useState(false);
-  const constrainedTextRef = useCallback(
-    (element) => {
-      element && setDisplayToolTip(isEllipsisActive(element) || lineClamp > 1);
-    },
-    [lineClamp],
-  );
+  const constrainedTextRef = useCallback((element) => {
+    element && setDisplayToolTip(isEllipsisActive(element));
+  }, []);
   return (
     <BlockTooltip>
       {displayToolTip ? (

--- a/src/lib/components/tablev2/MultiSelectableContent.tsx
+++ b/src/lib/components/tablev2/MultiSelectableContent.tsx
@@ -2,7 +2,6 @@ import { useEffect, memo, CSSProperties } from 'react';
 import { Row } from 'react-table';
 import { areEqual } from 'react-window';
 
-import { ConstrainedText } from '../constrainedtext/Constrainedtext.component';
 import { Tooltip } from '../tooltip/Tooltip.component';
 import { useTableContext } from './Tablev2.component';
 import {
@@ -85,6 +84,7 @@ export const MultiSelectableContent = <
     headerGroups,
     prepareRow,
     rows,
+    setRowHeight,
     setHiddenColumns,
     selectedRowIds,
     onBottom,
@@ -92,6 +92,10 @@ export const MultiSelectableContent = <
     isAllRowsSelected,
     toggleAllRowsSelected,
   } = useTableContext<DATA_ROW>();
+
+  useEffect(() => {
+    setRowHeight(rowHeight);
+  }, [rowHeight, setRowHeight]);
 
   useEffect(() => {
     setHiddenColumns((oldHiddenColumns) => {
@@ -217,18 +221,7 @@ export const MultiSelectableContent = <
 
           return (
             <div {...cellProps} className="td">
-              {/**
-               * react-table use function called `defaultRenderer` as
-               * default render.
-               * We use the name of the function to differentiate default
-               * implementation to our override in the column
-               */}
-              {(cell.column.Cell as { name: string | undefined }).name ===
-                'defaultRenderer' && typeof cell.value === 'string' ? (
-                <ConstrainedText text={cell.value} />
-              ) : (
-                cell.render('Cell')
-              )}
+              {cell.render('Cell')}
             </div>
           );
         })}

--- a/src/lib/components/tablev2/SingleSelectableContent.tsx
+++ b/src/lib/components/tablev2/SingleSelectableContent.tsx
@@ -1,9 +1,8 @@
-import React, { memo, CSSProperties } from 'react';
+import React, { memo, CSSProperties, useEffect } from 'react';
 import { areEqual } from 'react-window';
 import { Row } from 'react-table';
 
 import { Tooltip } from '../tooltip/Tooltip.component';
-import { ConstrainedText } from '../constrainedtext/Constrainedtext.component';
 import { useTableContext } from './Tablev2.component';
 import {
   HeadRow,
@@ -69,8 +68,19 @@ export function SingleSelectableContent<
   }
 
   const { bodyRef, headerRef } = useSyncedScroll<DATA_ROW>();
-  const { headerGroups, prepareRow, rows, onBottom, onBottomOffset } =
-    useTableContext<DATA_ROW>();
+  const {
+    headerGroups,
+    prepareRow,
+    rows,
+    onBottom,
+    onBottomOffset,
+    setRowHeight,
+  } = useTableContext<DATA_ROW>();
+
+  useEffect(() => {
+    setRowHeight(rowHeight);
+  }, [rowHeight, setRowHeight]);
+
   const RenderRow = memo(({ index, style }: RenderRowType) => {
     const row = rows[index];
     prepareRow(row);
@@ -126,12 +136,7 @@ export function SingleSelectableContent<
 
           return (
             <div {...cellProps} className="td">
-              {(cell.column.Cell as { name: string | undefined }).name ===
-                'defaultRenderer' && typeof cell.value === 'string' ? (
-                <ConstrainedText text={cell.value} />
-              ) : (
-                cell.render('Cell')
-              )}
+              {cell.render('Cell')}
             </div>
           );
         })}

--- a/src/lib/components/tablev2/TableUtils.ts
+++ b/src/lib/components/tablev2/TableUtils.ts
@@ -53,8 +53,8 @@ export type TableVariantType =
 
 // in rem unit
 export const tableRowHeight = {
-  h32: '2.286',
-  h40: '2.858',
-  h48: '3.428',
-  h64: '4.572',
+  h32: '2.286', //1 line
+  h40: '2.858', //2 line
+  h48: '3.428', //2 line
+  h64: '4.572', //3 line
 };

--- a/stories/tablev2.stories.tsx
+++ b/stories/tablev2.stories.tsx
@@ -21,7 +21,7 @@ export default info;
 const data = [
   {
     id: 1,
-    firstName: 'Sotiria',
+    firstName: 'Sotiria-long-long-long-long-long',
     lastName: 'Agathangelou',
     age: undefined,
     health: 'healthy',


### PR DESCRIPTION
…definition instead of content rendering. This enables to fix an issue because when the code is minified the defaultRenderer name is changed to an auto-generated tiny equivalent

