### PR TITLE
Implement ref API for Select component

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -71,6 +71,7 @@
         "@types/react-dom": "^18.3.1",
         "@types/react-router": "^5.1.20",
         "@types/react-router-dom": "^5.3.3",
+        "@types/react-select": "^4.0.18",
         "@types/react-table": "^7.7.11",
         "@types/react-virtualized-auto-sizer": "^1.0.1",
         "@types/react-window": "^1.8.5",
@@ -5538,12 +5539,33 @@
         "@types/react-router": "*"
       }
     },
+    "node_modules/@types/react-select": {
+      "version": "4.0.18",
+      "resolved": "https://registry.npmjs.org/@types/react-select/-/react-select-4.0.18.tgz",
+      "integrity": "sha512-uCPRMPshd96BwHuT7oCrFduiv5d6km3VwmtW7rVl9g4XetS3VoJ9nZo540LiwtQgaFcW96POwaxQDZDAyYaepg==",
+      "dev": true,
+      "dependencies": {
+        "@emotion/serialize": "^1.0.0",
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "@types/react-transition-group": "*"
+      }
+    },
     "node_modules/@types/react-table": {
       "version": "7.7.20",
       "resolved": "https://registry.npmjs.org/@types/react-table/-/react-table-7.7.20.tgz",
       "integrity": "sha512-ahMp4pmjVlnExxNwxyaDrFgmKxSbPwU23sGQw2gJK4EhCvnvmib2s/O/+y1dfV57dXOwpr2plfyBol+vEHbi2w==",
       "dev": true,
       "dependencies": {
+        "@types/react": "*"
+      }
+    },
+    "node_modules/@types/react-transition-group": {
+      "version": "4.4.12",
+      "resolved": "https://registry.npmjs.org/@types/react-transition-group/-/react-transition-group-4.4.12.tgz",
+      "integrity": "sha512-8TV6R3h2j7a91c+1DXdJi3Syo69zzIZbz7Lg5tORM5LEJG7X/E6a1V3drRyBRZq7/utz7A+c4OgYLiLcYGHG6w==",
+      "dev": true,
+      "peerDependencies": {
         "@types/react": "*"
       }
     },

--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
     "@types/react-dom": "^18.3.1",
     "@types/react-router": "^5.1.20",
     "@types/react-router-dom": "^5.3.3",
+    "@types/react-select": "^4.0.18",
     "@types/react-table": "^7.7.11",
     "@types/react-virtualized-auto-sizer": "^1.0.1",
     "@types/react-window": "^1.8.5",

--- a/src/lib/components/selectv2/Selectv2.component.tsx
+++ b/src/lib/components/selectv2/Selectv2.component.tsx
@@ -10,7 +10,12 @@ import React, {
   useImperativeHandle,
 } from 'react';
 import { ScrollbarWrapper, Tooltip } from '../../index';
-import { components, SelectInstance } from 'react-select';
+import {
+  components,
+  GroupTypeBase,
+  OptionTypeBase,
+  ValueContainerProps,
+} from 'react-select';
 import { Icon } from '../icon/Icon.component';
 import { SelectStyle } from './SelectStyle';
 import { FixedSizeList, FixedSizeList as List } from 'react-window';
@@ -18,6 +23,7 @@ import { convertRemToPixels } from '../../utils';
 import { spacing } from '../../spacing';
 import { convertSizeToRem } from '../inputv2/inputv2';
 import { ConstrainedText } from '../constrainedtext/Constrainedtext.component';
+import ReactSelect from 'react-select/src/Select';
 
 const ITEMS_PER_SCROLL_WINDOW = 4;
 // more/equal than NOPT_SEARCH options enable search
@@ -284,7 +290,14 @@ const MenuList = (props) => {
   return <components.MenuList {...props}>{children}</components.MenuList>;
 };
 
-const ValueContainer = ({ children, ...props }) => {
+const ValueContainer = <
+  OptionType extends OptionTypeBase,
+  IsMulti extends boolean,
+  GroupType extends GroupTypeBase<OptionType>,
+>({
+  children,
+  ...props
+}: ValueContainerProps<OptionType, IsMulti, GroupType>) => {
   const selectedOption = props.selectProps.selectedOption;
   const icon = selectedOption ? selectedOption.icon : null;
   const ariaProps = {
@@ -304,8 +317,12 @@ const ValueContainer = ({ children, ...props }) => {
     </components.ValueContainer>
   );
 };
-export interface SelectRef {
-  select: SelectInstance<any> | null;
+export interface SelectRef<
+  OptionType extends OptionTypeBase,
+  IsMulti extends boolean,
+  GroupType extends GroupTypeBase<OptionType>,
+> {
+  select: ReactSelect<OptionType, IsMulti, GroupType> | null;
   focus: () => void;
   blur: () => void;
   openMenu: () => void;
@@ -339,8 +356,12 @@ type SelectOptionProps = {
   disabledReason?: React.ReactNode;
 };
 
-type SelectComponentType = ForwardRefExoticComponent<
-  SelectProps & RefAttributes<SelectRef>
+type SelectComponentType<
+  OptionType extends OptionTypeBase,
+  IsMulti extends boolean,
+  GroupType extends GroupTypeBase<OptionType>,
+> = ForwardRefExoticComponent<
+  SelectProps & RefAttributes<SelectRef<OptionType, IsMulti, GroupType>>
 > & {
   Option: typeof Option;
 };
@@ -351,7 +372,11 @@ const OptionContext = createContext<{
   unregister: (value: string) => void;
 } | null>(null);
 
-function SelectBox({
+function SelectBox<
+  OptionType extends OptionTypeBase,
+  IsMulti extends boolean,
+  GroupType extends GroupTypeBase<OptionType>,
+>({
   placeholder = 'Select...',
   disabled = false,
   value,
@@ -362,14 +387,25 @@ function SelectBox({
   id,
   selectRef,
   ...rest
-}: SelectProps & { selectRef?: React.Ref<SelectRef> }) {
+}: SelectProps & {
+  selectRef?: React.Ref<SelectRef<OptionType, IsMulti, GroupType>>;
+}) {
   const [keyboardFocusEnabled, setKeyboardFocusEnabled] = useState(false);
   const [searchSelection, setSearchSelection] = useState('');
   const [searchValue, setSearchValue] = useState('');
   const [customPlaceholder, setPlaceholder] = useState(placeholder);
   const isDefaultVariant = variant === 'default';
   const [isMenuBottom, setIsMenuBottom] = useState(true);
-  const internalSelectRef = useRef<any>(null);
+  const internalSelectRef = useRef<
+    ReactSelect<OptionType, IsMulti, GroupType> & {
+      setState: (state: { menuIsOpen: boolean }) => void;
+      state: { isOpen: boolean };
+      select: {
+        setValue: (option: SelectOptionProps) => void;
+        clearValue: () => void;
+      };
+    }
+  >(null);
 
   useImperativeHandle(
     selectRef,
@@ -518,36 +554,39 @@ function SelectBox({
   );
 }
 
-const SelectWithOptionContext = forwardRef<SelectRef, SelectProps>(
-  (props, ref) => {
-    const [options, setOptions] = useState<Record<string, SelectOptionProps>>(
-      {},
-    );
+const SelectWithOptionContext = forwardRef<
+  SelectRef<OptionTypeBase, boolean, GroupTypeBase<OptionTypeBase>>,
+  SelectProps
+>((props, ref) => {
+  const [options, setOptions] = useState<Record<string, SelectOptionProps>>({});
 
-    const register = (option: SelectOptionProps) => {
-      setOptions((prevOptions) => ({
-        ...prevOptions,
-        [option.value]: option,
-      }));
-    };
+  const register = (option: SelectOptionProps) => {
+    setOptions((prevOptions) => ({
+      ...prevOptions,
+      [option.value]: option,
+    }));
+  };
 
-    const unregister = (value: string) => {
-      setOptions((prevOptions) => {
-        const { [value]: _, ...rest } = prevOptions;
-        return rest;
-      });
-    };
+  const unregister = (value: string) => {
+    setOptions((prevOptions) => {
+      const { [value]: _, ...rest } = prevOptions;
+      return rest;
+    });
+  };
 
-    return (
-      <OptionContext.Provider value={{ options, register, unregister }}>
-        <>
-          <SelectBox {...props} selectRef={ref} />
-          {props.children}
-        </>
-      </OptionContext.Provider>
-    );
-  },
-) as SelectComponentType;
+  return (
+    <OptionContext.Provider value={{ options, register, unregister }}>
+      <>
+        <SelectBox {...props} selectRef={ref} />
+        {props.children}
+      </>
+    </OptionContext.Provider>
+  );
+}) as SelectComponentType<
+  OptionTypeBase,
+  boolean,
+  GroupTypeBase<OptionTypeBase>
+>;
 
 SelectWithOptionContext.displayName = 'Select';
 SelectWithOptionContext.Option = Option;

--- a/src/lib/components/selectv2/Selectv2.component.tsx
+++ b/src/lib/components/selectv2/Selectv2.component.tsx
@@ -4,9 +4,13 @@ import React, {
   useState,
   useEffect,
   useRef,
+  forwardRef,
+  ForwardRefExoticComponent,
+  RefAttributes,
+  useImperativeHandle,
 } from 'react';
 import { ScrollbarWrapper, Tooltip } from '../../index';
-import { components } from 'react-select';
+import { components, SelectInstance } from 'react-select';
 import { Icon } from '../icon/Icon.component';
 import { SelectStyle } from './SelectStyle';
 import { FixedSizeList, FixedSizeList as List } from 'react-window';
@@ -300,6 +304,15 @@ const ValueContainer = ({ children, ...props }) => {
     </components.ValueContainer>
   );
 };
+export interface SelectRef {
+  select: SelectInstance<any> | null;
+  focus: () => void;
+  blur: () => void;
+  openMenu: () => void;
+  closeMenu: () => void;
+  setValue: (value: string) => void;
+  clearValue: () => void;
+}
 
 export type SelectProps = {
   id: string;
@@ -316,6 +329,7 @@ export type SelectProps = {
   /** use menuPositon='fixed' inside modal to avoid display issue */
   menuPosition?: 'fixed' | 'absolute';
 };
+
 type SelectOptionProps = {
   value: string;
   label: React.ReactNode;
@@ -325,38 +339,17 @@ type SelectOptionProps = {
   disabledReason?: React.ReactNode;
 };
 
+type SelectComponentType = ForwardRefExoticComponent<
+  SelectProps & RefAttributes<SelectRef>
+> & {
+  Option: typeof Option;
+};
+
 const OptionContext = createContext<{
   options: Record<string, SelectOptionProps>;
   register: (option: SelectOptionProps) => void;
   unregister: (value: string) => void;
 } | null>(null);
-
-function SelectWithOptionContext(props: SelectProps) {
-  const [options, setOptions] = useState<Record<string, SelectOptionProps>>({});
-
-  const register = (option: SelectOptionProps) => {
-    setOptions((prevOptions) => ({
-      ...prevOptions,
-      [option.value]: option,
-    }));
-  };
-
-  const unregister = (value: string) => {
-    setOptions((prevOptions) => {
-      const { [value]: _, ...rest } = prevOptions;
-      return rest;
-    });
-  };
-
-  return (
-    <OptionContext.Provider value={{ options, register, unregister }}>
-      <>
-        <SelectBox {...props} />
-        {props.children}
-      </>
-    </OptionContext.Provider>
-  );
-}
 
 function SelectBox({
   placeholder = 'Select...',
@@ -367,15 +360,57 @@ function SelectBox({
   className,
   size = '1',
   id,
+  selectRef,
   ...rest
-}: SelectProps) {
+}: SelectProps & { selectRef?: React.Ref<SelectRef> }) {
   const [keyboardFocusEnabled, setKeyboardFocusEnabled] = useState(false);
   const [searchSelection, setSearchSelection] = useState('');
   const [searchValue, setSearchValue] = useState('');
   const [customPlaceholder, setPlaceholder] = useState(placeholder);
   const isDefaultVariant = variant === 'default';
   const [isMenuBottom, setIsMenuBottom] = useState(true);
-  const selectRef = useRef<any>();
+  const internalSelectRef = useRef<any>(null);
+
+  useImperativeHandle(
+    selectRef,
+    () => ({
+      focus: () => {
+        if (internalSelectRef.current) {
+          internalSelectRef.current.focus();
+        }
+      },
+      blur: () => {
+        if (internalSelectRef.current) {
+          internalSelectRef.current.blur();
+        }
+      },
+      select: internalSelectRef.current,
+      openMenu: () => {
+        if (internalSelectRef.current) {
+          internalSelectRef.current.setState({ menuIsOpen: true });
+        }
+      },
+      closeMenu: () => {
+        if (internalSelectRef.current) {
+          internalSelectRef.current.setState({ menuIsOpen: false });
+        }
+      },
+      setValue: (newValue: string) => {
+        if (internalSelectRef.current) {
+          const option = options.find((opt) => opt.value === newValue);
+          if (option) {
+            internalSelectRef.current.select.setValue(option);
+          }
+        }
+      },
+      clearValue: () => {
+        if (internalSelectRef.current && internalSelectRef.current.select) {
+          internalSelectRef.current.select.clearValue();
+        }
+      },
+    }),
+    [internalSelectRef],
+  );
 
   const options = useOptions();
 
@@ -385,8 +420,8 @@ function SelectBox({
       onChange(newValue);
     }
 
-    if (options && options.length > NOPT_SEARCH) {
-      selectRef.current.blur();
+    if (options && options.length > NOPT_SEARCH && internalSelectRef.current) {
+      internalSelectRef.current.blur();
     }
   };
 
@@ -414,12 +449,12 @@ function SelectBox({
     if (
       !isEmptyStringInOptions &&
       value === '' &&
-      selectRef.current &&
-      selectRef.current.select
+      internalSelectRef.current &&
+      internalSelectRef.current.select
     ) {
-      selectRef.current.select.clearValue();
+      internalSelectRef.current.select.clearValue();
     }
-  }, [value, selectRef, isEmptyStringInOptions]);
+  }, [value, isEmptyStringInOptions]);
 
   return (
     <ScrollbarWrapper>
@@ -454,7 +489,7 @@ function SelectBox({
             ITEMS_PER_SCROLL_WINDOW={ITEMS_PER_SCROLL_WINDOW}
             onChange={handleChange}
             onInputChange={handleSearchInput}
-            ref={selectRef}
+            ref={internalSelectRef}
             isMenuBottom={isMenuBottom}
             setIsMenuBottom={setIsMenuBottom}
             onBlur={rest.onBlur}
@@ -464,10 +499,10 @@ function SelectBox({
               if (
                 event &&
                 event.key === 'Enter' &&
-                selectRef &&
-                !selectRef.current.state.isOpen
+                internalSelectRef.current &&
+                !internalSelectRef.current.state.isOpen
               ) {
-                selectRef.current.setState({
+                internalSelectRef.current.setState({
                   menuIsOpen: true,
                 });
               } else {
@@ -483,5 +518,37 @@ function SelectBox({
   );
 }
 
+const SelectWithOptionContext = forwardRef<SelectRef, SelectProps>(
+  (props, ref) => {
+    const [options, setOptions] = useState<Record<string, SelectOptionProps>>(
+      {},
+    );
+
+    const register = (option: SelectOptionProps) => {
+      setOptions((prevOptions) => ({
+        ...prevOptions,
+        [option.value]: option,
+      }));
+    };
+
+    const unregister = (value: string) => {
+      setOptions((prevOptions) => {
+        const { [value]: _, ...rest } = prevOptions;
+        return rest;
+      });
+    };
+
+    return (
+      <OptionContext.Provider value={{ options, register, unregister }}>
+        <>
+          <SelectBox {...props} selectRef={ref} />
+          {props.children}
+        </>
+      </OptionContext.Provider>
+    );
+  },
+) as SelectComponentType;
+
+SelectWithOptionContext.displayName = 'Select';
 SelectWithOptionContext.Option = Option;
 export const Select = SelectWithOptionContext;

--- a/src/lib/components/selectv2/selectv2.test.tsx
+++ b/src/lib/components/selectv2/selectv2.test.tsx
@@ -1,8 +1,8 @@
 import { screen, render as testingRender } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import React, { useState } from 'react';
+import React, { useState, useRef } from 'react';
 import { QueryClient, QueryClientProvider } from 'react-query';
-import { Option, Select } from '../selectv2/Selectv2.component';
+import { Option, Select, SelectRef } from '../selectv2/Selectv2.component';
 
 const render = (args) => {
   return testingRender(
@@ -451,5 +451,159 @@ describe('SelectV2', () => {
      * const option = within(selectContainer).getByRole('option', { name: /account 1/i });
      */
     await userEvent.click(screen.getByRole('option', { name: /account 1/i }));
+  });
+
+  describe('Ref API', () => {
+    it('should expose focus method via ref', async () => {
+      const RefTestComponent = () => {
+        const selectRef = useRef<SelectRef>(null);
+        const [value, setValue] = useState<string>('');
+
+        return (
+          <div>
+            <button onClick={() => selectRef.current?.focus()}>Focus</button>
+            <Select
+              id="ref-test"
+              value={value}
+              onChange={(value) => setValue(value)}
+              ref={selectRef}
+              placeholder="Select with ref"
+            >
+              {simpleOptions}
+            </Select>
+          </div>
+        );
+      };
+
+      render(<RefTestComponent />);
+      expect(selectors.input()).not.toHaveFocus();
+
+      userEvent.click(screen.getByRole('button', { name: /Focus/i }));
+      expect(selectors.input()).toHaveFocus();
+    });
+
+    it('should expose openMenu and closeMenu methods via ref', async () => {
+      const RefTestComponent = () => {
+        const selectRef = useRef<SelectRef>(null);
+        const [value, setValue] = useState<string>('');
+
+        return (
+          <div>
+            <button onClick={() => selectRef.current?.openMenu()}>
+              Open Menu
+            </button>
+            <button onClick={() => selectRef.current?.closeMenu()}>
+              Close Menu
+            </button>
+            <Select
+              id="ref-test"
+              value={value}
+              onChange={(value) => setValue(value)}
+              ref={selectRef}
+              placeholder="Select with ref"
+            >
+              {simpleOptions}
+            </Select>
+          </div>
+        );
+      };
+
+      render(<RefTestComponent />);
+      expect(selectors.options()).toHaveLength(0);
+
+      userEvent.click(screen.getByRole('button', { name: /Open Menu/i }));
+      expect(selectors.options().length).toBeGreaterThan(0);
+      simpleOptions.forEach((opt) => {
+        const option = selectors.option(opt.props.label);
+        expect(option).toBeInTheDocument();
+      });
+
+      userEvent.click(screen.getByRole('button', { name: /Close Menu/i }));
+      expect(selectors.options()).toHaveLength(0);
+    });
+
+    it('should expose setValue and clearValue methods via ref', async () => {
+      const handleChange = jest.fn();
+
+      const RefTestComponent = () => {
+        const [value, setValue] = useState('');
+        const selectRef = useRef<SelectRef>(null);
+
+        return (
+          <div>
+            <button
+              onClick={() => {
+                selectRef.current?.setValue('0');
+                setValue('0');
+              }}
+            >
+              Set Value
+            </button>
+            <button
+              onClick={() => {
+                selectRef.current?.clearValue();
+                setValue('');
+              }}
+            >
+              Clear
+            </button>
+            <Select
+              id="ref-test"
+              value={value}
+              onChange={(newValue) => {
+                setValue(newValue);
+                handleChange(newValue);
+              }}
+              ref={selectRef}
+              placeholder="Select with ref"
+            >
+              {simpleOptions}
+            </Select>
+          </div>
+        );
+      };
+
+      render(<RefTestComponent />);
+
+      const select = selectors.select();
+      expect(select).toHaveTextContent('Select with ref');
+
+      userEvent.click(screen.getByRole('button', { name: /Set Value/i }));
+      expect(select).toHaveTextContent('Item 0');
+
+      userEvent.click(screen.getByRole('button', { name: /Clear/i }));
+      expect(select).toHaveTextContent('Select with ref');
+    });
+
+    it('should expose blur method via ref', async () => {
+      const RefTestComponent = () => {
+        const selectRef = useRef<SelectRef>(null);
+        const [value, setValue] = useState<string>('');
+
+        return (
+          <div>
+            <button onClick={() => selectRef.current?.focus()}>Focus</button>
+            <button onClick={() => selectRef.current?.blur()}>Blur</button>
+            <Select
+              id="ref-test"
+              value={value}
+              onChange={(value) => setValue(value)}
+              ref={selectRef}
+              placeholder="Select with ref"
+            >
+              {simpleOptions}
+            </Select>
+          </div>
+        );
+      };
+
+      render(<RefTestComponent />);
+
+      userEvent.click(screen.getByRole('button', { name: /Focus/i }));
+      expect(selectors.input()).toHaveFocus();
+
+      userEvent.click(screen.getByRole('button', { name: /Blur/i }));
+      expect(selectors.input()).not.toHaveFocus();
+    });
   });
 });


### PR DESCRIPTION
# Component: Select V2

## Description
Enhanced the `Select V2` component to support ref forwarding, enabling programmatic control of the component. This allows parent components to directly interact with the Select, implementing features like focus management, menu control, and value manipulation.

## Design
- Used React's `forwardRef` and `useImperativeHandle` to expose a controlled API
- Added a strongly typed `SelectRef` interface with the following methods:
  - `focus()`: Sets focus to the select component
  - `blur()`: Removes focus from the select component
  - `openMenu()`: Programmatically opens the dropdown menu
  - `closeMenu()`: Programmatically closes the dropdown menu
  - `setValue(value: string)`: Sets a specific option value
  - `clearValue()`: Clears the currently selected value
  - `select`: Access to the underlying SelectInstance for advanced usage

- Implemented comprehensive test coverage for all exposed methods

## Breaking Changes

- [x] No Breaking Changes

The implementation maintains full backward compatibility with existing usages. Components that don't use refs will continue working exactly as before, while new code can optionally leverage the ref-based API.

---

Closes: #ISSUE_NUMBER