### PR TITLE
feat: Add navbar custom entry support for the right tabs groups

### DIFF
--- a/src/lib/components/navbar/Navbar.component.tsx
+++ b/src/lib/components/navbar/Navbar.component.tsx
@@ -173,6 +173,8 @@ const getActionRenderer = ({ type, items = null, ...rest }, index) => {
         {...rest}
       />
     );
+  } else if (type === 'custom') {
+    return <rest.render key={`navbar_right_action_${index}`} />;
   }
 
   return null;

--- a/stories/navbar.stories.tsx
+++ b/stories/navbar.stories.tsx
@@ -1,6 +1,8 @@
 import React from 'react';
 import { Navbar } from '../src/lib/components/navbar/Navbar.component';
 import { action } from '@storybook/addon-actions';
+import { Link } from '../src/lib/components/text/Text.component';
+import { Stack } from '../src/lib/spacing';
 const tabs = [
   {
     selected: true,
@@ -86,6 +88,15 @@ const rightActions = [
         onClick: action('Onboarding clicked'),
       },
     ],
+  },
+  {
+    type: 'custom',
+    render: () => (
+      <Stack>
+        <i className="fas fa-exclamation-circle" />{' '}
+        <Link>New version available</Link>
+      </Stack>
+    ),
   },
   {
     type: 'button',


### PR DESCRIPTION
**Component**:

<!-- E.g. 'Layout', 'Table', 'build', 'tests'... -->

**Description**:

**Design**:

**Breaking Changes**:

- [] Breaking Changes


---

<!-- Declare one or more issues to close once this PR gets merged -->

Closes: #ISSUE_NUMBER

<!-- If you want to refer to an issue while not closing it, use:

See: #ISSUE_NUMBER

-->
