### PR TITLE
Improve chart labels

### DIFF
--- a/src/lib/components/barchartv2/Barchart.component.tsx
+++ b/src/lib/components/barchartv2/Barchart.component.tsx
@@ -20,7 +20,7 @@ import { IconHelp } from '../iconhelper/IconHelper';
 import { Loader } from '../loader/Loader.component';
 import { Text } from '../text/Text.component';
 import { BarchartTooltip } from './BarchartTooltip';
-import { UnitRange, useChartData } from './utils';
+import { getTicks, UnitRange, useChartData } from './utils';
 
 const CHART_CONSTANTS = {
   TICK_WIDTH_OFFSET: 4,
@@ -301,7 +301,7 @@ export const Barchart = <T extends BarchartBars>(props: BarchartProps<T>) => {
     );
 
   return (
-    <Stack direction="vertical">
+    <Stack direction="vertical" style={{ gap: '0' }}>
       <ChartHeader
         title={title}
         secondaryTitle={secondaryTitle}
@@ -354,13 +354,12 @@ export const Barchart = <T extends BarchartBars>(props: BarchartProps<T>) => {
             })}
 
             <YAxis
-              tickCount={1}
+              ticks={getTicks(roundReferenceValue, false)}
               interval={0}
               unit={` ${unitLabel}`}
               domain={[0, roundReferenceValue]}
               tickFormatter={
-                (value) =>
-                  new Intl.NumberFormat('fr-FR').format(value.toFixed(0)) // Add a space as thousand separator
+                (value) => new Intl.NumberFormat('fr-FR').format(value) // Add a space as thousand separator and max 2 decimal places
               }
               axisLine={{ stroke: theme.border }}
               tick={{

--- a/src/lib/components/barchartv2/Barchart.component.tsx
+++ b/src/lib/components/barchartv2/Barchart.component.tsx
@@ -76,6 +76,7 @@ export type BarchartSortFn<T extends BarchartBars> = (
 
 export type BarchartProps<T extends BarchartBars> = {
   type: CategoryType | TimeType;
+  title: string;
   bars?: T;
   tooltip?: BarchartTooltipFn<T>;
   defaultSort?: BarchartSortFn<T>;
@@ -89,7 +90,6 @@ export type BarchartProps<T extends BarchartBars> = {
    * @default 'default'
    */
   stackedBarSort?: 'default' | 'legend';
-  title?: string;
   secondaryTitle?: string;
   rightTitle?: React.ReactNode;
   height?: number;
@@ -299,11 +299,11 @@ export const Barchart = <T extends BarchartBars>(props: BarchartProps<T>) => {
       unitRange,
       stackedBarSort,
     );
-
+  const titleWithUnit = unitLabel ? `${title} (${unitLabel})` : title;
   return (
     <Stack direction="vertical" style={{ gap: '0' }}>
       <ChartHeader
-        title={title}
+        title={titleWithUnit}
         secondaryTitle={secondaryTitle}
         helpTooltip={helpTooltip}
         rightTitle={rightTitle}
@@ -354,12 +354,11 @@ export const Barchart = <T extends BarchartBars>(props: BarchartProps<T>) => {
             })}
 
             <YAxis
-              ticks={getTicks(roundReferenceValue, false)}
               interval={0}
-              unit={` ${unitLabel}`}
               domain={[0, roundReferenceValue]}
+              ticks={getTicks(roundReferenceValue, false)}
               tickFormatter={
-                (value) => new Intl.NumberFormat('fr-FR').format(value) // Add a space as thousand separator and max 2 decimal places
+                (value) => new Intl.NumberFormat('fr-FR').format(value) // Add a space as thousand separator
               }
               axisLine={{ stroke: theme.border }}
               tick={{

--- a/src/lib/components/barchartv2/utils.test.ts
+++ b/src/lib/components/barchartv2/utils.test.ts
@@ -7,6 +7,7 @@ import {
   getCurrentPoint,
   getMaxBarValue,
   getRoundReferenceValue,
+  getTicks,
   sortStackedBars,
   transformCategoryData,
   transformTimeData,
@@ -526,6 +527,51 @@ describe('getRoundReferenceValue', () => {
     expect(getRoundReferenceValue(3500)).toBe(4000); // 3850 → 4000
     expect(getRoundReferenceValue(7500)).toBe(10000); // 8250 → 10000
     expect(getRoundReferenceValue(15000)).toBe(20000); // 16500 → 20000
+  });
+});
+
+describe('getTicks', () => {
+  describe('small values (< 10)', () => {
+    it('should return 2 ticks for non-symmetrical small values', () => {
+      expect(getTicks(1, false)).toEqual([0, 1]);
+      expect(getTicks(2, false)).toEqual([0, 2]);
+      expect(getTicks(5, false)).toEqual([0, 5]);
+    });
+
+    it('should return 3 ticks for symmetrical small values', () => {
+      expect(getTicks(1, true)).toEqual([-1, 0, 1]);
+      expect(getTicks(2, true)).toEqual([-2, 0, 2]);
+      expect(getTicks(5, true)).toEqual([-5, 0, 5]);
+    });
+  });
+
+  describe('even topValue (divisible by 2)', () => {
+    it('should return 3 ticks for non-symmetrical even values', () => {
+      expect(getTicks(10, false)).toEqual([0, 5, 10]);
+      expect(getTicks(20, false)).toEqual([0, 10, 20]);
+      expect(getTicks(40, false)).toEqual([0, 20, 40]);
+      expect(getTicks(50, false)).toEqual([0, 25, 50]);
+      expect(getTicks(100, false)).toEqual([0, 50, 100]);
+      expect(getTicks(1000, false)).toEqual([0, 500, 1000]);
+    });
+
+    it('should return 5 ticks for symmetrical even values', () => {
+      expect(getTicks(10, true)).toEqual([-10, -5, 0, 5, 10]);
+      expect(getTicks(100, true)).toEqual([-100, -50, 0, 50, 100]);
+    });
+  });
+
+  describe('odd topValue (not divisible by 2) - 7.5 multiples', () => {
+    it('should return 4 ticks for non-symmetrical values from 7.5 × magnitude', () => {
+      expect(getTicks(75, false)).toEqual([0, 25, 50, 75]);
+      expect(getTicks(750, false)).toEqual([0, 250, 500, 750]);
+      expect(getTicks(7500, false)).toEqual([0, 2500, 5000, 7500]);
+    });
+
+    it('should return 7 ticks for symmetrical values from 7.5 × magnitude', () => {
+      expect(getTicks(75, true)).toEqual([-75, -50, -25, 0, 25, 50, 75]);
+      expect(getTicks(750, true)).toEqual([-750, -500, -250, 0, 250, 500, 750]);
+    });
   });
 });
 

--- a/src/lib/components/barchartv2/utils.test.ts
+++ b/src/lib/components/barchartv2/utils.test.ts
@@ -504,21 +504,27 @@ describe('applySortingToData', () => {
 });
 
 describe('getRoundReferenceValue', () => {
-  it('should return appropriate rounded values', () => {
-    expect(getRoundReferenceValue(1)).toBe(5);
-    expect(getRoundReferenceValue(2)).toBe(5);
-    expect(getRoundReferenceValue(3)).toBe(5);
-    expect(getRoundReferenceValue(7)).toBe(10);
-    expect(getRoundReferenceValue(15)).toBe(25);
-    expect(getRoundReferenceValue(35)).toBe(50);
-    expect(getRoundReferenceValue(75)).toBe(100);
-    expect(getRoundReferenceValue(150)).toBe(250);
-    expect(getRoundReferenceValue(350)).toBe(500);
-    expect(getRoundReferenceValue(750)).toBe(1000);
-    expect(getRoundReferenceValue(1500)).toBe(2500);
-    expect(getRoundReferenceValue(3500)).toBe(5000);
-    expect(getRoundReferenceValue(7500)).toBe(10000);
-    expect(getRoundReferenceValue(15000)).toBe(25000);
+  it('should return appropriate rounded values with 10% buffer', () => {
+    // Small values (< 5) get minimum of 5
+    expect(getRoundReferenceValue(1)).toBe(5); // 1.1 → 1.5 → min 5
+    expect(getRoundReferenceValue(2)).toBe(5); // 2.2 → 3 → min 5
+    expect(getRoundReferenceValue(3)).toBe(5); // 3.3 → 4 → min 5
+
+    // Values 5-10 range
+    expect(getRoundReferenceValue(6)).toBe(10); // 6.6 → 10 (skip 7.5 for values < 10)
+    expect(getRoundReferenceValue(9)).toBe(10); // 9.9 → 10
+
+    // Larger values get 10% buffer applied
+    expect(getRoundReferenceValue(15)).toBe(20); // 16.5 → 20
+    expect(getRoundReferenceValue(35)).toBe(40); // 38.5 → 40
+    expect(getRoundReferenceValue(75)).toBe(100); // 82.5 → 100
+    expect(getRoundReferenceValue(150)).toBe(200); // 165 → 200
+    expect(getRoundReferenceValue(350)).toBe(400); // 385 → 400
+    expect(getRoundReferenceValue(750)).toBe(1000); // 825 → 1000
+    expect(getRoundReferenceValue(1500)).toBe(2000); // 1650 → 2000
+    expect(getRoundReferenceValue(3500)).toBe(4000); // 3850 → 4000
+    expect(getRoundReferenceValue(7500)).toBe(10000); // 8250 → 10000
+    expect(getRoundReferenceValue(15000)).toBe(20000); // 16500 → 20000
   });
 });
 
@@ -685,7 +691,8 @@ describe('computeUnitLabelAndRoundReferenceValue', () => {
     );
 
     expect(result.unitLabel).toBe('kB');
-    expect(result.roundReferenceValue).toBe(10);
+    // 1680 / 1000 = 1.68, with buffer: 1.848 → rounds to 2 → min 5
+    expect(result.roundReferenceValue).toBe(5);
     expect(result.rechartsData).toEqual([
       {
         category: 'category1',
@@ -718,7 +725,8 @@ describe('computeUnitLabelAndRoundReferenceValue', () => {
     );
 
     expect(result.unitLabel).toBe('B');
-    expect(result.roundReferenceValue).toBe(1000);
+    // 680 with buffer: 748 → rounds to 750 (7.5 * 100, value > 10)
+    expect(result.roundReferenceValue).toBe(750);
     expect(result.rechartsData).toEqual([
       { category: 'category1', success: 680 },
     ]);

--- a/src/lib/components/barchartv2/utils.test.ts
+++ b/src/lib/components/barchartv2/utils.test.ts
@@ -505,10 +505,11 @@ describe('applySortingToData', () => {
 
 describe('getRoundReferenceValue', () => {
   it('should return appropriate rounded values with 10% buffer', () => {
-    // Small values (< 5) get minimum of 5
-    expect(getRoundReferenceValue(1)).toBe(5); // 1.1 → 1.5 → min 5
-    expect(getRoundReferenceValue(2)).toBe(5); // 2.2 → 3 → min 5
-    expect(getRoundReferenceValue(3)).toBe(5); // 3.3 → 4 → min 5
+    // Small values (< 10)
+    expect(getRoundReferenceValue(0.1)).toBe(0.2); // 0.1 → 0.11 → 0.2
+    expect(getRoundReferenceValue(1)).toBe(2); // 1.1 → 1.5 → 2
+    expect(getRoundReferenceValue(2)).toBe(5); // 2.2 → 3 → 5
+    expect(getRoundReferenceValue(3)).toBe(5); // 3.3 → 4 → 5
 
     // Values 5-10 range
     expect(getRoundReferenceValue(6)).toBe(10); // 6.6 → 10 (skip 7.5 for values < 10)
@@ -691,8 +692,8 @@ describe('computeUnitLabelAndRoundReferenceValue', () => {
     );
 
     expect(result.unitLabel).toBe('kB');
-    // 1680 / 1000 = 1.68, with buffer: 1.848 → rounds to 2 → min 5
-    expect(result.roundReferenceValue).toBe(5);
+    // 1680 / 1000 = 1.68, with buffer: 1.848 → rounds to 2
+    expect(result.roundReferenceValue).toBe(2);
     expect(result.rechartsData).toEqual([
       {
         category: 'category1',

--- a/src/lib/components/barchartv2/utils.ts
+++ b/src/lib/components/barchartv2/utils.ts
@@ -21,9 +21,7 @@ export const getRoundReferenceValue = (value: number): number => {
   let result: number;
 
   if (normalized <= 1) result = magnitude;
-  else if (value > 10 && normalized <= 1.5) result = 1.5 * magnitude;
   else if (normalized <= 2) result = 2 * magnitude;
-  else if (value > 10 && normalized <= 3) result = 3 * magnitude;
   else if (value > 10 && normalized <= 4) result = 4 * magnitude;
   else if (normalized <= 5) result = 5 * magnitude;
   else if (value > 10 && normalized <= 7.5) result = 7.5 * magnitude;

--- a/src/lib/components/barchartv2/utils.ts
+++ b/src/lib/components/barchartv2/utils.ts
@@ -38,20 +38,20 @@ export const getTicks = (topValue: number, isSymmetrical: boolean) => {
       return [0, topValue];
     }
   }
-  const numberOfTicks = topValue % 2 === 0 ? 3 : 4;
+  const numberOfTicks = topValue % 3 === 0 ? 4 : 3;
   const tickInterval = topValue / (numberOfTicks - 1);
   const ticks = Array.from(
     { length: numberOfTicks },
     (_, index) => index * tickInterval,
   );
   if (isSymmetrical) {
+    // Create negative ticks in order without 0
     const negativeTicks = Array.from(
       { length: numberOfTicks - 1 },
-      (_, index) => -(index + 1) * tickInterval,
+      (_, index) => -(numberOfTicks - 1 - index) * tickInterval,
     );
     ticks.unshift(...negativeTicks);
   }
-
   return ticks;
 };
 

--- a/src/lib/components/barchartv2/utils.ts
+++ b/src/lib/components/barchartv2/utils.ts
@@ -332,7 +332,7 @@ export const computeUnitLabelAndRoundReferenceValue = (
 ) => {
   if (!unitRange) {
     const roundReferenceValue = getRoundReferenceValue(maxValue);
-    return { unitLabel: '', roundReferenceValue, rechartsData: data };
+    return { unitLabel: undefined, roundReferenceValue, rechartsData: data };
   }
 
   const { valueBase, unitLabel } = getUnitLabel(unitRange, maxValue);

--- a/src/lib/components/barchartv2/utils.ts
+++ b/src/lib/components/barchartv2/utils.ts
@@ -4,23 +4,57 @@ import { chartColors, ChartColors } from '../../style/theme';
 import { useChartLegend } from '../chartlegend/ChartLegendWrapper';
 
 export const getRoundReferenceValue = (value: number): number => {
-  if (value <= 0) return 10; // Default for zero or negative values
+  if (value <= 0) return 5; // Default for zero or negative values
 
   // Get the magnitude (10^n where n is the number of digits - 1)
   const magnitude = Math.pow(10, Math.floor(Math.log10(value)));
 
+  // Buffer the value by 10% to avoid being too close to the edge of the chart
+  const bufferedValue = value * 1.1;
+
   // Normalized value between 1 and 10
-  const normalized = value / magnitude;
+  const normalized = bufferedValue / magnitude;
 
   // Round to nice numbers based on normalized value
   let result: number;
   if (normalized <= 1) result = magnitude;
-  else if (normalized <= 2.5) result = 2.5 * magnitude;
+  else if (normalized <= 1.5) result = 1.5 * magnitude;
+  else if (normalized <= 2) result = 2 * magnitude;
+  else if (normalized <= 3) result = 3 * magnitude;
+  else if (normalized <= 4) result = 4 * magnitude;
   else if (normalized <= 5) result = 5 * magnitude;
+  // skip 7.5 as top value (but not 75, 750, 7500, etc.) for better chart appearance
+  else if (value > 10 && normalized <= 7.5) result = 7.5 * magnitude;
   else result = 10 * magnitude;
 
-  // Ensure minimum value of 5 for better chart appearance
+  // Ensure minimum value of 5 for Round Reference Value
+  // for better chart appearance
   return Math.max(result, 5);
+};
+
+export const getTicks = (topValue: number, isSymmetrical: boolean) => {
+  if (topValue < 10) {
+    if (isSymmetrical) {
+      return [-topValue, 0, topValue];
+    } else {
+      return [0, topValue];
+    }
+  }
+  const numberOfTicks = topValue % 2 === 0 ? 3 : 4;
+  const tickInterval = topValue / (numberOfTicks - 1);
+  const ticks = Array.from(
+    { length: numberOfTicks },
+    (_, index) => index * tickInterval,
+  );
+  if (isSymmetrical) {
+    const negativeTicks = Array.from(
+      { length: numberOfTicks - 1 },
+      (_, index) => -(index + 1) * tickInterval,
+    );
+    ticks.unshift(...negativeTicks);
+  }
+
+  return ticks;
 };
 
 export const getMaxBarValue = (

--- a/src/lib/components/barchartv2/utils.ts
+++ b/src/lib/components/barchartv2/utils.ts
@@ -4,7 +4,7 @@ import { chartColors, ChartColors } from '../../style/theme';
 import { useChartLegend } from '../chartlegend/ChartLegendWrapper';
 
 export const getRoundReferenceValue = (value: number): number => {
-  if (value <= 0) return 5; // Default for zero or negative values
+  if (value <= 0) return 1; // Default for zero or negative values
 
   // Get the magnitude (10^n where n is the number of digits - 1)
   const magnitude = Math.pow(10, Math.floor(Math.log10(value)));
@@ -16,20 +16,20 @@ export const getRoundReferenceValue = (value: number): number => {
   const normalized = bufferedValue / magnitude;
 
   // Round to nice numbers based on normalized value
+  // skip 1.5, 3, 4, 7.5 as top value for better chart
+  // appearance for small values
   let result: number;
+
   if (normalized <= 1) result = magnitude;
-  else if (normalized <= 1.5) result = 1.5 * magnitude;
+  else if (value > 10 && normalized <= 1.5) result = 1.5 * magnitude;
   else if (normalized <= 2) result = 2 * magnitude;
-  else if (normalized <= 3) result = 3 * magnitude;
-  else if (normalized <= 4) result = 4 * magnitude;
+  else if (value > 10 && normalized <= 3) result = 3 * magnitude;
+  else if (value > 10 && normalized <= 4) result = 4 * magnitude;
   else if (normalized <= 5) result = 5 * magnitude;
-  // skip 7.5 as top value (but not 75, 750, 7500, etc.) for better chart appearance
   else if (value > 10 && normalized <= 7.5) result = 7.5 * magnitude;
   else result = 10 * magnitude;
 
-  // Ensure minimum value of 5 for Round Reference Value
-  // for better chart appearance
-  return Math.max(result, 5);
+  return result;
 };
 
 export const getTicks = (topValue: number, isSymmetrical: boolean) => {

--- a/src/lib/components/barchartv2/utils.ts
+++ b/src/lib/components/barchartv2/utils.ts
@@ -338,7 +338,7 @@ export const computeUnitLabelAndRoundReferenceValue = (
   }
 
   const { valueBase, unitLabel } = getUnitLabel(unitRange, maxValue);
-  const topValue = Math.ceil(maxValue / valueBase / 10) * 10;
+  const topValue = maxValue / valueBase;
   const roundReferenceValue = getRoundReferenceValue(topValue);
   const rechartsData = data.map((dataPoint) => {
     const normalizedDataPoint = { ...dataPoint };

--- a/src/lib/components/globalhealthbar/GlobalHealthBarRecharts.component.tsx
+++ b/src/lib/components/globalhealthbar/GlobalHealthBarRecharts.component.tsx
@@ -26,10 +26,7 @@ export interface GlobalHealthProps {
 
 const ChartInteractiveContainer = styled.div`
   position: relative;
-
-  &:focus {
-    outline: none;
-  }
+  outline: none;
 `;
 
 export function GlobalHealthBar({ id, alerts, start, end }: GlobalHealthProps) {

--- a/src/lib/components/globalhealthbar/GlobalHealthBarRecharts.component.tsx
+++ b/src/lib/components/globalhealthbar/GlobalHealthBarRecharts.component.tsx
@@ -27,6 +27,9 @@ export interface GlobalHealthProps {
 const ChartInteractiveContainer = styled.div`
   position: relative;
   outline: none;
+  .recharts-surface {
+    outline: none;
+  }
 `;
 
 export function GlobalHealthBar({ id, alerts, start, end }: GlobalHealthProps) {

--- a/src/lib/components/globalhealthbar/components/HealthBarXAxis.tsx
+++ b/src/lib/components/globalhealthbar/components/HealthBarXAxis.tsx
@@ -47,7 +47,7 @@ const CustomTick = ({
           fontSize={fontSize.smaller}
           fill={theme.textSecondary}
         >
-          {is7DaySpan || isDaySpan ? (
+          {is7DaySpan ? (
             <FormattedDateTime
               format="day-month-abbreviated-hour-minute"
               value={new Date(payload.value)}

--- a/src/lib/components/linetimeseriechart/linetimeseriechart.component.tsx
+++ b/src/lib/components/linetimeseriechart/linetimeseriechart.component.tsx
@@ -526,7 +526,7 @@ export function LineTimeSerieChart({
               label={{
                 value: yAxisTitle,
                 angle: 90,
-                dx: 12,
+                dx: 20,
                 style: {
                   fill: theme.textSecondary,
                   fontSize: fontSize.smaller,

--- a/src/lib/components/linetimeseriechart/linetimeseriechart.component.tsx
+++ b/src/lib/components/linetimeseriechart/linetimeseriechart.component.tsx
@@ -33,6 +33,7 @@ import {
 } from '../charttooltip/ChartTooltip';
 import { LegendShape } from '../chartlegend/ChartLegend';
 import { StyledResponsiveContainer } from '../barchartv2/Barchart.component';
+import { getRoundReferenceValue, getTicks } from '../barchartv2/utils';
 
 const LineTemporalChartWrapper = styled.div`
   display: flex;
@@ -397,8 +398,8 @@ export function LineTimeSerieChart({
     const maxValue = Math.max(top, bottom);
 
     const { valueBase, unitLabel } = getUnitLabel(unitRange ?? [], maxValue);
-
-    const topValue = Math.ceil(maxValue / valueBase / 10) * 10;
+    // Use round reference value to add extra padding to the top value
+    const topValue = getRoundReferenceValue(maxValue / valueBase);
 
     const rechartsData = chartData.map((dataPoint) => {
       const normalizedDataPoint = { ...dataPoint };
@@ -525,9 +526,8 @@ export function LineTimeSerieChart({
               label={{
                 value: yAxisTitle,
                 angle: 90,
-                position: 'insideRight',
+                dx: 12,
                 style: {
-                  textAnchor: 'middle',
                   fill: theme.textSecondary,
                   fontSize: fontSize.smaller,
                 },
@@ -545,9 +545,9 @@ export function LineTimeSerieChart({
                 fontSize: fontSize.smaller,
               }}
               tickFormatter={(value) =>
-                new Intl.NumberFormat('fr-FR').format(value.toFixed(0))
+                new Intl.NumberFormat('fr-FR').format(value)
               }
-              tickCount={5}
+              ticks={getTicks(topValue, yAxisType === 'symmetrical')}
               interval={0}
             />
             <Tooltip

--- a/src/lib/components/linetimeseriechart/utils.test.ts
+++ b/src/lib/components/linetimeseriechart/utils.test.ts
@@ -12,10 +12,10 @@ describe('formatXAxisLabel', () => {
   });
 
   describe('medium duration (≤ 7 days)', () => {
-    it('should format timestamp with day-month-abbreviated format', () => {
+    it('should format timestamp with day-month-abbreviated-hour-minute format', () => {
       const duration = 3 * 24 * 60 * 60; // 3 days
       const result = formatXAxisLabel(mockTimestamp, duration);
-      expect(result).toBe('15 Sep');
+      expect(result).toBe('15 Sep 14:30');
     });
   });
 
@@ -37,7 +37,7 @@ describe('formatXAxisLabel', () => {
     it('should handle exactly 7 days duration', () => {
       const duration = 7 * 24 * 60 * 60; // exactly 7 days
       const result = formatXAxisLabel(mockTimestamp, duration);
-      expect(result).toBe('15 Sep');
+      expect(result).toBe('15 Sep 14:30');
     });
 
     it('should handle just over 7 days duration', () => {

--- a/src/lib/components/linetimeseriechart/utils.ts
+++ b/src/lib/components/linetimeseriechart/utils.ts
@@ -27,7 +27,6 @@ export const formatXAxisLabel = (
   const date = new Date(timestamp);
   if (duration <= 24 * 60 * 60) {
     return TIME_FORMATER.format(date);
-    //? At which point do we consider chart to be long term? 1 week? 2 weeks? 1 month?
   } else if (duration <= 7 * 24 * 60 * 60) {
     return DAY_MONTH_ABBREVIATED_HOUR_MINUTE.format(date)
       .replace(',', '')

--- a/src/lib/components/linetimeseriechart/utils.ts
+++ b/src/lib/components/linetimeseriechart/utils.ts
@@ -1,7 +1,7 @@
 import {
   TIME_FORMATER,
-  DAY_MONTH_ABBREVIATED,
   DAY_MONTH_ABBREVIATED_YEAR,
+  DAY_MONTH_ABBREVIATED_HOUR_MINUTE,
 } from '../date/FormattedDateTime';
 
 export const ONE_YEAR_MILLISECONDS = 366 * 24 * 60 * 60 * 1000;
@@ -27,8 +27,9 @@ export const formatXAxisLabel = (
   const date = new Date(timestamp);
   if (duration <= 24 * 60 * 60) {
     return TIME_FORMATER.format(date);
+    //? At which point do we consider chart to be long term? 1 week? 2 weeks? 1 month?
   } else if (duration <= 7 * 24 * 60 * 60) {
-    return DAY_MONTH_ABBREVIATED.format(date)
+    return DAY_MONTH_ABBREVIATED_HOUR_MINUTE.format(date)
       .replace(',', '')
       .replace(/Sept/g, 'Sep');
   } else {

--- a/stories/BarChart/barchart.stories.tsx
+++ b/stories/BarChart/barchart.stories.tsx
@@ -39,17 +39,17 @@ export const Playground: Story = {
       {
         label: 'Success',
         data: [
-          ['category1', 2],
-          ['category2', 4],
-          ['category3', 6],
+          ['category1', 1],
+          ['category2', 1],
+          ['category3', 2],
         ],
       },
       {
         label: 'Failed',
         data: [
-          ['category1', 8],
-          ['category2', 10],
-          ['category3', 12],
+          ['category1', 1],
+          ['category2', 1],
+          ['category3', 2],
         ],
       },
     ] as const;
@@ -61,7 +61,11 @@ export const Playground: Story = {
         }}
       >
         <Stack direction="vertical" gap="r16">
-          <Barchart type={{ type: 'category' }} bars={exampleData} />
+          <Barchart
+            type={{ type: 'category' }}
+            bars={exampleData}
+            title="Playground"
+          />
           <ChartLegend shape="rectangle" direction="horizontal" />
         </Stack>
       </ChartLegendWrapper>
@@ -122,6 +126,7 @@ export const Time7Days: Story = {
       >
         <Stack direction="vertical" gap="r16">
           <Barchart
+            title="Time 7 Days"
             type={{
               type: 'time',
               timeRange: {
@@ -192,6 +197,7 @@ export const Time7DaysWithMissingData: Story = {
         }}
       >
         <Barchart
+          title="Time 7 Days With Missing Data"
           type={{
             type: 'time',
             timeRange: {
@@ -285,6 +291,7 @@ export const TimeLast24Hours: Story = {
         }}
       >
         <Barchart
+          title="Time Last 24 Hours"
           type={{
             type: 'time',
             timeRange: {
@@ -332,6 +339,7 @@ export const CapacityWithUnitRange: Story = {
         }}
       >
         <Barchart
+          title="Capacity With Unit Range"
           type={{ type: 'category' }}
           bars={capacityDataWithUnitRange}
           unitRange={[
@@ -402,7 +410,12 @@ export const Stacked: Story = {
         }}
       >
         <Stack direction="vertical" gap="r16">
-          <Barchart type={{ type: 'category' }} bars={stackedData} stacked />
+          <Barchart
+            type={{ type: 'category' }}
+            bars={stackedData}
+            stacked
+            title="Stacked"
+          />
           <ChartLegend shape="rectangle" />
         </Stack>
       </ChartLegendWrapper>
@@ -457,6 +470,7 @@ export const DefaultSort: Story = {
           stacked
           bars={defaultSortData}
           defaultSort={customSort}
+          title="Default Sort"
         />
       </ChartLegendWrapper>
     );
@@ -531,6 +545,7 @@ export const WithCustomTooltip: Story = {
         >
           <Stack direction="vertical" gap="r16">
             <Barchart
+              title="Custom Tooltip"
               type={{ type: 'category' }}
               bars={exampleData}
               tooltip={customTooltip}


### PR DESCRIPTION
Various improvement on label for charts
Use getRoundreferecneValue for Line chart to add space between top chart value and top data value
Create fn to getTicks for charts to avoid issues with weird steps on Y axis (incosnistent steps and number of ticks, not showing 0 on symmetrical chart)
Put HH:MM on X axis label for span <= 7days
