### PR TITLE
add sort() to legend wrapper

### DIFF
--- a/src/lib/components/chartlegend/ChartLegendWrapper.tsx
+++ b/src/lib/components/chartlegend/ChartLegendWrapper.tsx
@@ -133,7 +133,7 @@ export const ChartLegendWrapper = ({
   );
 
   const listResources = useCallback(() => {
-    return Object.keys(internalColorSet);
+    return Object.keys(internalColorSet).sort();
   }, [internalColorSet]);
 
   const chartLegendState = useMemo(


### PR DESCRIPTION
Add sort to list resources to avoid issue with object.keys sorting when keys is a number
