### PR TITLE
Multi select issue in ChartLegend

### DIFF
--- a/src/lib/components/chartlegend/ChartLegend.test.tsx
+++ b/src/lib/components/chartlegend/ChartLegend.test.tsx
@@ -214,5 +214,22 @@ describe('ChartLegend', () => {
       expect(screen.getByLabelText('Memory not selected')).toBeInTheDocument();
       expect(screen.getByLabelText('Disk selected')).toBeInTheDocument();
     });
+    it('should select one item when clicking on selected item and other items are selected', () => {
+      render(
+        <ChartLegendWrapper colorSet={colorSet}>
+          <ChartLegend shape="line" />
+        </ChartLegendWrapper>,
+      );
+      userEvent.click(screen.getByText('CPU'));
+      userEvent.click(screen.getByText('Memory'), { metaKey: true });
+
+      expect(screen.getByLabelText('CPU selected')).toBeInTheDocument();
+      expect(screen.getByLabelText('Memory selected')).toBeInTheDocument();
+      expect(screen.getByLabelText('Disk not selected')).toBeInTheDocument();
+      userEvent.click(screen.getByText('CPU'));
+      expect(screen.getByLabelText('CPU selected')).toBeInTheDocument();
+      expect(screen.getByLabelText('Memory not selected')).toBeInTheDocument();
+      expect(screen.getByLabelText('Disk not selected')).toBeInTheDocument();
+    });
   });
 });

--- a/src/lib/components/chartlegend/ChartLegend.tsx
+++ b/src/lib/components/chartlegend/ChartLegend.tsx
@@ -73,8 +73,8 @@ export const ChartLegend = ({
     addSelectedResource,
     removeSelectedResource,
     selectAllResources,
-    getSelectedCount,
     selectOnlyResource,
+    isOnlyOneSelected,
   } = useChartLegend();
 
   const resources = listResources();
@@ -88,7 +88,7 @@ export const ChartLegend = ({
 
       if (isModifierClick) {
         if (itemIsSelected) {
-          if (getSelectedCount() === 1) {
+          if (isOnlyOneSelected()) {
             selectAllResources();
           } else {
             removeSelectedResource(resource);
@@ -96,7 +96,7 @@ export const ChartLegend = ({
         } else {
           addSelectedResource(resource);
         }
-      } else if (itemIsSelected && getSelectedCount() === 1) {
+      } else if (itemIsSelected && isOnlyOneSelected()) {
         selectAllResources();
       } else {
         selectOnlyResource(resource);
@@ -109,7 +109,7 @@ export const ChartLegend = ({
       removeSelectedResource,
       selectAllResources,
       selectOnlyResource,
-      getSelectedCount,
+      isOnlyOneSelected,
     ],
   );
 

--- a/src/lib/components/chartlegend/ChartLegend.tsx
+++ b/src/lib/components/chartlegend/ChartLegend.tsx
@@ -73,7 +73,6 @@ export const ChartLegend = ({
     addSelectedResource,
     removeSelectedResource,
     selectAllResources,
-    getAllResourcesCount,
     getSelectedCount,
     selectOnlyResource,
   } = useChartLegend();
@@ -97,14 +96,10 @@ export const ChartLegend = ({
         } else {
           addSelectedResource(resource);
         }
+      } else if (itemIsSelected && getSelectedCount() === 1) {
+        selectAllResources();
       } else {
-        if (getSelectedCount() === getAllResourcesCount()) {
-          selectOnlyResource(resource);
-        } else if (itemIsSelected) {
-          selectAllResources();
-        } else {
-          selectOnlyResource(resource);
-        }
+        selectOnlyResource(resource);
       }
     },
     [
@@ -114,7 +109,6 @@ export const ChartLegend = ({
       removeSelectedResource,
       selectAllResources,
       selectOnlyResource,
-      getAllResourcesCount,
       getSelectedCount,
     ],
   );

--- a/src/lib/components/chartlegend/ChartLegendWrapper.tsx
+++ b/src/lib/components/chartlegend/ChartLegendWrapper.tsx
@@ -17,7 +17,7 @@ export type ChartLegendState = {
   isSelected: (resource: string) => boolean;
   getColor: (resource: string) => string | undefined;
   listResources: () => string[];
-  getSelectedCount: () => number;
+  isOnlyOneSelected: () => boolean;
 };
 
 const ChartLegendContext = createContext<ChartLegendState | null>(null);
@@ -53,10 +53,9 @@ export const ChartLegendWrapper = ({
     setSelectedResources([resource]);
   }, []);
 
-  const getSelectedCount = useCallback(() => {
-    return selectedResources.length;
+  const isOnlyOneSelected = useCallback(() => {
+    return selectedResources.length === 1;
   }, [selectedResources]);
-
   const isSelected = useCallback(
     (resource: string) => {
       return selectedResources.includes(resource);
@@ -92,7 +91,7 @@ export const ChartLegendWrapper = ({
       isSelected,
       getColor,
       listResources,
-      getSelectedCount,
+      isOnlyOneSelected,
     }),
     [
       selectedResources,
@@ -103,7 +102,7 @@ export const ChartLegendWrapper = ({
       isSelected,
       getColor,
       listResources,
-      getSelectedCount,
+      isOnlyOneSelected,
     ],
   );
 

--- a/src/lib/components/chartlegend/ChartLegendWrapper.tsx
+++ b/src/lib/components/chartlegend/ChartLegendWrapper.tsx
@@ -17,7 +17,6 @@ export type ChartLegendState = {
   isSelected: (resource: string) => boolean;
   getColor: (resource: string) => string | undefined;
   listResources: () => string[];
-  getAllResourcesCount: () => number;
   getSelectedCount: () => number;
 };
 
@@ -53,10 +52,6 @@ export const ChartLegendWrapper = ({
   const selectOnlyResource = useCallback((resource: string) => {
     setSelectedResources([resource]);
   }, []);
-
-  const getAllResourcesCount = useCallback(() => {
-    return allResources.length;
-  }, [allResources]);
 
   const getSelectedCount = useCallback(() => {
     return selectedResources.length;
@@ -97,7 +92,6 @@ export const ChartLegendWrapper = ({
       isSelected,
       getColor,
       listResources,
-      getAllResourcesCount,
       getSelectedCount,
     }),
     [
@@ -109,7 +103,6 @@ export const ChartLegendWrapper = ({
       isSelected,
       getColor,
       listResources,
-      getAllResourcesCount,
       getSelectedCount,
     ],
   );


### PR DESCRIPTION
Previous behavior : when multiple legend items but not all are selected, clicking on a selected item select all

New behavior: when multiple legend items but not all are selected, clicking on a selected item select only this item


