### PR TITLE
fix toast provider unnecessary re-renders

### DIFF
--- a/src/lib/components/toast/ToastProvider.tsx
+++ b/src/lib/components/toast/ToastProvider.tsx
@@ -1,4 +1,4 @@
-import { ReactNode, createContext, useContext, useState } from 'react';
+import { ReactNode, createContext, useCallback, useContext, useMemo, useState } from 'react';
 import { Toast, ToastProps } from './Toast.component';
 
 export type ToastContextState = Omit<ToastProps, 'onClose'>;
@@ -14,20 +14,27 @@ export const ToastContext = createContext<ToastContextType | undefined>(
 interface ToastProviderProps {
   children: ReactNode;
 }
+
 export const ToastProvider: React.FC<
   React.PropsWithChildren<ToastProviderProps>
 > = ({ children }) => {
   const [toastProps, setToastProps] = useState<ToastContextState | null>(null);
 
-  const showToast = (toastProps: ToastContextState) => {
-    setToastProps(toastProps);
-  };
+  const toastCtxValue = useMemo(
+    () => ({ showToast: setToastProps }),
+    [],
+  );
+
+  const closeToast = useCallback(
+    () => setToastProps(null),
+    []
+  );
 
   return (
-    <ToastContext.Provider value={{ showToast }}>
+    <ToastContext.Provider value={toastCtxValue}>
       {children}
       {toastProps && (
-        <Toast {...toastProps} onClose={() => setToastProps(null)} />
+        <Toast {...toastProps} onClose={closeToast} />
       )}
     </ToastContext.Provider>
   );
@@ -38,5 +45,6 @@ export const useToast = () => {
   if (!context) {
     throw new Error('useToast must be used within a ToastProvider');
   }
+
   return context;
 };


### PR DESCRIPTION
**Component**:

Toast

**Description**:

Fix toast provider unnecessary re-renders.

**Design**:

Toast was missing a memoization on the Provider value. They should always be memoized. Without that every time the ToastProvider is re-rendered the context value reference changes (and this can happen a lot if it's parent is a QueryClientProvider for example). This means that the components calling useToast would re-render for completely unrelated reasons.

I did not provide the `setToastProps` dependency since react provides guaranties that it's ref is stable and the project don't enforce exhaustive deps.

**Breaking Changes**:

- None
