### PR TITLE
bugfix - onChange is not trigger anymore when defaultValue is empty

### DIFF
--- a/src/lib/components/selectv2/Selectv2.component.tsx
+++ b/src/lib/components/selectv2/Selectv2.component.tsx
@@ -367,8 +367,9 @@ function SelectBox({
   const options = useOptions();
 
   const handleChange = (option: SelectOptionProps) => {
-    if (onChange && typeof onChange === 'function') {
-      onChange(option ? option.value : '');
+    const newValue = option ? option.value : '';
+    if (onChange && typeof onChange === 'function' && newValue !== value) {
+      onChange(newValue);
     }
 
     if (options && options.length > NOPT_SEARCH) {

--- a/src/lib/components/selectv2/selectv2.test.tsx
+++ b/src/lib/components/selectv2/selectv2.test.tsx
@@ -264,4 +264,14 @@ describe('SelectV2', () => {
       container.querySelector('.sc-select__placeholder'),
     ).toHaveTextContent('Select...');
   });
+
+  it('should not trigger onChange when defaultValue is empty string', () => {
+    const onChange = jest.fn();
+    render(
+      <Select value={''} onChange={onChange}>
+        <Option value="test">test</Option>
+      </Select>,
+    );
+    expect(onChange).toBeCalledTimes(0);
+  });
 });


### PR DESCRIPTION
**Component**:

<!-- E.g. 'Layout', 'Table', 'build', 'tests'... -->

**Description**:

**Design**:

**Breaking Changes**:

- [] Breaking Changes


---

<!-- Declare one or more issues to close once this PR gets merged -->

Closes: #ISSUE_NUMBER

<!-- If you want to refer to an issue while not closing it, use:

See: #ISSUE_NUMBER

-->
