### PR TITLE
Add the tooltip for the standalone close button in the toast to avoid…

### DIFF
--- a/src/lib/components/toast/Toast.component.tsx
+++ b/src/lib/components/toast/Toast.component.tsx
@@ -165,6 +165,7 @@ function Toast({
             icon={<Icon name="Close" size="lg" color="textSecondary" />}
             onClick={params?.onClose}
             aria-label="Close"
+            tooltip={{ overlay: 'Close', placement: 'top' }}
           />
         </Box>
       </motion.div>


### PR DESCRIPTION
… the warning

**Component**:

Toast

**Description**:

**Design**:

**Breaking Changes**:

- [] Breaking Changes


---

<!-- Declare one or more issues to close once this PR gets merged -->

Closes: #ISSUE_NUMBER

<!-- If you want to refer to an issue while not closing it, use:

See: #ISSUE_NUMBER

-->
