### PR TITLE
Add navbarBackground token for independent navbar theming

### DIFF
--- a/src/lib/components/navbar/Navbar.component.tsx
+++ b/src/lib/components/navbar/Navbar.component.tsx
@@ -43,7 +43,7 @@ const NavbarContainer = styled.div`
   display: flex;
   justify-content: space-between;
   ${css`
-    background-color: ${getThemePropSelector('backgroundLevel1')};
+    background-color: ${getThemePropSelector('navbarBackground')};
     color: ${getThemePropSelector('textPrimary')};
     .fas,
     .sc-trigger-text {
@@ -131,7 +131,7 @@ const NavbarMenuItem = styled.div`
   align-items: center;
   .sc-dropdown {
     .trigger {
-      background-color: ${getThemePropSelector('backgroundLevel1')};
+      background-color: ${getThemePropSelector('navbarBackground')};
       &:hover {
         background-color: ${getThemePropSelector('highlight')};
       }
@@ -148,7 +148,7 @@ const NavbarMenuItem = styled.div`
     border-radius: 0;
     height: ${navbarHeight};
     font-size: ${fontSize.base};
-    background-color: ${getThemePropSelector('backgroundLevel1')};
+    background-color: ${getThemePropSelector('navbarBackground')};
     &:hover {
       background-color: ${getThemePropSelector('highlight')};
     }

--- a/src/lib/style/theme.ts
+++ b/src/lib/style/theme.ts
@@ -49,6 +49,7 @@ export type CoreUITheme = {
   backgroundLevel2: string;
   backgroundLevel3: string;
   backgroundLevel4: string;
+  navbarBackground: string;
   textPrimary: string;
   textSecondary: string;
   textTertiary: string;
@@ -84,6 +85,7 @@ export const coreUIAvailableThemes: Record<CoreUIThemeName, CoreUITheme> = {
     backgroundLevel2: '#323245',
     backgroundLevel3: '#232331',
     backgroundLevel4: '#1B1B27',
+    navbarBackground: '#121219',
     textPrimary: '#EAEAEA',
     textSecondary: '#B5B5B5',
     textTertiary: '#DFDFDF',
@@ -109,6 +111,7 @@ export const coreUIAvailableThemes: Record<CoreUIThemeName, CoreUITheme> = {
     backgroundLevel2: '#F0F0F4',
     backgroundLevel3: '#E4E6EC',
     backgroundLevel4: '#FAFAF6',
+    navbarBackground: '#FCFCFC',
     textPrimary: '#0D0D0D',
     textSecondary: '#4F506D',
     textTertiary: '#DFDFDF', // TO CHECK
@@ -134,6 +137,7 @@ export const coreUIAvailableThemes: Record<CoreUIThemeName, CoreUITheme> = {
     backgroundLevel2: '#272020',
     backgroundLevel3: '#201B1A',
     backgroundLevel4: '#191515',
+    navbarBackground: '#120F0F',
     textPrimary: '#EAEAEA',
     textSecondary: '#A4ACB4',
     textTertiary: '#DFDFDF',
@@ -159,6 +163,7 @@ export const coreUIAvailableThemes: Record<CoreUIThemeName, CoreUITheme> = {
     backgroundLevel2: '#323245',
     backgroundLevel3: '#232331',
     backgroundLevel4: '#1B1B27',
+    navbarBackground: '#121219',
     textPrimary: '#EAEAEA',
     textSecondary: '#B5B5B5',
     textTertiary: '#DFDFDF',


### PR DESCRIPTION
## Overview

This PR introduces a new `navbarBackground` token to the CoreUITheme, enabling independent control of the navigation bar's background color. This is the foundation for simplified white-label branding where customers can customize the navbar color separately from other UI backgrounds.

## What This Brings

Currently, the navbar shares its background color with other Level 1 elements through `backgroundLevel1`. While this works for default themes, it prevents customers from giving the navbar a distinct brand color without affecting the rest of the UI.

The new `navbarBackground` token solves this by:
- Providing dedicated control over navbar background color
- Maintaining complete backward compatibility (defaults to current `backgroundLevel1` values)
- Enabling future branding customization where a customer's brand color can be applied to just the navbar

## What's Next

Phase 2 (in data-browser) will introduce a brand resolution engine that transforms a lightweight branding configuration into a complete theme, using this new token to apply custom navbar colors.

Reference : https://docs.google.com/document/d/1ydlSKnwoQXIF4VhBdl1DJ2qC8XzMCednsCpXCYm6eYk/edit?tab=t.je70ddtye61r#heading=h.umciud4ds9a8