### PR TITLE
exported CoreUITheme and updated readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,38 +11,21 @@ Core-UI is a component library containing all components, layouts, icons and the
 - Add `@scality/core-ui` in the `package.json`'s dependencies of your project.
 
 ```json
-    "@scality/core-ui": "0.115.0",
+    "@scality/core-ui": "^0.165.0",
 ```
 
 - `@scality/core-ui` requires the peerDependencies below. Make sure that you have them in the `package.json`'s dependencies.
 
 ```json
-    "@fortawesome/fontawesome-free": "^5.10.2",
-    "@fortawesome/fontawesome-svg-core": "^1.2.35",
-    "@fortawesome/free-regular-svg-icons": "^5.15.3",
-    "@fortawesome/free-solid-svg-icons": "^5.15.3",
-    "@fortawesome/react-fontawesome": "^0.1.14",
-    "@js-temporal/polyfill": "^0.4.4",
-    "polished": "3.4.1",
-    "pretty-bytes": "^5.6.0",
-    "react": "^17.0.2",
-    "react-debounce-input": "3.2.2",
-    "react-dom": "^17.0.2",
-    "react-dropzone": "^14.2.3",
+    "react": "^18.0.0",
+    "react-dom": "^18.0.0",
+    // to provides a Provider to the components using react-query
     "react-query": "^3.34.0",
-    "react-router": "^5.2.0",
-    "react-router-dom": "^5.2.0",
-    "react-select": "4.3.1",
-    "react-table": "^7.7.0",
-    "react-virtualized": "9.22.3",
-    "react-virtualized-auto-sizer": "^1.0.5",
-    "react-window": "^1.8.6",
-    "styled-components": "^4.1.2",
-    "styled-system": "^5.1.5",
-    "vega": "^5.17.3",
-    "vega-embed": "^6.0.0",
-    "vega-lite": "^5.0.0",
-    "vega-tooltip": "^0.27.0"
+    // for the components using react router
+    "react-router": "^7.0.1",
+    "react-router-dom": "^7.0.1",
+    // for legacy chart components
+    "canvas": "^2.10.1",
 ```
 
 - Install the dependencies :
@@ -90,51 +73,23 @@ import { coreUIAvailableThemes as themes } from '@scality/core-ui/dist/style/the
 
 There is 2 default theme available in Core-UI : you can find them [here](https://github.com/scality/core-ui/pull/684#:~:text=https%3A//github.com/scality/core%2Dui/blob/development/1.0/src/lib/style/theme.ts)
 
-<br/>
-
-You can also modify or create a new theme. In this case make sure to respect this type :
+You can also modify or create a new theme but make sure to extend this type:
 
 ```tsx
-export type CoreUITheme = {
-  statusHealthy: string;
-  statusHealthyRGB: string;
-  statusWarning: string;
-  statusWarningRGB: string;
-  statusCritical: string;
-  statusCriticalRGB: string;
-  selectedActive: string;
-  highlight: string;
-  border: string;
-  buttonPrimary: string;
-  buttonSecondary: string;
-  buttonDelete: string;
-  infoPrimary: string;
-  infoSecondary: string;
-  backgroundLevel1: string;
-  backgroundLevel2: string;
-  backgroundLevel3: string;
-  backgroundLevel4: string;
-  textPrimary: string;
-  textSecondary: string;
-  textTertiary: string;
-  textReverse: string;
-  textLink: string;
-};
+import { CoreUITheme } from "@scality/core-ui/dist/next";
 ```
-
-<br />
 
 ## Development
 
 This project is built with [React](https://react.dev/) and [TypeScript](https://www.typescriptlang.org/), and styled with [styled-components](https://styled-components.com/).
 
-To start contributing to core-ui, clone the repository :
+To start contributing to core-ui, clone the repository:
 
 ```sh
 git clone git@github.com:scality/core-ui.git
 ```
 
-then install the dependancies :
+then install the dependancies:
 
 ```sh
 npm install
@@ -142,7 +97,7 @@ npm install
 
 ### Create a new branch
 
-Give your branch an explicit name with the reference to the Jira ticket or issue if it exists, and prefix it with :
+Give your branch an explicit name with the reference to the Jira ticket or issue if it exists, and prefix it with:
 
 - feature/ for new component or major component update : `feature/TICKET-123-some-feature`
 - improvement/ for code improvement, component update : `improvement/TICKET-456-some-improvement`
@@ -183,7 +138,7 @@ When creating a new version of an existing component, expose it in `src/lib/next
 
 You can use storybook to help with the development.
 Storybook helps to test and vizualize component in isolation.
-If it doesn't exist, write a [story](https://storybook.js.org/docs/get-started/whats-a-story) for the component :
+If it doesn't exist, write a [story](https://storybook.js.org/docs/get-started/whats-a-story) for the component:
 
 ```jsx
 // in stories/example/example.stories.tsx
@@ -200,10 +155,9 @@ type Story = StoryObj<typeof Example>;
 export const Default: Story = {
   render: () => <Example />,
 };
-
 ```
 
-then launch storybook :
+Then launch storybook:
 
 ```sh
 npm run storybook
@@ -213,7 +167,7 @@ Storybook will be launched on `http://localhost:3000`.
 
 ### Lint
 
-To make sure your code is correctly lint, run :
+To make sure your code is correctly lint, run:
 
 ```sh
 npm run lint
@@ -225,13 +179,13 @@ It will run ESLint by using `eslint-config-react-app` which is a shareable ESLin
 
 Build tests with [jest](https://jestjs.io/)
 
-Make sure to write tests that cover all cases, then you can run all tests with :
+Make sure to write tests that cover all cases, then you can run all tests with:
 
 ```sh
 npm run test
 ```
 
-or run a specific test with :
+Or run a specific test with:
 
 ```sh
 npm run test Example.test.tsx
@@ -241,7 +195,6 @@ npm run test Example.test.tsx
 
 Core-UI uses [storybook](https://storybook.js.org/) for its documentation. \
 Illustrate use cases and state variations with [stories](https://storybook.js.org/docs/writing-stories).
-All stories should be type.
 
 If possible create or update the component guideline.
 This guideline is an MDX file containing details about the component usage and is illustrated with the stories write in stories.tsx file.
@@ -259,29 +212,23 @@ import * as ExampleStories from './Example.stories';
 An Example component is used for example.
 
 <Canvas of={ExampleStories.Default} />
-
 ```
 
-### Pull request
+### Contributing
 
-Push your code on the repository
-
-```sh
-git push origin <branch-name>
-```
-
-then create a `Pull Request`.
-Pull request needs to be approved by at least one reviewer.
-After your PR is approved you can comment `/approve`
+- Push your code on a branch following the [branch naming convention](#create-a-new-branch)
+- Create a pull request.
+- Obtain the approval of at least one reviewer.
+- Then comment with `/approve` to merge the PR.
 
 ### Release
 
 After merging one or more PR in Core-UI, it is possible to plublish a new release.
-In the Core-UI repo, follow these steps :
+In the Core-UI repo, follow these steps:
 
 1. Go on `Releases` then `Draft a new release`
-2. In the select menu `Choose a tag` : Create a new tag (the current tag increment by 1).
-3. You can now `Generate release notes` : it will add all the PR infos since the last release. \
+2. In the select menu `Choose a tag`: Create a new tag (the current tag increment by 1).
+3. You can now `Generate release notes`: it will add all the PR infos since the last release. \
    You can add details if necessary.
 4. `Publish release`
 5. It will create a PR that need to be approved.

--- a/src/lib/next.ts
+++ b/src/lib/next.ts
@@ -25,3 +25,4 @@ export { ChartTooltip } from './components/barchartv2/ChartTooltip';
 export { ChartLegendWrapper } from './components/chartlegend/ChartLegendWrapper';
 export { ChartLegend } from './components/chartlegend/ChartLegend';
 export { LineTimeSerieChart } from './components/linetimeseriechart/linetimeseriechart.component';
+export { CoreUITheme } from './style/theme';


### PR DESCRIPTION
**Component**:

- None

**Description**:

I wished to bring some updates to the readme to better reflect the dependencies you actually need to use core-ui and to clean a few formulations and syntax stuff.

Doing so I noticed the readme encourages to use `CoreUITheme` type but it is actually never exported by the lib. So I decided to export it and discussed with @ChengYanJin @JeanMarcMilletScality to n know if I should put it in index or next.

We concluded that we probably wants to put everything that is not deprecated in next. But reading the readme it says otherwise, I also noticed @JBWatenbergScality that your latest components are exported in index.

So should I export `CoreUITheme` in index or should I correct the readme ?

**Design**:

**Breaking Changes**:

- None