### PR TITLE
add more possible top value for charts

### DIFF
--- a/src/lib/components/barchartv2/utils.test.ts
+++ b/src/lib/components/barchartv2/utils.test.ts
@@ -772,8 +772,8 @@ describe('computeUnitLabelAndRoundReferenceValue', () => {
     );
 
     expect(result.unitLabel).toBe('B');
-    // 680 with buffer: 748 → rounds to 750 (7.5 * 100, value > 10)
-    expect(result.roundReferenceValue).toBe(750);
+    // 680 with buffer: 748 → rounds to 800 (8 * 100, value > 10)
+    expect(result.roundReferenceValue).toBe(800);
     expect(result.rechartsData).toEqual([
       { category: 'category1', success: 680 },
     ]);

--- a/src/lib/components/barchartv2/utils.ts
+++ b/src/lib/components/barchartv2/utils.ts
@@ -21,10 +21,15 @@ export const getRoundReferenceValue = (value: number): number => {
   let result: number;
 
   if (normalized <= 1) result = magnitude;
+  else if (value > 10 && normalized <= 1.5) result = 1.5 * magnitude;
   else if (normalized <= 2) result = 2 * magnitude;
+  else if (value > 10 && normalized <= 2.5) result = 2.5 * magnitude;
+  else if (value > 10 && normalized <= 3) result = 3 * magnitude;
   else if (value > 10 && normalized <= 4) result = 4 * magnitude;
   else if (normalized <= 5) result = 5 * magnitude;
-  else if (value > 10 && normalized <= 7.5) result = 7.5 * magnitude;
+  else if (value > 10 && normalized <= 6) result = 6 * magnitude;
+  else if (value > 10 && normalized <= 8) result = 8 * magnitude;
+  else if (normalized <= 10) result = 10 * magnitude;
   else result = 10 * magnitude;
 
   return result;
@@ -38,7 +43,9 @@ export const getTicks = (topValue: number, isSymmetrical: boolean) => {
       return [0, topValue];
     }
   }
-  const numberOfTicks = topValue % 3 === 0 ? 4 : 3;
+  const possibleTickNumbers = [4, 3];
+  const numberOfTicks =
+    possibleTickNumbers.find((number) => topValue % (number - 1) === 0) || 2; // Default to 2 ticks if no match
   const tickInterval = topValue / (numberOfTicks - 1);
   const ticks = Array.from(
     { length: numberOfTicks },


### PR DESCRIPTION
Enhance getRoundReferenceValue and getTicks functions for improved tick calculation and rounding logic in charts
Avoid too big space between 100 and 200 or 200 and 400, etc

