### PR TITLE
Fix ghpages storybook auth

### DIFF
--- a/.github/workflows/github-pages.yml
+++ b/.github/workflows/github-pages.yml
@@ -11,5 +11,9 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: 20
-      - run: npm ci
-      - run: npm run storybook:deploy
+      - run: |
+          git remote set-url origin https://${{ github.actor }}:${{ secrets.GITHUB_TOKEN }}@github.com/$GITHUB_REPOSITORY
+          npm ci
+          npm run storybook:deploy
+        env:
+          STORYBOOK_DISABLE_TELEMETRY: 1


### PR DESCRIPTION
Previous attempt to fix storybook deployment failed because it tried to provide user/password auth over https but git was not properly configured. I configured git here as it was configured before through storybook-deployment.
Disabled storybook telemetry.