### PR TITLE
Bugfix/test warning clear

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
         "@fortawesome/fontawesome-svg-core": "^1.2.35",
         "@fortawesome/free-regular-svg-icons": "^5.15.3",
         "@fortawesome/free-solid-svg-icons": "^5.15.3",
-        "@fortawesome/react-fontawesome": "^0.1.14",
+        "@fortawesome/react-fontawesome": "^0.2.3",
         "@js-temporal/polyfill": "^0.4.4",
         "@storybook/preview-api": "^8.3.6",
         "downshift": "^7.0.5",
@@ -2916,15 +2916,16 @@
       }
     },
     "node_modules/@fortawesome/react-fontawesome": {
-      "version": "0.1.19",
-      "resolved": "https://registry.npmjs.org/@fortawesome/react-fontawesome/-/react-fontawesome-0.1.19.tgz",
-      "integrity": "sha512-Hyb+lB8T18cvLNX0S3llz7PcSOAJMLwiVKBuuzwM/nI5uoBw+gQjnf9il0fR1C3DKOI5Kc79pkJ4/xB0Uw9aFQ==",
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/@fortawesome/react-fontawesome/-/react-fontawesome-0.2.3.tgz",
+      "integrity": "sha512-HlJco8RDY8NrzFVjy23b/7mNS4g9NegcrBG3n7jinwpc2x/AmSVk53IhWniLYM4szYLxRAFTAGwGn0EIlclDeQ==",
+      "license": "MIT",
       "dependencies": {
         "prop-types": "^15.8.1"
       },
       "peerDependencies": {
-        "@fortawesome/fontawesome-svg-core": "~1 || ~6",
-        "react": ">=16.x"
+        "@fortawesome/fontawesome-svg-core": "~1 || ~6 || ~7",
+        "react": "^16.3 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/@humanwhocodes/config-array": {

--- a/package.json
+++ b/package.json
@@ -108,7 +108,7 @@
     "@fortawesome/fontawesome-svg-core": "^1.2.35",
     "@fortawesome/free-regular-svg-icons": "^5.15.3",
     "@fortawesome/free-solid-svg-icons": "^5.15.3",
-    "@fortawesome/react-fontawesome": "^0.1.14",
+    "@fortawesome/react-fontawesome": "^0.2.3",
     "@js-temporal/polyfill": "^0.4.4",
     "@storybook/preview-api": "^8.3.6",
     "downshift": "^7.0.5",

--- a/src/lib/components/accordion/Accordion.test.tsx
+++ b/src/lib/components/accordion/Accordion.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from '@testing-library/react';
+import { render, screen, waitFor } from '@testing-library/react';
 import React, { useState } from 'react';
 import { Accordion } from './Accordion.component';
 import userEvent from '@testing-library/user-event';
@@ -19,8 +19,9 @@ describe('Accordion', () => {
   const renderAccordion = (open = false) => {
     render(<SUT open={open} />);
   };
-  it('should render the Accordion component with title and content', () => {
+  it('should render the Accordion component with title and content', async () => {
     renderAccordion();
+    await waitFor(() => screen.findByRole('img', { hidden: true }));
 
     const accordionToggle = selectors.accordionToggle();
     expect(accordionToggle).toBeInTheDocument();

--- a/src/lib/components/accordion/Accordion.test.tsx
+++ b/src/lib/components/accordion/Accordion.test.tsx
@@ -2,7 +2,6 @@ import { render, screen } from '@testing-library/react';
 import React, { useState } from 'react';
 import { Accordion } from './Accordion.component';
 import userEvent from '@testing-library/user-event';
-import { QueryClient, QueryClientProvider } from 'react-query';
 
 describe('Accordion', () => {
   const selectors = {
@@ -11,13 +10,10 @@ describe('Accordion', () => {
     accordionContent: () => screen.queryByText(/Test content/i),
   };
   const SUT = ({ open = false }) => {
-    const queryClient = new QueryClient();
     return (
-      <QueryClientProvider client={queryClient}>
-        <Accordion title="Advanced Testings" id="test-accordion" open={open}>
-          <div>Test content</div>
-        </Accordion>
-      </QueryClientProvider>
+      <Accordion title="Advanced Testings" id="test-accordion" open={open}>
+        <div>Test content</div>
+      </Accordion>
     );
   };
   const renderAccordion = (open = false) => {
@@ -54,7 +50,6 @@ describe('Accordion', () => {
   });
 
   it('should toggle the content when open prop changes', () => {
-    const queryClient = new QueryClient();
     const TestWrapper = () => {
       const [isOpen, setisOpen] = useState(false);
       return (
@@ -65,11 +60,7 @@ describe('Accordion', () => {
       );
     };
 
-    render(
-      <QueryClientProvider client={queryClient}>
-        <TestWrapper />
-      </QueryClientProvider>,
-    );
+    render(<TestWrapper />);
 
     userEvent.click(screen.getByRole('button', { name: /Test button/i }));
     expect(selectors.accordionContent()).toBeInTheDocument();

--- a/src/lib/components/healthselectorv2/HealthSelector.component.test.tsx
+++ b/src/lib/components/healthselectorv2/HealthSelector.component.test.tsx
@@ -5,7 +5,6 @@ import {
 import React from 'react';
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import { QueryClient, QueryClientProvider } from 'react-query';
 import { getWrapper } from '../../testUtils';
 describe('HealthSelector', () => {
   it('should display correctly without any props and select first option', () => {

--- a/src/lib/components/healthselectorv2/HealthSelector.component.test.tsx
+++ b/src/lib/components/healthselectorv2/HealthSelector.component.test.tsx
@@ -3,17 +3,18 @@ import {
   optionsDefaultConfiguration,
 } from './HealthSelector.component';
 import React from 'react';
-import { render, screen } from '@testing-library/react';
+import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { getWrapper } from '../../testUtils';
 describe('HealthSelector', () => {
-  it('should display correctly without any props and select first option', () => {
+  it('should display correctly without any props and select first option', async () => {
     const { Wrapper } = getWrapper();
     const { getByText } = render(
       <Wrapper>
         <HealthSelector id="health" onChange={() => {}} />
       </Wrapper>,
     );
+    await waitFor(() => screen.findByRole('img', { hidden: true }));
     const input = screen.getByRole('textbox');
 
     // open the menu

--- a/src/lib/components/inlineinput/InlineInput.test.tsx
+++ b/src/lib/components/inlineinput/InlineInput.test.tsx
@@ -7,6 +7,7 @@ import {
 } from 'react-query';
 import { ToastProvider } from '../toast/ToastProvider';
 import {
+  act,
   render,
   screen,
   waitFor,
@@ -68,17 +69,18 @@ describe('InlineInput', () => {
         </ChangeMutationProvider>,
         { wrapper: Wrapper },
       );
+      await waitFor(() => screen.findByRole('img', { hidden: true }));
 
       //E
       /// First focus the edit button
       await userEvent.tab();
       /// Then press enter to edit the input
-      await userEvent.keyboard('{enter}');
+      await act(() => userEvent.keyboard('{enter}'));
       /// Then type a new value
-      await userEvent.type(document.activeElement, 'new value');
+      await act(() => userEvent.type(document.activeElement, 'new value'));
       /// Then press enter to confirm the new value
-      await userEvent.keyboard('{enter}');
-      await waitForElementToBeRemoved(() => screen.getByRole('textbox'));
+      await act(() => userEvent.keyboard('{enter}'));
+      expect(screen.queryByRole('textbox')).not.toBeInTheDocument();
 
       //V
       expect(mock).toHaveBeenCalledWith('testnew value');
@@ -105,24 +107,23 @@ describe('InlineInput', () => {
         </ChangeMutationProvider>,
         { wrapper: Wrapper },
       );
+      await waitFor(() => screen.findByRole('img', { hidden: true }));
 
       //E
       /// First focus the edit button
       await userEvent.tab();
       /// Then press enter to edit the input
-      await userEvent.keyboard('{enter}');
+      await act(() => userEvent.keyboard('{enter}'));
       /// Then type a new value
-      await userEvent.type(document.activeElement, 'new value');
+      await act(() => userEvent.type(document.activeElement, 'new value'));
       /// Then press enter to confirm the new value
-      await userEvent.keyboard('{enter}');
+      await act(() => userEvent.keyboard('{enter}'));
       /// Expect the confirmation modal to be opened
-      await waitFor(() =>
-        expect(selectors.confirmationModal()).toBeInTheDocument(),
-      );
+      expect(selectors.confirmationModal()).toBeInTheDocument()
       /// Click the confirm button
-      await userEvent.click(screen.getByRole('button', { name: /confirm/i }));
-      /// Wait for modal to be closed
-      await waitForElementToBeRemoved(() => selectors.confirmationModal());
+      await act(() => userEvent.click(screen.getByRole('button', { name: /confirm/i })));
+      /// modal should be closed
+      expect(screen.queryByRole('dialog', { name: /Confirm/i })).not.toBeInTheDocument();
 
       //V
       expect(mock).toHaveBeenCalledWith('testnew value');
@@ -147,16 +148,17 @@ describe('InlineInput', () => {
         </ChangeMutationProvider>,
         { wrapper: Wrapper },
       );
+      await waitFor(() => screen.findByRole('img', { hidden: true }));
 
       //E
       /// First focus the edit button
       await userEvent.tab();
       /// Then press enter to edit the input
-      await userEvent.keyboard('{enter}');
+      await act(() => userEvent.keyboard('{enter}'));
       /// Then type a new value
-      await userEvent.type(document.activeElement, 'new value');
+      await act(() => userEvent.type(document.activeElement, 'new value'));
       /// Then press escape to cancel the new value
-      await userEvent.keyboard('{esc}');
+      await act(() => userEvent.keyboard('{esc}'));
 
       //V
       expect(mock).not.toHaveBeenCalled();
@@ -181,16 +183,17 @@ describe('InlineInput', () => {
         </ChangeMutationProvider>,
         { wrapper: Wrapper },
       );
+      await waitFor(() => screen.findByRole('img', { hidden: true }));
 
       //E
       /// First focus the edit button
       await userEvent.tab();
       /// Then press enter to edit the input
-      await userEvent.keyboard('{enter}');
+      await act(() => userEvent.keyboard('{enter}'));
       /// Then type a new value
-      await userEvent.type(document.activeElement, 'new value');
+      await act(() => userEvent.type(document.activeElement, 'new value'));
       /// Then press enter to confirm the new value
-      await userEvent.keyboard('{enter}');
+      await act(() => userEvent.keyboard('{enter}'));
       /// Expect the confirmation modal to be opened
       await waitFor(() =>
         expect(selectors.confirmationModal()).toBeInTheDocument(),

--- a/src/lib/components/inputlist/InputList.test.tsx
+++ b/src/lib/components/inputlist/InputList.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { render, screen, fireEvent } from '@testing-library/react';
+import { render, screen, fireEvent, waitFor, act } from '@testing-library/react';
 import { InputList, InputListProps } from './InputList.component';
 import { FormSection } from '../form/Form.component';
 
@@ -23,20 +23,22 @@ describe('InputList', () => {
     onChangeMock.mockClear();
   });
 
-  it('should render an empty input list', () => {
+  it('should render an empty input list', async () => {
     renderInputList({
       value: [''],
     });
+    await waitFor(() => screen.queryAllByRole('img', { hidden: true }));
 
     expect(screen.getByLabelText('inputListTest0')).toHaveValue('');
   });
 
-  it('should render an input list with initial values', () => {
+  it('should render an input list with initial values', async () => {
     const initialValues = ['Value 1', 'Value 2', 'Value 3'];
 
     renderInputList({
       value: initialValues,
     });
+    await waitFor(() => screen.queryAllByRole('img', { hidden: true }));
 
     const inputElements = screen.getAllByRole('textbox');
 
@@ -47,44 +49,47 @@ describe('InputList', () => {
     });
   });
 
-  it('should add a new input when clicking the add button', () => {
+  it('should add a new input when clicking the add button', async () => {
     const initialValues = ['Value 1', 'Value 2'];
 
     renderInputList({
       value: initialValues,
     });
+    await waitFor(() => screen.queryAllByRole('img', { hidden: true }));
 
     const addButton = screen.getByLabelText('Add1');
 
-    fireEvent.click(addButton);
+    await act(() => fireEvent.click(addButton));
 
     expect(onChangeMock).toHaveBeenCalledWith({
       target: { value: [...initialValues, ''] },
     });
   });
 
-  it('should delete an input when clicking the delete button', () => {
+  it('should delete an input when clicking the delete button', async () => {
     const initialValues = ['Value 1', 'Value 2', 'Value 3'];
 
     renderInputList({
       value: initialValues,
     });
+    await waitFor(() => screen.queryAllByRole('img', { hidden: true }));
 
     const deleteButton = screen.getByLabelText('Remove1');
 
-    fireEvent.click(deleteButton);
+    await act(() => fireEvent.click(deleteButton));
 
     expect(onChangeMock).toHaveBeenCalledWith({
       target: { value: ['Value 1', 'Value 3'] },
     });
   });
 
-  it('should update the value of an input', () => {
+  it('should update the value of an input', async () => {
     const initialValues = ['Value 1', 'Value 2', 'Value 3'];
 
     renderInputList({
       value: initialValues,
     });
+    await waitFor(() => screen.queryAllByRole('img', { hidden: true }));
 
     const inputElements = screen.getAllByRole('textbox');
 

--- a/src/lib/components/inputlist/InputList.test.tsx
+++ b/src/lib/components/inputlist/InputList.test.tsx
@@ -2,23 +2,20 @@ import React from 'react';
 import { render, screen, fireEvent } from '@testing-library/react';
 import { InputList, InputListProps } from './InputList.component';
 import { FormSection } from '../form/Form.component';
-import { QueryClient, QueryClientProvider } from 'react-query';
 
 describe('InputList', () => {
   const onChangeMock = jest.fn();
 
   const renderInputList = (props: InputListProps<string[]>) => {
     render(
-      <QueryClientProvider client={new QueryClient()}>
-        <FormSection>
-          <InputList
-            placeholder="Input list Test"
-            onChange={onChangeMock}
-            value={props.value}
-            name="inputListTest"
-          />
-        </FormSection>
-      </QueryClientProvider>,
+      <FormSection>
+        <InputList
+          placeholder="Input list Test"
+          onChange={onChangeMock}
+          value={props.value}
+          name="inputListTest"
+        />
+      </FormSection>
     );
   };
 

--- a/src/lib/components/searchinput/SearchInput.test.tsx
+++ b/src/lib/components/searchinput/SearchInput.test.tsx
@@ -14,8 +14,9 @@ describe('SearchInput', () => {
     searchInput: () => screen.getByRole('searchbox'),
     clearButton: () => screen.queryByRole('button'),
   };
-  it('should render the SearchInput component', () => {
+  it('should render the SearchInput component', async () => {
     render(<SearchInputRender value="" onChange={() => {}} />);
+    await waitFor(() => screen.queryAllByRole('img', { hidden: true }));
 
     const searchInput = selectors.searchInput();
     expect(searchInput).toBeInTheDocument();

--- a/src/lib/components/searchinput/SearchInput.test.tsx
+++ b/src/lib/components/searchinput/SearchInput.test.tsx
@@ -1,16 +1,11 @@
 import React from 'react';
 import { render, screen, waitFor } from '@testing-library/react';
 import { SearchInput, Props } from './SearchInput.component';
-import { QueryClient, QueryClientProvider } from 'react-query';
 import userEvent from '@testing-library/user-event';
-
-const queryClient = new QueryClient();
 
 const SearchInputRender = (props: Props) => {
   return (
-    <QueryClientProvider client={queryClient}>
-      <SearchInput {...props} />
-    </QueryClientProvider>
+    <SearchInput {...props} />
   );
 };
 

--- a/src/lib/components/selectv2/selectv2.test.tsx
+++ b/src/lib/components/selectv2/selectv2.test.tsx
@@ -1,15 +1,10 @@
 import { screen, render as testingRender } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import React, { useState, useRef } from 'react';
-import { QueryClient, QueryClientProvider } from 'react-query';
 import { Option, Select, SelectRef } from '../selectv2/Selectv2.component';
 
 const render = (args) => {
-  return testingRender(
-    <QueryClientProvider client={new QueryClient()}>
-      {args}
-    </QueryClientProvider>,
-  );
+  return testingRender(args);
 };
 
 const generateOptionsData = (n: number) =>

--- a/src/lib/components/selectv2/selectv2.test.tsx
+++ b/src/lib/components/selectv2/selectv2.test.tsx
@@ -1,4 +1,4 @@
-import { screen, render as testingRender } from '@testing-library/react';
+import { act, screen, render as testingRender, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import React, { useState, useRef } from 'react';
 import { Option, Select, SelectRef } from '../selectv2/Selectv2.component';
@@ -69,27 +69,29 @@ describe('SelectV2', () => {
     expect(() => render(<Option value="Option 1" />)).toThrowError();
   });
 
-  it('should open/close on click', () => {
+  it('should open/close on click', async () => {
     render(<SelectWrapper />);
+    await waitFor(() => screen.queryAllByRole('img', { hidden: true }));
     const select = selectors.select();
     expect(select).toBeInTheDocument();
     let options = selectors.options();
     expect(options).toHaveLength(0);
 
     // should open on click
-    userEvent.click(select);
+    await act(() => userEvent.click(select));
     simpleOptions.forEach((opt) => {
       const option = selectors.option(opt.props.label);
       expect(option).toBeInTheDocument();
     });
 
-    userEvent.click(select);
+    await act(() => userEvent.click(select));
     options = selectors.options();
     expect(options).toHaveLength(0);
   });
 
-  it('should open/close with keyboard', () => {
+  it('should open/close with keyboard', async () => {
     render(<SelectWrapper />);
+    await waitFor(() => screen.queryAllByRole('img', { hidden: true }));
     const select = selectors.select();
     expect(select).toBeInTheDocument();
     const options = selectors.options();
@@ -97,7 +99,7 @@ describe('SelectV2', () => {
 
     // should open on Enter
     userEvent.tab();
-    userEvent.keyboard('{Enter}');
+    await act(() => userEvent.keyboard('{Enter}'));
     simpleOptions.forEach((opt) => {
       const option = selectors.option(opt.props.label);
       expect(option).toBeInTheDocument();
@@ -116,13 +118,14 @@ describe('SelectV2', () => {
     });
   });
 
-  it('should display custom placeholder', () => {
+  it('should display custom placeholder', async () => {
     const placeholder = 'My placeholder...';
     render(<SelectWrapper placeholder={placeholder} />);
+    await waitFor(() => screen.queryAllByRole('img', { hidden: true }));
     expect(screen.getByText(placeholder)).toBeInTheDocument();
   });
 
-  it('should be disabled', () => {
+  it('should be disabled', async () => {
     render(
       <SelectWrapper value="1" disabled={true}>
         {simpleOptions}
@@ -134,27 +137,29 @@ describe('SelectV2', () => {
     // use input instead of select because select will still trigger the open/close action
     // despite select container not being clickable and input being disabled
     const input = selectors.input();
-    userEvent.click(input);
+    await act(() => userEvent.click(input));
     const options = selectors.options();
     expect(options).toHaveLength(0);
   });
 
-  it('should display no option', () => {
+  it('should display no option', async () => {
     render(
       <SelectWrapper>
         <></>
       </SelectWrapper>,
     );
+    await waitFor(() => screen.queryAllByRole('img', { hidden: true }));
     const select = selectors.select();
-    userEvent.click(select);
+    await act(() => userEvent.click(select));
     const noOptions = selectors.noOptions();
     expect(noOptions).toBeInTheDocument();
   });
 
-  it('should filter and highlight on search', () => {
+  it('should filter and highlight on search', async () => {
     render(<SelectWrapper>{optionsWithScrollSearchBar} </SelectWrapper>);
+    await waitFor(() => screen.queryAllByRole('img', { hidden: true }));
     const select = selectors.select(true);
-    userEvent.click(select);
+    await act(() => userEvent.click(select));
     const input = selectors.input();
 
     userEvent.type(input, '2');
@@ -164,25 +169,26 @@ describe('SelectV2', () => {
     expect(searchedText).toHaveTextContent('2');
   });
 
-  it('should unfocus the search input when the select is closed', () => {
+  it('should unfocus the search input when the select is closed', async () => {
     render(<SelectWrapper>{optionsWithScrollSearchBar} </SelectWrapper>);
+    await waitFor(() => screen.queryAllByRole('img', { hidden: true }));
     const select = selectors.select(true);
-    userEvent.click(select);
+    await act(() => userEvent.click(select));
     let input = selectors.input();
     expect(input).toHaveFocus();
     const option = selectors.option(/Item 1/);
-    userEvent.click(option);
+    await act(() => userEvent.click(option));
     input = selectors.input();
     expect(input).not.toHaveFocus();
   });
 
-  it('should be possible to use searchbar when option is selected', () => {
+  it('should be possible to use searchbar when option is selected', async () => {
     render(
       <SelectWrapper value="1">{optionsWithScrollSearchBar}</SelectWrapper>,
     );
     expect(screen.getByText(/Item 1/)).toBeVisible();
     const select = selectors.select(true);
-    userEvent.click(select);
+    await act(() => userEvent.click(select));
     const input = selectors.input();
     userEvent.type(input, '2');
     expect(screen.queryByText(/Item 1/)).not.toBeInTheDocument();
@@ -190,47 +196,48 @@ describe('SelectV2', () => {
     expect(options).toHaveLength(1);
   });
 
-  it('should select/unselect option with keyboard', () => {
+  it('should select/unselect option with keyboard', async () => {
     render(<SelectWrapper />);
+    await waitFor(() => screen.queryAllByRole('img', { hidden: true }));
     const select = selectors.select();
     userEvent.tab();
-    userEvent.keyboard('{ArrowDown}');
+    act(() => userEvent.keyboard('{ArrowDown}'));
 
     // should select first option
-    userEvent.keyboard('{Enter}');
+    await act(() => userEvent.keyboard('{Enter}'));
     expect(select).toHaveTextContent('Item 0');
 
     // should select second option
     userEvent.tab();
-    userEvent.keyboard('{ArrowDown}');
-    userEvent.keyboard('{ArrowDown}');
+    await act(() => userEvent.keyboard('{ArrowDown}'));
+    await act(() => userEvent.keyboard('{ArrowDown}'));
 
-    userEvent.keyboard('{Enter}');
+    await act(() => userEvent.keyboard('{Enter}'));
     expect(select).toHaveTextContent('Item 1');
   });
 
-  it('should scroll to selected value when opening select', () => {
+  it('should scroll to selected value when opening select', async () => {
     render(
       <SelectWrapper value={optionsWithScrollSearchBar[9].props.value}>
         {optionsWithScrollSearchBar}
       </SelectWrapper>,
     );
     const select = selectors.select(true);
-    userEvent.click(select);
+    await act(() => userEvent.click(select));
     const option = selectors.option(/Item 9/);
     expect(screen.queryByRole('option', { name: /Item 1/i })).toBeNull();
     expect(option).toBeVisible();
   });
 
-  it('should be able to reset the value', () => {
+  it('should be able to reset the value', async () => {
     render(<SelectReset>{simpleOptions}</SelectReset>);
     const button = screen.getByText(/reset/);
-    userEvent.click(button);
+    await act(() => userEvent.click(button));
     const select = selectors.select();
     expect(select).toHaveTextContent('Select...');
   });
 
-  it('should not be possible to select an option if it is disabled', () => {
+  it('should not be possible to select an option if it is disabled', async () => {
     render(
       <SelectWrapper>
         <Option value="1" disabled>
@@ -240,15 +247,15 @@ describe('SelectV2', () => {
       </SelectWrapper>,
     );
     const select = selectors.select();
-    userEvent.click(select);
+    await act(() => userEvent.click(select));
     const option = selectors.option(/Item 1/);
 
-    userEvent.click(option);
+    await act(() => userEvent.click(option));
     const option2 = selectors.option(/Item 2/);
     expect(option2).toBeVisible();
   });
 
-  it('should display a tooltip if the option is disabled with a reason', () => {
+  it('should display a tooltip if the option is disabled with a reason', async () => {
     render(
       <SelectWrapper>
         <Option value="1" disabled disabledReason="This option is disabled">
@@ -257,10 +264,10 @@ describe('SelectV2', () => {
       </SelectWrapper>,
     );
     const select = selectors.select();
-    userEvent.click(select);
+    await act(() => userEvent.click(select));
     const option = selectors.option(/Item 1/);
     expect(option).toHaveAttribute('aria-disabled', 'true');
-    userEvent.hover(option);
+    await act(() => userEvent.hover(option));
     const tooltip = screen.getByText(/This option is disabled/);
     expect(tooltip).toBeInTheDocument();
   });
@@ -304,9 +311,9 @@ describe('SelectV2', () => {
     // It's not our case here, so it makes thing difficult to select the right select
     // I workaround this by using setting the aria-label to the select container (cf: test below)
     const singleSelect = screen.getByRole('listbox');
-    await userEvent.click(singleSelect);
+    await act(() => userEvent.click(singleSelect));
 
-    await userEvent.click(screen.getByRole('option', { name: /account 1/i }));
+    await act(() => userEvent.click(screen.getByRole('option', { name: /account 1/i })));
   });
 
   it('should be testable if we have several select', async () => {
@@ -367,13 +374,13 @@ describe('SelectV2', () => {
 
     render(<MyWrapperWith2Select />);
 
-    await userEvent.click(screen.getByLabelText(/select account/i));
+    await act(() => userEvent.click(screen.getByLabelText(/select account/i)));
 
-    await userEvent.click(screen.getByRole('option', { name: /account 1/i }));
+    await act(() => userEvent.click(screen.getByRole('option', { name: /account 1/i })));
 
-    await userEvent.click(screen.getByLabelText(/select user/i));
+    await act(() => userEvent.click(screen.getByLabelText(/select user/i)));
 
-    await userEvent.click(screen.getByRole('option', { name: /user 1/i }));
+    await act(() => userEvent.click(screen.getByRole('option', { name: /user 1/i })));
   });
 
   it('should be testable even if we have several select with the same value, the placeholder should be different', async () => {
@@ -434,8 +441,8 @@ describe('SelectV2', () => {
 
     render(<MyWrapperWith2Select />);
 
-    await userEvent.click(screen.getByLabelText(/select account/i));
-    await userEvent.click(screen.getByLabelText(/Select Second Account/i));
+    await act(() => userEvent.click(screen.getByLabelText(/select account/i)));
+    await act(() => userEvent.click(screen.getByLabelText(/Select Second Account/i)));
 
     /**
      * This is possible because only 1 select can be open at a time
@@ -445,7 +452,7 @@ describe('SelectV2', () => {
      * const selectContainer = select?.parentElement?.parentElement;
      * const option = within(selectContainer).getByRole('option', { name: /account 1/i });
      */
-    await userEvent.click(screen.getByRole('option', { name: /account 1/i }));
+    await act(() => userEvent.click(screen.getByRole('option', { name: /account 1/i })));
   });
 
   describe('Ref API', () => {
@@ -473,7 +480,7 @@ describe('SelectV2', () => {
       render(<RefTestComponent />);
       expect(selectors.input()).not.toHaveFocus();
 
-      userEvent.click(screen.getByRole('button', { name: /Focus/i }));
+      await act(() => userEvent.click(screen.getByRole('button', { name: /Focus/i })));
       expect(selectors.input()).toHaveFocus();
     });
 
@@ -506,14 +513,14 @@ describe('SelectV2', () => {
       render(<RefTestComponent />);
       expect(selectors.options()).toHaveLength(0);
 
-      userEvent.click(screen.getByRole('button', { name: /Open Menu/i }));
+      await act(() => userEvent.click(screen.getByRole('button', { name: /Open Menu/i })));
       expect(selectors.options().length).toBeGreaterThan(0);
       simpleOptions.forEach((opt) => {
         const option = selectors.option(opt.props.label);
         expect(option).toBeInTheDocument();
       });
 
-      userEvent.click(screen.getByRole('button', { name: /Close Menu/i }));
+      await act(() => userEvent.click(screen.getByRole('button', { name: /Close Menu/i })));
       expect(selectors.options()).toHaveLength(0);
     });
 
@@ -560,13 +567,16 @@ describe('SelectV2', () => {
 
       render(<RefTestComponent />);
 
-      const select = selectors.select();
+      let select;
+      await act(() => {
+        select = selectors.select();
+      });
       expect(select).toHaveTextContent('Select with ref');
 
-      userEvent.click(screen.getByRole('button', { name: /Set Value/i }));
+      await act(() => userEvent.click(screen.getByRole('button', { name: /Set Value/i })));
       expect(select).toHaveTextContent('Item 0');
 
-      userEvent.click(screen.getByRole('button', { name: /Clear/i }));
+      await act(() => userEvent.click(screen.getByRole('button', { name: /Clear/i })));
       expect(select).toHaveTextContent('Select with ref');
     });
 
@@ -594,10 +604,10 @@ describe('SelectV2', () => {
 
       render(<RefTestComponent />);
 
-      userEvent.click(screen.getByRole('button', { name: /Focus/i }));
+      await act(() => userEvent.click(screen.getByRole('button', { name: /Focus/i })));
       expect(selectors.input()).toHaveFocus();
 
-      userEvent.click(screen.getByRole('button', { name: /Blur/i }));
+      await act(() => userEvent.click(screen.getByRole('button', { name: /Blur/i })));
       expect(selectors.input()).not.toHaveFocus();
     });
   });

--- a/src/lib/components/tablev2/TableSync.test.tsx
+++ b/src/lib/components/tablev2/TableSync.test.tsx
@@ -1,15 +1,12 @@
 import { fireEvent, render, screen } from '@testing-library/react';
 import React from 'react';
 import { TableSync } from './TableSync';
-import { QueryClient, QueryClientProvider } from 'react-query';
 
 describe('TableSync', () => {
   it('should render correctly', () => {
     const onSync = jest.fn();
     render(
-      <QueryClientProvider client={new QueryClient()}>
-        <TableSync onSync={onSync} />
-      </QueryClientProvider>,
+      <TableSync onSync={onSync} />
     );
 
     const button = screen.getByRole('button');
@@ -19,9 +16,7 @@ describe('TableSync', () => {
   it('should call onSync when clicked', () => {
     const onSync = jest.fn();
     render(
-      <QueryClientProvider client={new QueryClient()}>
-        <TableSync onSync={onSync} />
-      </QueryClientProvider>,
+      <TableSync onSync={onSync} />
     );
 
     const button = screen.getByRole('button');

--- a/src/lib/components/tablev2/TableSync.test.tsx
+++ b/src/lib/components/tablev2/TableSync.test.tsx
@@ -1,26 +1,28 @@
-import { fireEvent, render, screen } from '@testing-library/react';
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
 import React from 'react';
 import { TableSync } from './TableSync';
 
 describe('TableSync', () => {
-  it('should render correctly', () => {
+  it('should render correctly', async () => {
     const onSync = jest.fn();
     render(
       <TableSync onSync={onSync} />
     );
+    await waitFor(() => screen.queryAllByRole('img', { hidden: true }));
 
     const button = screen.getByRole('button');
     expect(button).toBeInTheDocument();
   });
 
-  it('should call onSync when clicked', () => {
+  it('should call onSync when clicked', async () => {
     const onSync = jest.fn();
     render(
       <TableSync onSync={onSync} />
     );
+    await waitFor(() => screen.queryAllByRole('img', { hidden: true }));
 
     const button = screen.getByRole('button');
-    fireEvent.click(button);
+    await act(() => fireEvent.click(button));
     expect(onSync).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/lib/components/tablev2/Tablev2.test.tsx
+++ b/src/lib/components/tablev2/Tablev2.test.tsx
@@ -1,7 +1,6 @@
 import { Table } from './Tablev2.component';
 import React from 'react';
 import { render } from '@testing-library/react';
-import { QueryClient, QueryClientProvider } from 'react-query';
 
 jest.mock('./TableUtils', () => ({
   ...jest.requireActual('./TableUtils'),
@@ -66,16 +65,14 @@ const columns = [
 describe('TableV2', () => {
   test('it should display all the data', async () => {
     const { getAllByRole } = render(
-      <QueryClientProvider client={new QueryClient()}>
-        <div>
-          <Table columns={columns} data={data} defaultSortingKey={'health'}>
-            <Table.SingleSelectableContent
-              rowHeight="h40"
-              separationLineVariant="backgroundLevel3"
-            />
-          </Table>
-        </div>
-      </QueryClientProvider>,
+      <div>
+        <Table columns={columns} data={data} defaultSortingKey={'health'}>
+          <Table.SingleSelectableContent
+            rowHeight="h40"
+            separationLineVariant="backgroundLevel3"
+          />
+        </Table>
+      </div>
     );
     // we check that the table is displaying all the data
     const rows = getAllByRole('row');
@@ -85,16 +82,14 @@ describe('TableV2', () => {
   });
   test('it should sort by defaultSortingKey', async () => {
     const { getAllByRole } = render(
-      <QueryClientProvider client={new QueryClient()}>
-        <div>
-          <Table columns={columns} data={data} defaultSortingKey={'firstName'}>
-            <Table.SingleSelectableContent
-              rowHeight="h40"
-              separationLineVariant="backgroundLevel3"
-            />
-          </Table>
-        </div>
-      </QueryClientProvider>,
+      <div>
+        <Table columns={columns} data={data} defaultSortingKey={'firstName'}>
+          <Table.SingleSelectableContent
+            rowHeight="h40"
+            separationLineVariant="backgroundLevel3"
+          />
+        </Table>
+      </div>
     );
     // we check that the table is displaying all the data
     const rows = getAllByRole('row');
@@ -104,21 +99,19 @@ describe('TableV2', () => {
   });
   test('it should filterGlobally', async () => {
     const { getAllByRole } = render(
-      <QueryClientProvider client={new QueryClient()}>
-        <div>
-          <Table
-            columns={columns}
-            data={data}
-            defaultSortingKey={'firstName'}
-            globalFilter="an"
-          >
-            <Table.SingleSelectableContent
-              rowHeight="h40"
-              separationLineVariant="backgroundLevel3"
-            />
-          </Table>
-        </div>
-      </QueryClientProvider>,
+      <div>
+        <Table
+          columns={columns}
+          data={data}
+          defaultSortingKey={'firstName'}
+          globalFilter="an"
+        >
+          <Table.SingleSelectableContent
+            rowHeight="h40"
+            separationLineVariant="backgroundLevel3"
+          />
+        </Table>
+      </div>
     );
     // we check that the table is displaying all the data
     const rows = getAllByRole('row');

--- a/src/lib/components/tablev2/Tablev2.test.tsx
+++ b/src/lib/components/tablev2/Tablev2.test.tsx
@@ -1,6 +1,6 @@
 import { Table } from './Tablev2.component';
 import React from 'react';
-import { render } from '@testing-library/react';
+import { render, screen, waitFor } from '@testing-library/react';
 
 jest.mock('./TableUtils', () => ({
   ...jest.requireActual('./TableUtils'),
@@ -74,6 +74,8 @@ describe('TableV2', () => {
         </Table>
       </div>
     );
+    await waitFor(() => screen.queryAllByRole('img', { hidden: true }));
+
     // we check that the table is displaying all the data
     const rows = getAllByRole('row');
     expect(rows[4]).toHaveTextContent(/Ninette/i);
@@ -91,6 +93,8 @@ describe('TableV2', () => {
         </Table>
       </div>
     );
+    await waitFor(() => screen.queryAllByRole('img', { hidden: true }));
+
     // we check that the table is displaying all the data
     const rows = getAllByRole('row');
     expect(rows[1]).toHaveTextContent(/ninette/i);
@@ -113,6 +117,8 @@ describe('TableV2', () => {
         </Table>
       </div>
     );
+    await waitFor(() => screen.queryAllByRole('img', { hidden: true }));
+
     // we check that the table is displaying all the data
     const rows = getAllByRole('row');
     expect(rows[1]).toHaveTextContent(/an/i); //first name yoh-an-n


### PR DESCRIPTION
**Component**:

-

**Description**:

This does the following changes to fix react props warning:
"@fortawesome/react-fontawesome": "^0.1.14" -> "@fortawesome/react-fontawesome": "^0.2.3"
And many changes related to Act and rerenders during test to reduce the amount of warnings.
Went from ~2160 to ~1360 lines of warnings.

**Design**:

- waitFor waits for the first rerender in components using icon (icon loading rerender)
- act wraps emulated user actions

**Breaking Changes**:
