### PR TITLE
Fix additional decode uri component not necessary

### DIFF
--- a/src/lib/components/tabsv2/Tabsv2.component.tsx
+++ b/src/lib/components/tabsv2/Tabsv2.component.tsx
@@ -68,7 +68,7 @@ function Tabs({
         if (
           !(
             queryURL.has(key) &&
-            decodeURIComponent(queryURL.get(key) || '') === query[key]
+            queryURL.get(key) === query[key]
           )
         )
           return false;


### PR DESCRIPTION
URLSearchParams is already decoding the URI natively