### PR TITLE
Introduce a new prop for Banner component: withDefaultIcon.

### DIFF
--- a/src/lib/components/banner/Banner.component.test.tsx
+++ b/src/lib/components/banner/Banner.component.test.tsx
@@ -1,0 +1,58 @@
+import React from 'react';
+import '@testing-library/jest-dom';
+import { render, screen, waitFor } from '@testing-library/react';
+import { Banner } from './Banner.component';
+import { Icon } from '../icon/Icon.component';
+import { getWrapper } from '../../testUtils';
+
+describe('Banner', () => {
+  const { Wrapper } = getWrapper();
+
+  it('should render with text content', () => {
+    render(
+      <Banner variant="base">Some text content</Banner>,
+      { wrapper: Wrapper }
+    );
+    expect(screen.getByText('Some text content')).toBeInTheDocument();
+  });
+
+  it('should render with title', () => {
+    render(
+      <Banner variant="base" title="My Title">
+        Body text
+      </Banner>,
+      { wrapper: Wrapper }
+    );
+    expect(screen.getByText('My Title')).toBeInTheDocument();
+    expect(screen.getByText('Body text')).toBeInTheDocument();
+  });
+
+  it('should render with default icon when withDefaultIcon is true', async () => {
+    render(
+      <Banner variant="base" withDefaultIcon>
+        Message with default icon
+      </Banner>,
+      { wrapper: Wrapper }
+    );
+    expect(screen.getByText('Message with default icon')).toBeInTheDocument();
+
+    await waitFor(() => {
+      expect(screen.getByLabelText('Info-circle')).toBeInTheDocument();
+    });
+  });
+
+  it('should render with custom icon when icon prop is provided', async () => {
+    render(
+      <Banner variant="danger" icon={<Icon name="Check-circle" />}>
+        Message with custom icon
+      </Banner>,
+      { wrapper: Wrapper }
+    );
+    expect(screen.getByText('Message with custom icon')).toBeInTheDocument();
+
+    await waitFor(() => {
+      expect(screen.getByLabelText('Check-circle')).toBeInTheDocument();
+    });
+
+  });
+});

--- a/src/lib/components/banner/Banner.component.tsx
+++ b/src/lib/components/banner/Banner.component.tsx
@@ -39,14 +39,32 @@ const BannerContainer = styled.div<{ variant: Variant }>`
     border-left: 5px solid;
     border-radius: 3px;
     border-color: ${getThemeVariantSelector()};
-    i {
-      display: flex;
-      align-items: center;
-      margin-left: ${spacing.r8};
-      color: ${getThemeVariantSelector()};
-    }
   `}
 `;
+
+const BannerIconContainerStyled = styled.div<{ variant: Variant }>`
+  ${(props) => css`
+    display: flex;
+    align-items: center;
+    margin-left: ${spacing.r8};
+    color: ${getThemeVariantSelector()};
+  `}
+`;
+
+function BannerIconContainer({
+  variant,
+  children,
+}: {
+  variant: Variant;
+  children: React.ReactNode;
+}) {
+  if (children == null) return null;
+  return (
+    <BannerIconContainerStyled variant={variant}>
+      {children}
+    </BannerIconContainerStyled>
+  );
+}
 
 const TextContainer = styled.div`
   display: flex;
@@ -75,8 +93,8 @@ function Banner({ withDefaultIcon = false, icon, title, children, variant, ...re
         : null;
 
   return (
-    <BannerContainer className="sc-banner" variant={variant}>
-      {iconContent}
+    <BannerContainer variant={variant}>
+      <BannerIconContainer variant={variant}>{iconContent}</BannerIconContainer>
       <TextContainer>
         {title && <Title>{title}</Title>}
         <Text>{children}</Text>

--- a/src/lib/components/banner/Banner.component.tsx
+++ b/src/lib/components/banner/Banner.component.tsx
@@ -1,10 +1,26 @@
 import styled, { css } from 'styled-components';
 import { spacing } from '../../spacing';
 import { fontSize, fontWeight } from '../../style/theme';
-import { getThemeVariantSelector } from '../../utils';
+import { getThemeVariantSelector, getVariantThemeKey } from '../../utils';
 import { Variant } from '../constants';
+import { Icon, type IconName } from '../icon/Icon.component';
+
+const BANNER_ICON_SIZE = 'lg';
+
+const DEFAULT_ICON_BY_VARIANT: Record<Variant, IconName> = {
+  base: 'Info-circle',
+  selected: 'Exclamation-circle',
+  healthy: 'Exclamation-circle',
+  warning: 'Exclamation-circle',
+  danger: 'Exclamation-circle',
+};
 
 export type Props = {
+  /** When true, shows the default icon (Info-circle for base, Exclamation-circle otherwise) with variant color and "lg" size. 
+   * Use icon prop to override the default icon.
+  */
+  withDefaultIcon?: boolean;
+  /** Custom icon element. Overrides withDefaultIcon when provided. */
   icon?: React.ReactNode;
   title?: string;
   children: React.ReactNode;
@@ -44,10 +60,23 @@ const Title = styled.div`
   font-weight: ${fontWeight.bold};
 `;
 
-function Banner({ icon, title, children, variant, ...rest }: Props) {
+function Banner({ withDefaultIcon = false, icon, title, children, variant, ...rest }: Props) {
+  const iconContent =
+    icon !== undefined
+      ? icon
+      : withDefaultIcon
+        ? (
+          <Icon
+            name={DEFAULT_ICON_BY_VARIANT[variant]}
+            size={BANNER_ICON_SIZE}
+            color={getVariantThemeKey(variant)}
+          />
+        )
+        : null;
+
   return (
     <BannerContainer className="sc-banner" variant={variant}>
-      {icon}
+      {iconContent}
       <TextContainer>
         {title && <Title>{title}</Title>}
         <Text>{children}</Text>

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -25,6 +25,10 @@ export const getThemeVariantSelector = () => (props) => {
   return theme[key];
 };
 
+/** Returns the theme color key for a given variant (e.g. for use with Icon color prop). */
+export const getVariantThemeKey = (variant: string): string =>
+  variantMapping[variant] ?? variant;
+
 export const hex2RGB = (str: string): [number, number, number] => {
   const [, short, long] = String(str).match(RGB_HEX) || [];
 

--- a/stories/banner.stories.tsx
+++ b/stories/banner.stories.tsx
@@ -9,22 +9,24 @@ export default {
   component: Banner,
   decorators: [(story) => <Wrapper>{story()}</Wrapper>],
   args: {
-    icon: 'Exclamation-circle',
+    withDefaultIcon: true,
   },
   argTypes: {
+    withDefaultIcon: { control: 'boolean' },
     icon: iconArgType,
   },
 };
 
 export const Playground = {
-  render: ({ icon, variant, children, ...args }) => {
+  render: ({ withDefaultIcon, icon, variant, children, ...args }) => {
     return (
       <Banner
-        icon={icon && <Icon name={icon}></Icon>}
+        withDefaultIcon={withDefaultIcon}
+        icon={icon ? <Icon name={icon} /> : undefined}
         variant={variant}
         children={children}
         {...args}
-      ></Banner>
+      />
     );
   },
   args: {
@@ -35,23 +37,38 @@ export const Playground = {
     variant: { control: { disable: false } },
     title: { control: { disable: false } },
     children: { control: { disable: false } },
+    withDefaultIcon: { control: { disable: false } },
     icon: { control: { disable: false } },
   },
 };
 
+/** No icon. */
 export const Default = {
   ...Playground,
   args: {
     children: 'There is an alert',
     variant: 'base',
+    withDefaultIcon: false,
     icon: undefined,
+  },
+};
+
+/** Simple default: withDefaultIcon + variant. Info-circle for base, Exclamation-circle otherwise. */
+export const WithIcon = {
+  args: {
+    withDefaultIcon: true,
+    variant: 'base',
+    title: 'Info',
+    children: 'Use withDefaultIcon for the default icon (Info-circle on base, Exclamation-circle on warning/danger/etc.).',
   },
 };
 
 export const SuccessBanner = {
   ...Playground,
   args: {
-    variant: 'success',
+    variant: 'healthy',
+    withDefaultIcon: false,
+    icon: 'Check-circle',
     title: 'Success',
     children: 'There is a success',
   },
@@ -60,16 +77,31 @@ export const SuccessBanner = {
 export const WarningBanner = {
   ...Playground,
   args: {
+    withDefaultIcon: true,
     variant: 'warning',
     title: 'Warning',
     children: 'There is a warning',
   },
 };
+
 export const ErrorBanner = {
   ...Playground,
   args: {
+    withDefaultIcon: true,
     variant: 'danger',
     title: 'Error',
     children: 'There is an error',
+  },
+};
+
+/** Custom icon when default (Exclamation-circle / Info-circle) is not desired. */
+export const WithCustomIcon = {
+  ...Playground,
+  args: {
+    variant: 'base',
+    withDefaultIcon: false,
+    icon: 'Exclamation-circle',
+    title: 'Custom',
+    children: 'Use the icon prop when you need a specific icon other than the withDefaultIcon default.',
   },
 };


### PR DESCRIPTION
Proposal to introduce a new prop `withDefaultIcon` for Banner component.
When `withDefaultIcon` is true then it will render either `Exclamation-circle` or `Info-circle` with the variant color and new default icon size in Banner:  'lg'


Why: Icon need to be defined  with correct color, name and size when we want to use a Banner with Icon. Almost all usage of this is `Exclamation-circle` with the variant color of Banner. 
This will simplify the usage of Banner and improve consistency accross all UIs
For specific usage (and backward compatibility) the `icon` prop is kept.

Ref: https://docs.google.com/document/d/1Mtv5SFpai_2FxN-jh00eZ6LShaUoUTZ4-rIDrX90Xnw/edit?tab=t.hvadtzdafoq5#heading=h.jj9tvth74pzr