### PR TITLE
Add `autoGrow` to TextArea so the size fits the content

### DIFF
--- a/src/lib/components/textarea/TextArea.component.tsx
+++ b/src/lib/components/textarea/TextArea.component.tsx
@@ -3,6 +3,10 @@ import {
   forwardRef,
   TextareaHTMLAttributes,
   ForwardedRef,
+  useEffect,
+  useRef,
+  useImperativeHandle,
+  useCallback,
 } from 'react';
 import styled, { css } from 'styled-components';
 import { spacing } from '../../spacing';
@@ -12,6 +16,12 @@ type Props = TextareaHTMLAttributes<HTMLTextAreaElement> & {
   variant?: TextAreaVariant;
   width?: CSSProperties['width'];
   height?: CSSProperties['height'];
+  /**
+   * Automatically adjust height to fit content
+   * When enabled, the textarea will grow/shrink to show all content
+   * It disables the resize property
+   */
+  autoGrow?: boolean;
 };
 type RefType = HTMLTextAreaElement | null;
 
@@ -19,6 +29,7 @@ const TextAreaContainer = styled.textarea<{
   variant: TextAreaVariant;
   width?: CSSProperties['width'];
   height?: CSSProperties['height'];
+  autoGrow?: boolean;
 }>`
   padding: ${spacing.r12} ${spacing.r8};
   border-radius: 4px;
@@ -44,6 +55,13 @@ const TextAreaContainer = styled.textarea<{
     props.height &&
     css`
       height: ${props.height};
+    `}
+
+  ${(props) =>
+    props.autoGrow &&
+    css`
+      resize: none;
+      overflow: hidden;
     `}
 
   &:placeholder-shown {
@@ -77,9 +95,42 @@ const TextAreaContainer = styled.textarea<{
 `;
 
 function TextAreaElement(
-  { rows = 3, cols = 20, width, height, variant = 'code', ...rest }: Props,
+  {
+    rows = 3,
+    cols = 20,
+    width,
+    height,
+    variant = 'code',
+    autoGrow = false,
+    value,
+    defaultValue,
+    onChange,
+    ...rest
+  }: Props,
   ref: ForwardedRef<RefType>,
 ) {
+  const internalRef = useRef<HTMLTextAreaElement>(null);
+
+  // Expose the textarea element to parent components via forwarded ref
+  useImperativeHandle(ref, () => internalRef.current as HTMLTextAreaElement);
+
+  const adjustHeight = useCallback(() => {
+    const textarea = internalRef.current;
+    if (!textarea || !autoGrow) return;
+
+    // Reset height to auto to get the correct scrollHeight
+    textarea.style.height = 'auto';
+
+    // Set the height to match the content
+    const newHeight = textarea.scrollHeight;
+    textarea.style.height = `${newHeight}px`;
+  }, [autoGrow]);
+
+  // Adjust height on mount to fit initial content
+  useEffect(() => {
+    adjustHeight();
+  }, []);
+
   if (width || height) {
     return (
       <TextAreaContainer
@@ -87,8 +138,12 @@ function TextAreaElement(
         width={width}
         height={height}
         variant={variant}
+        autoGrow={autoGrow}
+        value={value}
+        defaultValue={defaultValue}
+        onChange={onChange}
         {...rest}
-        ref={ref}
+        ref={internalRef}
       />
     );
   }
@@ -99,8 +154,12 @@ function TextAreaElement(
       rows={rows}
       cols={cols}
       variant={variant}
+      autoGrow={autoGrow}
+      value={value}
+      defaultValue={defaultValue}
+      onChange={onChange}
       {...rest}
-      ref={ref}
+      ref={internalRef}
     />
   );
 }

--- a/src/lib/components/textarea/TextArea.component.tsx
+++ b/src/lib/components/textarea/TextArea.component.tsx
@@ -19,7 +19,6 @@ type Props = TextareaHTMLAttributes<HTMLTextAreaElement> & {
   /**
    * Automatically adjust height to fit content
    * When enabled, the textarea will grow/shrink to show all content
-   * It disables the resize property
    */
   autoGrow?: boolean;
 };
@@ -60,7 +59,6 @@ const TextAreaContainer = styled.textarea<{
   ${(props) =>
     props.autoGrow &&
     css`
-      resize: none;
       overflow: hidden;
     `}
 
@@ -114,6 +112,7 @@ function TextAreaElement(
   // Expose the textarea element to parent components via forwarded ref
   useImperativeHandle(ref, () => internalRef.current as HTMLTextAreaElement);
 
+  // Adjust height on mount and when value changes (for controlled components)
   const adjustHeight = useCallback(() => {
     const textarea = internalRef.current;
     if (!textarea || !autoGrow) return;
@@ -126,10 +125,22 @@ function TextAreaElement(
     textarea.style.height = `${newHeight}px`;
   }, [autoGrow]);
 
-  // Adjust height on mount to fit initial content
   useEffect(() => {
     adjustHeight();
-  }, []);
+  }, [adjustHeight, value]);
+
+  // Handle onChange to support both controlled and uncontrolled components
+  const handleChange = useCallback(
+    (event: React.ChangeEvent<HTMLTextAreaElement>) => {
+      if (autoGrow) {
+        adjustHeight();
+      }
+      if (onChange) {
+        onChange(event);
+      }
+    },
+    [autoGrow, adjustHeight, onChange],
+  );
 
   if (width || height) {
     return (
@@ -141,7 +152,7 @@ function TextAreaElement(
         autoGrow={autoGrow}
         value={value}
         defaultValue={defaultValue}
-        onChange={onChange}
+        onChange={handleChange}
         {...rest}
         ref={internalRef}
       />
@@ -157,7 +168,7 @@ function TextAreaElement(
       autoGrow={autoGrow}
       value={value}
       defaultValue={defaultValue}
-      onChange={onChange}
+      onChange={handleChange}
       {...rest}
       ref={internalRef}
     />

--- a/stories/textarea.stories.tsx
+++ b/stories/textarea.stories.tsx
@@ -67,3 +67,59 @@ export const RowsAndColsSet = {
     placeholder: 'With rows = 20 and cols = 40',
   },
 };
+
+/**
+ * Auto-growing textarea adjusts its height based on content
+ * Perfect for displaying commands or long text where you want the entire content visible
+ * Simply set autoGrow={true} and the textarea will grow to show all content
+ */
+export const AutoGrowTextArea = {
+  args: {
+    autoGrow: true,
+    placeholder:
+      'Type or paste content here...\nThe textarea will automatically grow to fit all the content.',
+    value: `docker run -d \\
+  --name my-container \\
+  -p 8080:80 \\
+  -v /host/path:/container/path \\
+  -e ENV_VAR=value \\
+  my-image:latest`,
+    width: '500px',
+    readOnly: true,
+  },
+};
+
+/**
+ * Auto-growing textarea with long command example
+ * The entire command is visible without scrolling
+ */
+export const AutoGrowWithLongCommand = {
+  args: {
+    autoGrow: true,
+    variant: 'code',
+    value: `kubectl apply -f - <<EOF
+apiVersion: v1
+kind: Pod
+metadata:
+  name: my-pod
+  labels:
+    app: myapp
+spec:
+  containers:
+  - name: nginx
+    image: nginx:1.14.2
+    ports:
+    - containerPort: 80
+    env:
+    - name: DATABASE_URL
+      value: "postgresql://user:password@localhost:5432/db"
+    - name: API_KEY
+      valueFrom:
+        secretKeyRef:
+          name: api-secret
+          key: api-key
+EOF`,
+    width: '600px',
+    readOnly: true,
+  },
+};

--- a/stories/textarea.stories.tsx
+++ b/stories/textarea.stories.tsx
@@ -32,14 +32,14 @@ export const Playground = {};
 
 export const DefaultTextArea = {
   args: {
-    value: 'Some text',
+    defaultValue: 'Some text',
   },
 };
 
 export const TextVariantTextArea = {
   args: {
     variant: 'text',
-    value: 'Text area with "text" variant',
+    defaultValue: 'Text area with "text" variant',
   },
 };
 
@@ -78,14 +78,13 @@ export const AutoGrowTextArea = {
     autoGrow: true,
     placeholder:
       'Type or paste content here...\nThe textarea will automatically grow to fit all the content.',
-    value: `docker run -d \\
+    defaultValue: `docker run -d \\
   --name my-container \\
   -p 8080:80 \\
   -v /host/path:/container/path \\
   -e ENV_VAR=value \\
   my-image:latest`,
     width: '500px',
-    readOnly: true,
   },
 };
 
@@ -97,7 +96,7 @@ export const AutoGrowWithLongCommand = {
   args: {
     autoGrow: true,
     variant: 'code',
-    value: `kubectl apply -f - <<EOF
+    defaultValue: `kubectl apply -f - <<EOF
 apiVersion: v1
 kind: Pod
 metadata:
@@ -120,6 +119,5 @@ spec:
           key: api-key
 EOF`,
     width: '600px',
-    readOnly: true,
   },
 };


### PR DESCRIPTION
**Component**: TextArea 

**Description**:

**Design**:

**Breaking Changes**:

- [] Breaking Changes


---

<!-- Declare one or more issues to close once this PR gets merged -->

Closes: #ISSUE_NUMBER

<!-- If you want to refer to an issue while not closing it, use:

See: #ISSUE_NUMBER

-->
