### PR TITLE
Improvement/aix 355 sparkline

### DIFF
--- a/src/lib/components/sparkline/sparkline.component.tsx
+++ b/src/lib/components/sparkline/sparkline.component.tsx
@@ -1,11 +1,11 @@
-import { memo } from "react";
+import { useMemo, useState } from "react";
 import { Area, AreaChart, CartesianGrid, ResponsiveContainer } from "recharts";
 import { chartColors } from "../../style/theme";
 
 type SparklineProps = {
   serie: {
     data: [number, number][],
-    color?: string,
+    color?: string, // exa color code like '#ff0000'
   }
 };
 
@@ -13,26 +13,35 @@ type SparklineProps = {
  * Sparkline is a simple dynamically sized area chart.
  * Used to show trends in data over time.
  */
-function SparklineCmp({ serie }: SparklineProps) {
+export function Sparkline({ serie }: SparklineProps) {
   const data = serie.data.map(([x, y]) => ({ x, y }));
-  const strokeColor = serie.color ?? chartColors.lineColor1;
-  const fillColor = `lighten(${strokeColor}, 0.5)`;
+  const color = serie.color ?? chartColors.lineColor1;
+
+  const [chartWidth, setChartWidth] = useState(0);
+  const verticalPoints = useMemo(
+    () => Array.from({ length: 7 }, (_, i) => 5 + (i * (chartWidth - 10)) / 5),
+    [chartWidth]
+  );
 
   return (
-    <ResponsiveContainer>
+    <ResponsiveContainer onResize={setChartWidth}>
       <AreaChart data={data}>
-      <CartesianGrid strokeDasharray="1" horizontal={false} />
-      <Area
-        type="monotone"
-        dataKey="y"
-        stroke={strokeColor}
-        fill={fillColor}
-        dot={false}
-        activeDot={false}
-      />
+        <defs>
+          <linearGradient id={`gradient-${color}`} x1="0" y1="0" x2="0" y2="1">
+            <stop offset="0%" stopColor={color} stopOpacity={0.7} />
+            <stop offset="100%" stopColor={color} stopOpacity={0.1} />
+          </linearGradient>
+        </defs>
+        <CartesianGrid horizontal={false} strokeOpacity={0.4} verticalPoints={verticalPoints} />
+        <Area
+          type="linear"
+          dataKey="y"
+          stroke={color}
+          fill={`url(#gradient-${color})`}
+          dot={false}
+          activeDot={false}
+        />
       </AreaChart>
     </ResponsiveContainer>
   );
 }
-
-export const Sparkline = memo(SparklineCmp);

--- a/src/lib/components/sparkline/sparkline.component.tsx
+++ b/src/lib/components/sparkline/sparkline.component.tsx
@@ -1,6 +1,7 @@
+import { useMemo } from "react";
 import { Area, AreaChart, CartesianGrid, ResponsiveContainer } from "recharts";
-import { chartColors } from "../../style/theme";
 import { useTheme } from "styled-components";
+import { chartColors } from "../../style/theme";
 
 type SparklineProps = {
   serie: {
@@ -14,7 +15,7 @@ type SparklineProps = {
  * Used to show trends in data over time.
  */
 export function Sparkline({ serie }: SparklineProps) {
-  const data = serie.data.map(([x, y]) => ({ x, y }));
+  const data = useMemo(() => serie.data.map(([x, y]) => ({ x, y })), [serie.data]);
   const color = serie.color ?? chartColors.lineColor1;
   const strokeGridColor = useTheme().border;
 

--- a/src/lib/components/sparkline/sparkline.component.tsx
+++ b/src/lib/components/sparkline/sparkline.component.tsx
@@ -1,6 +1,6 @@
-import { useMemo, useState } from "react";
 import { Area, AreaChart, CartesianGrid, ResponsiveContainer } from "recharts";
 import { chartColors } from "../../style/theme";
+import { useTheme } from "styled-components";
 
 type SparklineProps = {
   serie: {
@@ -16,15 +16,10 @@ type SparklineProps = {
 export function Sparkline({ serie }: SparklineProps) {
   const data = serie.data.map(([x, y]) => ({ x, y }));
   const color = serie.color ?? chartColors.lineColor1;
-
-  const [chartWidth, setChartWidth] = useState(0);
-  const verticalPoints = useMemo(
-    () => Array.from({ length: 7 }, (_, i) => 5 + (i * (chartWidth - 10)) / 5),
-    [chartWidth]
-  );
+  const strokeGridColor = useTheme().border;
 
   return (
-    <ResponsiveContainer onResize={setChartWidth}>
+    <ResponsiveContainer>
       <AreaChart data={data}>
         <defs>
           <linearGradient id={`gradient-${color}`} x1="0" y1="0" x2="0" y2="1">
@@ -32,15 +27,15 @@ export function Sparkline({ serie }: SparklineProps) {
             <stop offset="100%" stopColor={color} stopOpacity={0.1} />
           </linearGradient>
         </defs>
-        <CartesianGrid horizontal={false} strokeOpacity={0.4} verticalPoints={verticalPoints} />
-        <Area
-          type="linear"
-          dataKey="y"
-          stroke={color}
-          fill={`url(#gradient-${color})`}
-          dot={false}
-          activeDot={false}
-        />
+      <CartesianGrid horizontal={false} stroke={strokeGridColor} strokeOpacity={0.5} />
+      <Area
+        type="linear"
+        dataKey="y"
+        stroke={color}
+        fill={`url(#gradient-${color})`}
+        dot={false}
+        activeDot={false}
+      />
       </AreaChart>
     </ResponsiveContainer>
   );

--- a/src/lib/components/sparkline/sparkline.component.tsx
+++ b/src/lib/components/sparkline/sparkline.component.tsx
@@ -36,6 +36,7 @@ export function Sparkline({ serie }: SparklineProps) {
         fill={`url(#gradient-${color})`}
         dot={false}
         activeDot={false}
+        isAnimationActive={false}
       />
       </AreaChart>
     </ResponsiveContainer>

--- a/src/lib/components/sparkline/sparkline.component.tsx
+++ b/src/lib/components/sparkline/sparkline.component.tsx
@@ -5,7 +5,7 @@ import { chartColors } from "../../style/theme";
 
 type SparklineProps = {
   serie: {
-    data: [number, number][],
+    data: [number, number|null][],
     color?: string, // exa color code like '#ff0000'
   }
 };

--- a/src/lib/components/sparkline/sparkline.component.tsx
+++ b/src/lib/components/sparkline/sparkline.component.tsx
@@ -1,0 +1,38 @@
+import { memo } from "react";
+import { Area, AreaChart, CartesianGrid, ResponsiveContainer } from "recharts";
+import { chartColors } from "../../style/theme";
+
+type SparklineProps = {
+  serie: {
+    data: [number, number][],
+    color?: string,
+  }
+};
+
+/**
+ * Sparkline is a simple dynamically sized area chart.
+ * Used to show trends in data over time.
+ */
+function SparklineCmp({ serie }: SparklineProps) {
+  const data = serie.data.map(([x, y]) => ({ x, y }));
+  const strokeColor = serie.color ?? chartColors.lineColor1;
+  const fillColor = `lighten(${strokeColor}, 0.5)`;
+
+  return (
+    <ResponsiveContainer>
+      <AreaChart data={data}>
+      <CartesianGrid strokeDasharray="1" horizontal={false} />
+      <Area
+        type="monotone"
+        dataKey="y"
+        stroke={strokeColor}
+        fill={fillColor}
+        dot={false}
+        activeDot={false}
+      />
+      </AreaChart>
+    </ResponsiveContainer>
+  );
+}
+
+export const Sparkline = memo(SparklineCmp);

--- a/stories/sparkline.stories.tsx
+++ b/stories/sparkline.stories.tsx
@@ -67,15 +67,15 @@ const trendingDownData: [number, number][] = [
   [1740412800, 22.1],
 ];
 
-const flatData: [number, number][] = [
+const flatData: [number, number|null][] = [
   [1740405600, 50.0],
   [1740406320, 50.0],
   [1740407760, 50.0],
-  [1740408480, 50.0],
+  [1740408480, null],
   [1740409200, 50.0],
   [1740409920, 50.0],
   [1740410640, 50.0],
-  [1740411360, 50.0],
+  [1740411360, null],
   [1740412080, 50.0],
   [1740412800, 50.0],
 ];
@@ -127,7 +127,7 @@ export const TrendingDown: Story = {
   },
 };
 
-export const Flat: Story = {
+export const FlatWithMissingData: Story = {
   args: {
     serie: {
       data: flatData,
@@ -136,7 +136,7 @@ export const Flat: Story = {
   parameters: {
     docs: {
       description: {
-        story: 'Sparkline representing stable data with minimal fluctuations.',
+        story: 'Sparkline representing stable data with some missing values.',
       },
     },
   },

--- a/stories/sparkline.stories.tsx
+++ b/stories/sparkline.stories.tsx
@@ -39,7 +39,6 @@ const volatileData: [number, number][] = [
   [1740411360, 67.89],
   [1740412080, 12.45],
   [1740412800, 95.67],
-  [1740413520, 41.23],
 ];
 
 const trendingUpData: [number, number][] = [
@@ -53,7 +52,6 @@ const trendingUpData: [number, number][] = [
   [1740411360, 48.3],
   [1740412080, 55.9],
   [1740412800, 62.1],
-  [1740413520, 68.7],
 ];
 
 const trendingDownData: [number, number][] = [
@@ -67,7 +65,6 @@ const trendingDownData: [number, number][] = [
   [1740411360, 28.3],
   [1740412080, 25.9],
   [1740412800, 22.1],
-  [1740413520, 18.7],
 ];
 
 const flatData: [number, number][] = [
@@ -81,7 +78,6 @@ const flatData: [number, number][] = [
   [1740411360, 50.0],
   [1740412080, 50.0],
   [1740412800, 50.0],
-  [1740413520, 50.0],
 ];
 
 export const Default: Story = {

--- a/stories/sparkline.stories.tsx
+++ b/stories/sparkline.stories.tsx
@@ -1,0 +1,144 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { Sparkline } from '../src/lib/components/sparkline/sparkline.component';
+
+const meta: Meta<typeof Sparkline> = {
+  title: 'Components/Data Display/Charts/Sparkline',
+  component: Sparkline,
+  parameters: {
+    layout: 'centered',
+  },
+  tags: ['autodocs'],
+  argTypes: {
+    serie: { 
+      control: 'object',
+      description: 'Data series containing array of [timestamp, value] pairs'
+    },
+  },
+  decorators: [
+    (Story) => (
+      <div style={{ width: 300, height: 100 }}>
+        <Story />
+      </div>
+    ),
+  ],
+};
+
+export default meta;
+type Story = StoryObj<typeof Sparkline>;
+
+// Sample data for different scenarios
+const volatileData: [number, number][] = [
+  [1740405600, 25.32],
+  [1740406320, 78.45],
+  [1740407760, 15.67],
+  [1740408480, 92.33],
+  [1740409200, 8.91],
+  [1740409920, 88.76],
+  [1740410640, 34.22],
+  [1740411360, 67.89],
+  [1740412080, 12.45],
+  [1740412800, 95.67],
+  [1740413520, 41.23],
+];
+
+const trendingUpData: [number, number][] = [
+  [1740405600, 10.5],
+  [1740406320, 15.2],
+  [1740407760, 18.9],
+  [1740408480, 22.1],
+  [1740409200, 28.7],
+  [1740409920, 35.4],
+  [1740410640, 42.8],
+  [1740411360, 48.3],
+  [1740412080, 55.9],
+  [1740412800, 62.1],
+  [1740413520, 68.7],
+];
+
+const trendingDownData: [number, number][] = [
+  [1740405600, 70.5],
+  [1740406320, 65.2],
+  [1740407760, 58.9],
+  [1740408480, 52.1],
+  [1740409200, 48.7],
+  [1740409920, 35.4],
+  [1740410640, 32.8],
+  [1740411360, 28.3],
+  [1740412080, 25.9],
+  [1740412800, 22.1],
+  [1740413520, 18.7],
+];
+
+const flatData: [number, number][] = [
+  [1740405600, 50.0],
+  [1740406320, 50.0],
+  [1740407760, 50.0],
+  [1740408480, 50.0],
+  [1740409200, 50.0],
+  [1740409920, 50.0],
+  [1740410640, 50.0],
+  [1740411360, 50.0],
+  [1740412080, 50.0],
+  [1740412800, 50.0],
+  [1740413520, 50.0],
+];
+
+export const Default: Story = {
+  args: {
+    serie: {
+      data: volatileData,
+    },
+  },
+  parameters: {
+    docs: {
+      description: {
+        story: 'Sparkline displaying highly volatile data with frequent peaks and valleys.',
+      },
+    },
+  },
+};
+
+export const TrendingUp: Story = {
+  args: {
+    serie: {
+      data: trendingUpData,
+    },
+  },
+  parameters: {
+    docs: {
+      description: {
+        story: 'Sparkline showing a clear upward trend over time.',
+      },
+    },
+  },
+};
+
+export const TrendingDown: Story = {
+  args: {
+    serie: {
+      data: trendingDownData,
+    },
+  },
+  parameters: {
+    docs: {
+      description: {
+        story: 'Sparkline illustrating a downward trend over time.',
+      },
+    },
+  },
+};
+
+export const Flat: Story = {
+  args: {
+    serie: {
+      data: flatData,
+    },
+  },
+  parameters: {
+    docs: {
+      description: {
+        story: 'Sparkline representing stable data with minimal fluctuations.',
+      },
+    },
+  },
+};

--- a/stories/sparkline.stories.tsx
+++ b/stories/sparkline.stories.tsx
@@ -1,5 +1,6 @@
 import type { Meta, StoryObj } from '@storybook/react';
 import { Sparkline } from '../src/lib/components/sparkline/sparkline.component';
+import { lineColor5, lineColor6 } from '../src/lib/style/theme';
 
 const meta: Meta<typeof Sparkline> = {
   title: 'Components/Data Display/Charts/Sparkline',
@@ -16,7 +17,7 @@ const meta: Meta<typeof Sparkline> = {
   },
   decorators: [
     (Story) => (
-      <div style={{ width: 300, height: 100 }}>
+      <div style={{ width: 200, height: 100 }}>
         <Story />
       </div>
     ),
@@ -102,6 +103,7 @@ export const TrendingUp: Story = {
   args: {
     serie: {
       data: trendingUpData,
+      color: lineColor5, // Optional custom color (green)
     },
   },
   parameters: {
@@ -117,6 +119,7 @@ export const TrendingDown: Story = {
   args: {
     serie: {
       data: trendingDownData,
+      color: lineColor6,
     },
   },
   parameters: {


### PR DESCRIPTION
**Component**:

- Sparkline

**Description**:

This is a new component based on those specifications:
- [VitalsUI requierments](https://docs.google.com/document/d/1Z5Kkh5LQDxI23q3UqjB8VnlPMadBGAZZ5TJypUDJjAo/edit?tab=t.0)
- [figma](https://www.figma.com/design/N2jOAK44dTSiBclDjXzz6a/ARTESCA?node-id=24564-2151&p=f&t=MA0gQkjtf61qbhbp-0)
- [AIX-355](https://scality.atlassian.net/browse/AIX-355)

This components displays a simple single serie area chart without any interaction (no tooltips).

<img width="358" height="678" alt="image" src="https://github.com/user-attachments/assets/882f3771-ed16-41be-b82d-6b15d3cad09c" />

**Design**:

The colour of the charts defaults to `lineColor1` and can be customised via the `serie.color` property. I did not import the red or green logic depending on the value in this component as it would make reusability and extension way harder.

**Breaking Changes**:

- None


[AIX-355]: https://scality.atlassian.net/browse/AIX-355?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ