### PR TITLE
Improvement/misc improvement placeholder line height

### DIFF
--- a/src/lib/components/banner/Banner.component.test.tsx
+++ b/src/lib/components/banner/Banner.component.test.tsx
@@ -1,0 +1,58 @@
+import React from 'react';
+import '@testing-library/jest-dom';
+import { render, screen, waitFor } from '@testing-library/react';
+import { Banner } from './Banner.component';
+import { Icon } from '../icon/Icon.component';
+import { getWrapper } from '../../testUtils';
+
+describe('Banner', () => {
+  const { Wrapper } = getWrapper();
+
+  it('should render with text content', () => {
+    render(
+      <Banner variant="base">Some text content</Banner>,
+      { wrapper: Wrapper }
+    );
+    expect(screen.getByText('Some text content')).toBeInTheDocument();
+  });
+
+  it('should render with title', () => {
+    render(
+      <Banner variant="base" title="My Title">
+        Body text
+      </Banner>,
+      { wrapper: Wrapper }
+    );
+    expect(screen.getByText('My Title')).toBeInTheDocument();
+    expect(screen.getByText('Body text')).toBeInTheDocument();
+  });
+
+  it('should render with default icon when withDefaultIcon is true', async () => {
+    render(
+      <Banner variant="base" withDefaultIcon>
+        Message with default icon
+      </Banner>,
+      { wrapper: Wrapper }
+    );
+    expect(screen.getByText('Message with default icon')).toBeInTheDocument();
+
+    await waitFor(() => {
+      expect(screen.getByLabelText('Info-circle')).toBeInTheDocument();
+    });
+  });
+
+  it('should render with custom icon when icon prop is provided', async () => {
+    render(
+      <Banner variant="danger" icon={<Icon name="Check-circle" />}>
+        Message with custom icon
+      </Banner>,
+      { wrapper: Wrapper }
+    );
+    expect(screen.getByText('Message with custom icon')).toBeInTheDocument();
+
+    await waitFor(() => {
+      expect(screen.getByLabelText('Check-circle')).toBeInTheDocument();
+    });
+
+  });
+});

--- a/src/lib/components/banner/Banner.component.tsx
+++ b/src/lib/components/banner/Banner.component.tsx
@@ -39,14 +39,32 @@ const BannerContainer = styled.div<{ variant: Variant }>`
     border-left: 5px solid;
     border-radius: 3px;
     border-color: ${getThemeVariantSelector()};
-    i {
-      display: flex;
-      align-items: center;
-      margin-left: ${spacing.r8};
-      color: ${getThemeVariantSelector()};
-    }
   `}
 `;
+
+const BannerIconContainerStyled = styled.div<{ variant: Variant }>`
+  ${(props) => css`
+    display: flex;
+    align-items: center;
+    margin-left: ${spacing.r8};
+    color: ${getThemeVariantSelector()};
+  `}
+`;
+
+function BannerIconContainer({
+  variant,
+  children,
+}: {
+  variant: Variant;
+  children: React.ReactNode;
+}) {
+  if (children == null) return null;
+  return (
+    <BannerIconContainerStyled variant={variant}>
+      {children}
+    </BannerIconContainerStyled>
+  );
+}
 
 const TextContainer = styled.div`
   display: flex;
@@ -75,8 +93,8 @@ function Banner({ withDefaultIcon = false, icon, title, children, variant, ...re
         : null;
 
   return (
-    <BannerContainer className="sc-banner" variant={variant}>
-      {iconContent}
+    <BannerContainer variant={variant}>
+      <BannerIconContainer variant={variant}>{iconContent}</BannerIconContainer>
       <TextContainer>
         {title && <Title>{title}</Title>}
         <Text>{children}</Text>

--- a/src/lib/components/banner/Banner.component.tsx
+++ b/src/lib/components/banner/Banner.component.tsx
@@ -1,10 +1,26 @@
 import styled, { css } from 'styled-components';
 import { spacing } from '../../spacing';
 import { fontSize, fontWeight } from '../../style/theme';
-import { getThemeVariantSelector } from '../../utils';
+import { getThemeVariantSelector, getVariantThemeKey } from '../../utils';
 import { Variant } from '../constants';
+import { Icon, type IconName } from '../icon/Icon.component';
+
+const BANNER_ICON_SIZE = 'lg';
+
+const DEFAULT_ICON_BY_VARIANT: Record<Variant, IconName> = {
+  base: 'Info-circle',
+  selected: 'Exclamation-circle',
+  healthy: 'Exclamation-circle',
+  warning: 'Exclamation-circle',
+  danger: 'Exclamation-circle',
+};
 
 export type Props = {
+  /** When true, shows the default icon (Info-circle for base, Exclamation-circle otherwise) with variant color and "lg" size. 
+   * Use icon prop to override the default icon.
+  */
+  withDefaultIcon?: boolean;
+  /** Custom icon element. Overrides withDefaultIcon when provided. */
   icon?: React.ReactNode;
   title?: string;
   children: React.ReactNode;
@@ -44,10 +60,23 @@ const Title = styled.div`
   font-weight: ${fontWeight.bold};
 `;
 
-function Banner({ icon, title, children, variant, ...rest }: Props) {
+function Banner({ withDefaultIcon = false, icon, title, children, variant, ...rest }: Props) {
+  const iconContent =
+    icon !== undefined
+      ? icon
+      : withDefaultIcon
+        ? (
+          <Icon
+            name={DEFAULT_ICON_BY_VARIANT[variant]}
+            size={BANNER_ICON_SIZE}
+            color={getVariantThemeKey(variant)}
+          />
+        )
+        : null;
+
   return (
     <BannerContainer className="sc-banner" variant={variant}>
-      {icon}
+      {iconContent}
       <TextContainer>
         {title && <Title>{title}</Title>}
         <Text>{children}</Text>

--- a/src/lib/components/constrainedtext/Constrainedtext.component.tsx
+++ b/src/lib/components/constrainedtext/Constrainedtext.component.tsx
@@ -32,6 +32,7 @@ const ConstrainedTextContainer = styled.div`
   -webkit-box-orient: vertical;
   overflow-wrap: break-word;
   word-break: normal;
+  line-height: 1.2;
   `
       : `overflow-wrap: break-word;
       white-space: nowrap;

--- a/src/lib/components/form/Form.component.tsx
+++ b/src/lib/components/form/Form.component.tsx
@@ -18,7 +18,7 @@ import { Box } from '../box/Box';
 import { Icon, IconName } from '../icon/Icon.component';
 import { IconHelp } from '../iconhelper/IconHelper';
 import { ScrollbarWrapper } from '../scrollbarwrapper/ScrollbarWrapper.component';
-import { Text } from '../text/Text.component';
+import { HelperText, Text } from '../text/Text.component';
 
 const DESCRIPTION_PREFIX = 'describe-';
 const LABEL_PREFIX = 'label-';
@@ -202,33 +202,19 @@ const FormGroup = ({
         >
           {content}
           {error ? (
-            <Text
-              variant="Smaller"
-              color="statusCritical"
-              isEmphazed
-              id={`${DESCRIPTION_PREFIX}${id}`}
-            >
-              {error}
-            </Text>
+            <HelperText color="statusCritical" id={`${DESCRIPTION_PREFIX}${id}`}>{error}</HelperText>
           ) : help ? (
             <div
               style={{
                 opacity: disabled ? 0.5 : 1,
               }}
             >
-              <Text
-                variant="Smaller"
-                color="textSecondary"
-                isEmphazed
-                id={`${DESCRIPTION_PREFIX}${id}`}
-              >
-                {help}
-              </Text>
+              <HelperText color="textSecondary" id={`${DESCRIPTION_PREFIX}${id}`}>{help}</HelperText>
             </div>
           ) : (
-            <Text variant="Smaller" isEmphazed>
+            <HelperText>
               &nbsp;
-            </Text>
+            </HelperText>
           )}
         </Stack>
       </Box>

--- a/src/lib/components/inputlist/InputList.component.tsx
+++ b/src/lib/components/inputlist/InputList.component.tsx
@@ -1,7 +1,7 @@
 import { HTMLProps, forwardRef } from 'react';
 import { RefCallBack } from 'react-hook-form';
 import { Box } from '../box/Box';
-import { Input } from '../inputv2/inputv2';
+import { Input, InputSize } from '../inputv2/inputv2';
 import { AddButton, SubButton } from './InputButtons';
 
 export type InputListProps<T> = Omit<HTMLProps<HTMLInputElement>, 'size'> & {
@@ -15,6 +15,7 @@ export type InputListProps<T> = Omit<HTMLProps<HTMLInputElement>, 'size'> & {
   disabled?: boolean;
   maxItems?: number;
   value: T[];
+  size?: InputSize;
 };
 
 function InternalInputList<
@@ -33,6 +34,7 @@ function InternalInputList<
     maxItems,
     value,
     name,
+    size = '1/2',
     ...rest
   }: InputListProps<T>,
   _,
@@ -64,7 +66,7 @@ function InternalInputList<
           <Input
             id={`${name}[${index}]`}
             aria-label={`${name}${index}`}
-            size="1/2"
+            size={size}
             value={val}
             onChange={(evt) => {
               const tempValues = [...value];

--- a/src/lib/components/inputv2/inputv2.tsx
+++ b/src/lib/components/inputv2/inputv2.tsx
@@ -81,19 +81,19 @@ const InputBorder = styled.div<{
   height: ${spacing.r32};
   border: ${spacing.r1} solid
     ${(props) =>
-      props.hasError ? props.theme.statusCritical : props.theme.border};
+    props.hasError ? props.theme.statusCritical : props.theme.border};
   border-radius: ${spacing.r4};
   &:hover {
     ${(props) =>
-      !props.disabled &&
-      `border: ${spacing.r1} solid ${props.theme.infoPrimary};`}
+    !props.disabled &&
+    `border: ${spacing.r1} solid ${props.theme.infoPrimary};`}
   }
   &:focus-within {
     border: ${spacing.r1} solid ${(props) => props.theme.infoPrimary};
   }
 `;
 
-const SelfCenterredIcon = styled(Icon)<{ color: keyof CoreUITheme }>`
+const SelfCenterredIcon = styled(Icon) <{ color: keyof CoreUITheme }>`
   align-self: center;
   color: ${(props) => props.theme[props.color]};
 `;
@@ -108,6 +108,7 @@ export type InputProps = {
   rightIcon?: IconName;
   rightIconColor?: keyof CoreUITheme;
   size?: InputSize;
+  noPlaceholderPrefix?: boolean;
 } & Omit<InputHTMLAttributes<HTMLInputElement>, 'size'>;
 
 export const Input = forwardRef<HTMLInputElement, InputProps>(
@@ -122,6 +123,7 @@ export const Input = forwardRef<HTMLInputElement, InputProps>(
       rightIconColor = 'textSecondary',
       placeholder,
       size,
+      noPlaceholderPrefix,
       ...inputProps
     },
     ref,
@@ -131,7 +133,11 @@ export const Input = forwardRef<HTMLInputElement, InputProps>(
       disabled: disabledFromFieldContext,
       error: errorFromFieldContext,
     } = useFieldContext();
-    placeholder = placeholder ? `Example: ${placeholder}` : undefined;
+    placeholder = placeholder
+      ? noPlaceholderPrefix
+        ? placeholder
+        : `Example: ${placeholder}`
+      : undefined;
 
     return (
       <InputBorder

--- a/src/lib/components/searchinput/SearchInput.component.tsx
+++ b/src/lib/components/searchinput/SearchInput.component.tsx
@@ -117,6 +117,7 @@ const SearchInput = forwardRef(
           aria-label="search"
           name="search"
           placeholder={placeholder}
+          noPlaceholderPrefix
           value={debouncedValue}
           onChange={handleChange}
           onReset={reset}

--- a/src/lib/components/searchinput/SearchInput.test.tsx
+++ b/src/lib/components/searchinput/SearchInput.test.tsx
@@ -15,7 +15,7 @@ describe('SearchInput', () => {
     clearButton: () => screen.queryByRole('button'),
   };
   it('should render the SearchInput component', async () => {
-    render(<SearchInputRender value="" onChange={() => {}} />);
+    render(<SearchInputRender value="" onChange={() => { }} />);
     await waitFor(() => screen.queryAllByRole('img', { hidden: true }));
 
     const searchInput = selectors.searchInput();
@@ -24,15 +24,15 @@ describe('SearchInput', () => {
 
   it('should render the SearchInput component with placeholder', () => {
     render(
-      <SearchInputRender value="" onChange={() => {}} placeholder="Search" />,
+      <SearchInputRender value="" onChange={() => { }} placeholder="Search" />,
     );
 
-    const searchInput = screen.queryByPlaceholderText('Example: Search');
+    const searchInput = screen.queryByPlaceholderText('Search');
     expect(searchInput).toBeInTheDocument();
   });
 
   it('should render the SearchInput component with disabled prop', () => {
-    render(<SearchInputRender value="" onChange={() => {}} disabled />);
+    render(<SearchInputRender value="" onChange={() => { }} disabled />);
 
     const searchInput = selectors.searchInput();
     expect(searchInput).toBeInTheDocument();
@@ -55,7 +55,7 @@ describe('SearchInput', () => {
   });
 
   it('should have a clear button when the input is not empty', () => {
-    render(<SearchInputRender value="" onChange={() => {}} />);
+    render(<SearchInputRender value="" onChange={() => { }} />);
 
     // clear button should not be rendered as value is empty
     let clearButton = selectors.clearButton();
@@ -72,7 +72,7 @@ describe('SearchInput', () => {
   it('should call the onReset function when the clear button is clicked and clear the input value', async () => {
     const onReset = jest.fn();
     render(
-      <SearchInputRender value="test" onChange={() => {}} onReset={onReset} />,
+      <SearchInputRender value="test" onChange={() => { }} onReset={onReset} />,
     );
     const searchInput = selectors.searchInput();
     const clearButton = selectors.clearButton();

--- a/src/lib/components/text/Text.component.tsx
+++ b/src/lib/components/text/Text.component.tsx
@@ -16,6 +16,13 @@ type Props = {
   children: React.ReactNode | string;
   status?: Status;
   id?: string;
+} & TextProps;
+type TextProps = {
+  color?: keyof CoreUITheme;
+  variant?: TextVariant;
+  isEmphazed?: boolean;
+  isGentleEmphazed?: boolean;
+  compact?: boolean;
 };
 const BasicTextStyle = styled.span`
   color: ${(props) => props.theme.textPrimary};
@@ -33,7 +40,7 @@ const LargerTextStyle = styled(BasicTextStyle)`
 const EmphaseTextStyle = styled(BasicTextStyle)`
   font-weight: 700;
 `;
-const StatusTextStyle = styled(BasicTextStyle)<{ statusColor: string }>`
+const StatusTextStyle = styled(BasicTextStyle) <{ statusColor: string }>`
   color: ${(props) => props.theme[`${props.statusColor}`]};
 `;
 const LargetStyle = styled(BasicTextStyle)`
@@ -70,7 +77,7 @@ const getStatusColor = (status?: Status) => {
   return statusColor;
 };
 
-export const SmallerEmphaseTextStyle = styled(SmallerTextStyle)<{
+export const SmallerEmphaseTextStyle = styled(SmallerTextStyle) <{
   statusColor: string;
 }>`
   font-weight: 700;
@@ -122,7 +129,7 @@ export function SmallerEmphaseText({ children, status, ...rest }: Props) {
 export function ChartTitleText({ children, ...rest }: Props) {
   return <ChartTitleTextStyle {...rest}>{children}</ChartTitleTextStyle>;
 }
-export const GentleEmphaseSecondaryText = styled(SecondaryText)<{
+export const GentleEmphaseSecondaryText = styled(SecondaryText) <{
   alignRight?: boolean;
 }>`
   font-style: italic;
@@ -135,12 +142,7 @@ export const GentleEmphaseSecondaryText = styled(SecondaryText)<{
       : ''}
 `;
 
-export const Text = styled.span<{
-  variant?: TextVariant;
-  color?: keyof CoreUITheme;
-  isEmphazed?: boolean;
-  isGentleEmphazed?: boolean;
-}>`
+export const Text = styled.span<TextProps>`
   ${(props) => props.color && `color: ${props.theme[props.color]};`}
   ${(props) =>
     props.variant === 'Larger'
@@ -187,8 +189,14 @@ export const Text = styled.span<{
     
   ${(props) =>
     props.variant === 'ChartTitle' && `letter-spacing: ${spacing.r2};`}
-`;
 
+  ${(props) => props.compact && `line-height: 1.2;`}
+`;
+export const HelperText = ({ children, color, ...rest }: Props) => {
+  return (
+    <Text variant="Smaller" isEmphazed compact color={color} {...rest}>{children}</Text>
+  );
+}
 export const Link = styled.a`
   font-size: 1rem;
   line-height: ${spacing.r24};

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -25,6 +25,10 @@ export const getThemeVariantSelector = () => (props) => {
   return theme[key];
 };
 
+/** Returns the theme color key for a given variant (e.g. for use with Icon color prop). */
+export const getVariantThemeKey = (variant: string): string =>
+  variantMapping[variant] ?? variant;
+
 export const hex2RGB = (str: string): [number, number, number] => {
   const [, short, long] = String(str).match(RGB_HEX) || [];
 

--- a/stories/banner.stories.tsx
+++ b/stories/banner.stories.tsx
@@ -9,22 +9,24 @@ export default {
   component: Banner,
   decorators: [(story) => <Wrapper>{story()}</Wrapper>],
   args: {
-    icon: 'Exclamation-circle',
+    withDefaultIcon: true,
   },
   argTypes: {
+    withDefaultIcon: { control: 'boolean' },
     icon: iconArgType,
   },
 };
 
 export const Playground = {
-  render: ({ icon, variant, children, ...args }) => {
+  render: ({ withDefaultIcon, icon, variant, children, ...args }) => {
     return (
       <Banner
-        icon={icon && <Icon name={icon}></Icon>}
+        withDefaultIcon={withDefaultIcon}
+        icon={icon ? <Icon name={icon} /> : undefined}
         variant={variant}
         children={children}
         {...args}
-      ></Banner>
+      />
     );
   },
   args: {
@@ -35,23 +37,38 @@ export const Playground = {
     variant: { control: { disable: false } },
     title: { control: { disable: false } },
     children: { control: { disable: false } },
+    withDefaultIcon: { control: { disable: false } },
     icon: { control: { disable: false } },
   },
 };
 
+/** No icon. */
 export const Default = {
   ...Playground,
   args: {
     children: 'There is an alert',
     variant: 'base',
+    withDefaultIcon: false,
     icon: undefined,
+  },
+};
+
+/** Simple default: withDefaultIcon + variant. Info-circle for base, Exclamation-circle otherwise. */
+export const WithIcon = {
+  args: {
+    withDefaultIcon: true,
+    variant: 'base',
+    title: 'Info',
+    children: 'Use withDefaultIcon for the default icon (Info-circle on base, Exclamation-circle on warning/danger/etc.).',
   },
 };
 
 export const SuccessBanner = {
   ...Playground,
   args: {
-    variant: 'success',
+    variant: 'healthy',
+    withDefaultIcon: false,
+    icon: 'Check-circle',
     title: 'Success',
     children: 'There is a success',
   },
@@ -60,16 +77,31 @@ export const SuccessBanner = {
 export const WarningBanner = {
   ...Playground,
   args: {
+    withDefaultIcon: true,
     variant: 'warning',
     title: 'Warning',
     children: 'There is a warning',
   },
 };
+
 export const ErrorBanner = {
   ...Playground,
   args: {
+    withDefaultIcon: true,
     variant: 'danger',
     title: 'Error',
     children: 'There is an error',
+  },
+};
+
+/** Custom icon when default (Exclamation-circle / Info-circle) is not desired. */
+export const WithCustomIcon = {
+  ...Playground,
+  args: {
+    variant: 'base',
+    withDefaultIcon: false,
+    icon: 'Exclamation-circle',
+    title: 'Custom',
+    children: 'Use the icon prop when you need a specific icon other than the withDefaultIcon default.',
   },
 };

--- a/stories/inputlist.stories.tsx
+++ b/stories/inputlist.stories.tsx
@@ -1,6 +1,6 @@
 import type { Meta, StoryObj } from '@storybook/react';
 import React from 'react';
-import { InputList } from '../src/lib/components/inputlist/InputList.component';
+import { InputList, InputListProps } from '../src/lib/components/inputlist/InputList.component';
 import { Wrapper as StoryWrapper } from './common';
 import { FormSection } from '../src/lib/components/form/Form.component';
 import { Controller, useForm } from 'react-hook-form';
@@ -9,15 +9,27 @@ const meta: Meta<typeof InputList> = {
   tags: ['autodocs'],
   title: 'Components/Inputs/InputList',
   component: InputList,
+  args: {
+    value: [''],
+    size: '1/2',
+  },
+  argTypes: {
+    size: {
+      options: ['1/3', '1/2', '2/3', '1'],
+      control: 'select',
+    },
+  },
 };
 export default meta;
 
+type Story = StoryObj<typeof meta>;
 interface InputListForm {
   firstNames: string[];
   lastNames: string[];
 }
 
-const ExampleList = () => {
+
+const ExampleList = ({ size }: { size?: InputListProps<string>['size'] }) => {
   const { control } = useForm<InputListForm>({
     mode: 'all',
     defaultValues: {
@@ -35,10 +47,11 @@ const ExampleList = () => {
         }}
         render={({ field: { onChange, onBlur, value } }) => (
           <InputList
-            placeholder="First name"
+            placeholder="San Francisco"
             onBlur={onBlur}
             onChange={onChange}
             value={value}
+            size={size}
           />
         )}
         name="firstNames"
@@ -46,12 +59,11 @@ const ExampleList = () => {
     </FormSection>
   );
 };
-type Story = StoryObj<typeof InputList>;
 export const SimpleListOfInputs: Story = {
   name: 'List of inputs',
-  render: () => (
+  render: (args) => (
     <StoryWrapper>
-      <ExampleList />
+      <ExampleList {...args} />
     </StoryWrapper>
   ),
 };


### PR DESCRIPTION
## Misc Improvement

### Placeholder

Placeholder can be too long/not useful. The prefix sometimes unnecessarily extends the placeholder (SearchInput case). Or the input is too small (compared to available place)

- Input has a default prefix for placeholder. We don't want it for SearchInput and possibly others cases but we want it most of the times. Add a props that remove it if needed
- Add size to InputList to be able to handle size. Sometimes placeholder is too long while there is a lot of room for input


### Line-Height

Line height is too big for constrained height container (Table, Select options, etc).
- Add a prop in text to allow the change of line-height. 
For now it is used for helper text but it could be used elsewhere. Create a Text wrapper specific to helper text 
- Change line-height for ConstrainedText on multiple lines



Ref: https://docs.google.com/document/d/1Mtv5SFpai_2FxN-jh00eZ6LShaUoUTZ4-rIDrX90Xnw/edit?tab=t.hvadtzdafoq5#heading=h.gfn68ibob54k