### PR TITLE
feat: auto-derive text contrast color for Button and Navbar

### DIFF
--- a/src/lib/components/buttonv2/Buttonv2.component.tsx
+++ b/src/lib/components/buttonv2/Buttonv2.component.tsx
@@ -2,6 +2,7 @@ import type { ButtonHTMLAttributes } from 'react';
 import styled, { css } from 'styled-components';
 import { spacing } from '../../spacing';
 import { fontSize, fontWeight } from '../../style/theme';
+import { getContrastText } from '../../utils';
 import { Loader } from '../loader/Loader.component';
 import { Tooltip, Props as TooltipProps } from '../tooltip/Tooltip.component';
 
@@ -71,29 +72,31 @@ export const ButtonStyled = styled.button<ButtonStyledProps>`
     const brand = props.theme;
 
     switch (props.variant) {
-      case 'primary':
+      case 'primary': {
+        const primaryTextColor = getContrastText(brand.buttonPrimary) ?? brand.textPrimary;
         return css`
           background: ${brand.buttonPrimary};
           background-clip: padding-box, border-box;
           border: ${spacing.r1} solid transparent;
           border-color: ${brand.buttonPrimary};
-          color: ${brand.textPrimary};
+          color: ${primaryTextColor};
           &:hover:enabled {
             cursor: pointer;
             border: ${spacing.r1} solid ${brand.infoPrimary};
-            color: ${brand.textPrimary};
+            color: ${primaryTextColor};
           }
           // :focus-visible is the keyboard-only version of :focus
           &:focus-visible:enabled {
             ${FocusVisibleStyle}
-            color: ${brand.textPrimary};
+            color: ${primaryTextColor};
           }
           &:active:enabled {
             cursor: pointer;
-            color: ${brand.textPrimary};
+            color: ${primaryTextColor};
             border: ${spacing.r1} solid ${brand.infoSecondary};
           }
         `;
+      }
 
       case 'secondary':
         return css`

--- a/src/lib/components/buttonv2/Buttonv2.component.tsx
+++ b/src/lib/components/buttonv2/Buttonv2.component.tsx
@@ -73,7 +73,7 @@ export const ButtonStyled = styled.button<ButtonStyledProps>`
 
     switch (props.variant) {
       case 'primary': {
-        const primaryTextColor = getContrastText(brand.buttonPrimary) ?? brand.textPrimary;
+        const primaryTextColor = getContrastText(brand.buttonPrimary, brand.textPrimary, brand.textReverse) ?? brand.textPrimary;
         return css`
           background: ${brand.buttonPrimary};
           background-clip: padding-box, border-box;

--- a/src/lib/components/navbar/Navbar.component.tsx
+++ b/src/lib/components/navbar/Navbar.component.tsx
@@ -39,7 +39,7 @@ export type Props = {
   tabs?: Array<Tab>;
 };
 const getNavbarTextColor = (props) =>
-  getContrastText(props.theme.navbarBackground) ?? props.theme.textPrimary;
+  getContrastText(props.theme.navbarBackground, props.theme.textPrimary, props.theme.textReverse) ?? props.theme.textPrimary;
 
 const NavbarContainer = styled.div`
   height: ${navbarHeight};
@@ -79,7 +79,7 @@ const NavbarTabs = styled.div`
     border-top: ${spacing.r2} solid transparent;
     ${(props) => {
       const { selectedActive } = props.theme;
-      const navTextColor = getContrastText(props.theme.navbarBackground) ?? props.theme.textPrimary;
+      const navTextColor = getContrastText(props.theme.navbarBackground, props.theme.textPrimary, props.theme.textReverse) ?? props.theme.textPrimary;
       return css`
         color: ${navTextColor};
         &:hover {
@@ -107,7 +107,7 @@ const TabItem = styled.div<{ selected: boolean }>`
   align-items: center;
   padding: 0 ${spacing.r16};
   ${(props) => {
-    const navTextColor = getContrastText(props.theme.navbarBackground) ?? props.theme.textPrimary;
+    const navTextColor = getContrastText(props.theme.navbarBackground, props.theme.textPrimary, props.theme.textReverse) ?? props.theme.textPrimary;
     return css`
       color: ${navTextColor};
       &:hover {
@@ -153,14 +153,14 @@ const NavbarMenuItem = styled.div`
     height: ${navbarHeight};
     font-size: ${fontSize.base};
     background-color: ${getThemePropSelector('navbarBackground')};
-    color: ${(props) => getContrastText(props.theme.navbarBackground) ?? props.theme.textPrimary};
+    color: ${(props) => getContrastText(props.theme.navbarBackground, props.theme.textPrimary, props.theme.textReverse) ?? props.theme.textPrimary};
     &:hover {
       background-color: ${getThemePropSelector('highlight')};
     }
     // :focus-visible is the keyboard-only version of :focus
     &:focus-visible {
       ${FocusVisibleStyle}
-      color: ${(props) => getContrastText(props.theme.navbarBackground) ?? props.theme.textPrimary};
+      color: ${(props) => getContrastText(props.theme.navbarBackground, props.theme.textPrimary, props.theme.textReverse) ?? props.theme.textPrimary};
     }
     width: ${navbarItemWidth};
   }

--- a/src/lib/components/navbar/Navbar.component.tsx
+++ b/src/lib/components/navbar/Navbar.component.tsx
@@ -3,7 +3,7 @@ import styled, { css } from 'styled-components';
 import { Logo } from '../../icons/branding';
 import { spacing } from '../../spacing';
 import { fontSize, navbarHeight, navbarItemWidth } from '../../style/theme';
-import { getThemePropSelector } from '../../utils';
+import { getContrastText, getThemePropSelector } from '../../utils';
 import { Dropdown, type Item } from '../dropdown/Dropdown.component';
 import { Icon } from '../icon/Icon.component';
 import { Button, FocusVisibleStyle, type Props as ButtonProps } from '../buttonv2/Buttonv2.component';
@@ -38,16 +38,19 @@ export type Props = {
   logo?: JSX.Element;
   tabs?: Array<Tab>;
 };
+const getNavbarTextColor = (props) =>
+  getContrastText(props.theme.navbarBackground) ?? props.theme.textPrimary;
+
 const NavbarContainer = styled.div`
   height: ${navbarHeight};
   display: flex;
   justify-content: space-between;
   ${css`
     background-color: ${getThemePropSelector('navbarBackground')};
-    color: ${getThemePropSelector('textPrimary')};
+    color: ${getNavbarTextColor};
     .fas,
     .sc-trigger-text {
-      color: ${getThemePropSelector('textPrimary')};
+      color: ${getNavbarTextColor};
     }
     box-sizing: border-box;
     border-bottom: 0.5px solid ${(props) => props.theme.backgroundLevel2};
@@ -76,20 +79,21 @@ const NavbarTabs = styled.div`
     border-top: ${spacing.r2} solid transparent;
     ${(props) => {
       const { selectedActive } = props.theme;
+      const navTextColor = getContrastText(props.theme.navbarBackground) ?? props.theme.textPrimary;
       return css`
-        color: ${getThemePropSelector('textPrimary')};
+        color: ${navTextColor};
         &:hover {
           background-color: ${getThemePropSelector('highlight')};
         }
         &.selected {
-          color: ${getThemePropSelector('textPrimary')};
+          color: ${navTextColor};
           font-weight: bold;
           border-bottom-color: ${selectedActive};
         }
         // :focus-visible is the keyboard-only version of :focus
         &:focus-visible {
           ${FocusVisibleStyle}
-          color: ${props.theme.textPrimary};
+          color: ${navTextColor};
         }
       `;
     }};
@@ -103,9 +107,9 @@ const TabItem = styled.div<{ selected: boolean }>`
   align-items: center;
   padding: 0 ${spacing.r16};
   ${(props) => {
-    const { textPrimary } = props.theme;
+    const navTextColor = getContrastText(props.theme.navbarBackground) ?? props.theme.textPrimary;
     return css`
-      color: ${textPrimary};
+      color: ${navTextColor};
       &:hover {
         border-bottom: ${spacing.r2} solid;
         border-top: ${spacing.r2} solid;
@@ -114,7 +118,7 @@ const TabItem = styled.div<{ selected: boolean }>`
       // :focus-visible is the keyboard-only version of :focus
       &:focus-visible {
         ${FocusVisibleStyle}
-        color: ${props.theme.textPrimary};
+        color: ${navTextColor};
       }
     `;
   }};
@@ -149,13 +153,14 @@ const NavbarMenuItem = styled.div`
     height: ${navbarHeight};
     font-size: ${fontSize.base};
     background-color: ${getThemePropSelector('navbarBackground')};
+    color: ${(props) => getContrastText(props.theme.navbarBackground) ?? props.theme.textPrimary};
     &:hover {
       background-color: ${getThemePropSelector('highlight')};
     }
     // :focus-visible is the keyboard-only version of :focus
     &:focus-visible {
       ${FocusVisibleStyle}
-      color: ${(props) => props.theme.textPrimary};
+      color: ${(props) => getContrastText(props.theme.navbarBackground) ?? props.theme.textPrimary};
     }
     width: ${navbarItemWidth};
   }

--- a/src/lib/utils.test.ts
+++ b/src/lib/utils.test.ts
@@ -1,42 +1,48 @@
 import { getContrastText } from './utils';
 
+const LIGHT_TEXT = '#EAEAEA';
+const DARK_TEXT = '#000000';
+
 describe('getContrastText', () => {
-  it('returns white text for dark backgrounds', () => {
-    expect(getContrastText('#000000')).toBe('#FFFFFF');
-    expect(getContrastText('#1A1A1A')).toBe('#FFFFFF');
-    expect(getContrastText('#121219')).toBe('#FFFFFF'); // darkRebrand navbarBackground
-    expect(getContrastText('#2F4185')).toBe('#FFFFFF'); // darkRebrand buttonPrimary
+  it('returns textPrimary on dark backgrounds when textPrimary is light', () => {
+    expect(getContrastText('#000000', LIGHT_TEXT, DARK_TEXT)).toBe(LIGHT_TEXT);
+    expect(getContrastText('#1A1A1A', LIGHT_TEXT, DARK_TEXT)).toBe(LIGHT_TEXT);
+    expect(getContrastText('#121219', LIGHT_TEXT, DARK_TEXT)).toBe(LIGHT_TEXT);
+    expect(getContrastText('#2F4185', LIGHT_TEXT, DARK_TEXT)).toBe(LIGHT_TEXT);
   });
 
-  it('returns black text for light backgrounds', () => {
-    expect(getContrastText('#FFFFFF')).toBe('#000000');
-    expect(getContrastText('#F5F5F5')).toBe('#000000'); // light brandSecondary
-    expect(getContrastText('#FCFCFC')).toBe('#000000'); // artescaLight navbarBackground
-    expect(getContrastText('#ABB4F5')).toBe('#000000'); // artescaLight buttonPrimary
+  it('returns textReverse on light backgrounds when textPrimary is light', () => {
+    expect(getContrastText('#FFFFFF', LIGHT_TEXT, DARK_TEXT)).toBe(DARK_TEXT);
+    expect(getContrastText('#F5F5F5', LIGHT_TEXT, DARK_TEXT)).toBe(DARK_TEXT);
+    expect(getContrastText('#FCFCFC', LIGHT_TEXT, DARK_TEXT)).toBe(DARK_TEXT);
   });
 
-  it('returns white text for SG red (#E9041E)', () => {
-    expect(getContrastText('#E9041E')).toBe('#FFFFFF');
+  it('picks the text color with better contrast against a vivid background', () => {
+    expect(getContrastText('#E9041E', LIGHT_TEXT, DARK_TEXT)).toBe(DARK_TEXT);
+    expect(getContrastText('#E9041E', '#FFFFFF', '#000000')).toBe('#FFFFFF');
   });
 
   it('handles 3-character hex shorthand', () => {
-    expect(getContrastText('#FFF')).toBe('#000000');
-    expect(getContrastText('#000')).toBe('#FFFFFF');
+    expect(getContrastText('#FFF', LIGHT_TEXT, DARK_TEXT)).toBe(DARK_TEXT);
+    expect(getContrastText('#000', LIGHT_TEXT, DARK_TEXT)).toBe(LIGHT_TEXT);
   });
 
   it('handles hex without # prefix', () => {
-    expect(getContrastText('000000')).toBe('#FFFFFF');
-    expect(getContrastText('FFFFFF')).toBe('#000000');
+    expect(getContrastText('000000', LIGHT_TEXT, DARK_TEXT)).toBe(LIGHT_TEXT);
+    expect(getContrastText('FFFFFF', LIGHT_TEXT, DARK_TEXT)).toBe(DARK_TEXT);
   });
 
-  it('returns null for CSS gradients', () => {
+  it('returns null for non-hex values', () => {
     expect(
-      getContrastText('linear-gradient(130deg, #9355E7 0%, #2E4AA3 60%)'),
+      getContrastText(
+        'linear-gradient(130deg, #9355E7 0%, #2E4AA3 60%)',
+        LIGHT_TEXT,
+        DARK_TEXT,
+      ),
     ).toBeNull();
-  });
-
-  it('returns null for invalid color strings', () => {
-    expect(getContrastText('not-a-color')).toBeNull();
-    expect(getContrastText('rgb(255, 0, 0)')).toBeNull();
+    expect(getContrastText('not-a-color', LIGHT_TEXT, DARK_TEXT)).toBeNull();
+    expect(
+      getContrastText('rgb(255, 0, 0)', LIGHT_TEXT, DARK_TEXT),
+    ).toBeNull();
   });
 });

--- a/src/lib/utils.test.ts
+++ b/src/lib/utils.test.ts
@@ -1,0 +1,42 @@
+import { getContrastText } from './utils';
+
+describe('getContrastText', () => {
+  it('returns white text for dark backgrounds', () => {
+    expect(getContrastText('#000000')).toBe('#FFFFFF');
+    expect(getContrastText('#1A1A1A')).toBe('#FFFFFF');
+    expect(getContrastText('#121219')).toBe('#FFFFFF'); // darkRebrand navbarBackground
+    expect(getContrastText('#2F4185')).toBe('#FFFFFF'); // darkRebrand buttonPrimary
+  });
+
+  it('returns black text for light backgrounds', () => {
+    expect(getContrastText('#FFFFFF')).toBe('#000000');
+    expect(getContrastText('#F5F5F5')).toBe('#000000'); // light brandSecondary
+    expect(getContrastText('#FCFCFC')).toBe('#000000'); // artescaLight navbarBackground
+    expect(getContrastText('#ABB4F5')).toBe('#000000'); // artescaLight buttonPrimary
+  });
+
+  it('returns white text for SG red (#E9041E)', () => {
+    expect(getContrastText('#E9041E')).toBe('#FFFFFF');
+  });
+
+  it('handles 3-character hex shorthand', () => {
+    expect(getContrastText('#FFF')).toBe('#000000');
+    expect(getContrastText('#000')).toBe('#FFFFFF');
+  });
+
+  it('handles hex without # prefix', () => {
+    expect(getContrastText('000000')).toBe('#FFFFFF');
+    expect(getContrastText('FFFFFF')).toBe('#000000');
+  });
+
+  it('returns null for CSS gradients', () => {
+    expect(
+      getContrastText('linear-gradient(130deg, #9355E7 0%, #2E4AA3 60%)'),
+    ).toBeNull();
+  });
+
+  it('returns null for invalid color strings', () => {
+    expect(getContrastText('not-a-color')).toBeNull();
+    expect(getContrastText('rgb(255, 0, 0)')).toBeNull();
+  });
+});

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -45,9 +45,7 @@ export const hex2RGB = (str: string): [number, number, number] => {
   throw new Error('Invalid hex string provided');
 };
 
-/**
- * Returns the relative luminance of an sRGB color (WCAG 2.0 formula).
- */
+// WCAG 2.0 relative luminance
 const relativeLuminance = (r: number, g: number, b: number): number => {
   const [rs, gs, bs] = [r, g, b].map((c) => {
     const s = c / 255;
@@ -56,27 +54,24 @@ const relativeLuminance = (r: number, g: number, b: number): number => {
   return 0.2126 * rs + 0.7152 * gs + 0.0722 * bs;
 };
 
-/**
- * Returns the WCAG contrast ratio between two relative luminances.
- */
-const contrastRatio = (l1: number, l2: number): number => {
-  const lighter = Math.max(l1, l2);
-  const darker = Math.min(l1, l2);
-  return (lighter + 0.05) / (darker + 0.05);
+const wcagContrastRatio = (l1: number, l2: number): number =>
+  (Math.max(l1, l2) + 0.05) / (Math.min(l1, l2) + 0.05);
+
+const luminanceOf = (hex: string): number => {
+  const [r, g, b] = hex2RGB(hex);
+  return relativeLuminance(r, g, b);
 };
 
-/**
- * Returns '#FFFFFF' or '#000000' depending on which has better contrast
- * against the given background color. Returns null if the value is not
- * a valid hex color (e.g. CSS gradients).
- */
-export const getContrastText = (bgColor: string): string | null => {
+export const getContrastText = (
+  bgColor: string,
+  textPrimary: string,
+  textReverse: string,
+): string | null => {
   try {
-    const [r, g, b] = hex2RGB(bgColor);
-    const bgLuminance = relativeLuminance(r, g, b);
-    const whiteContrast = contrastRatio(1, bgLuminance);
-    const blackContrast = contrastRatio(bgLuminance, 0);
-    return whiteContrast >= blackContrast ? '#FFFFFF' : '#000000';
+    const bgLum = luminanceOf(bgColor);
+    const primaryContrast = wcagContrastRatio(luminanceOf(textPrimary), bgLum);
+    const reverseContrast = wcagContrastRatio(luminanceOf(textReverse), bgLum);
+    return reverseContrast > primaryContrast ? textReverse : textPrimary;
   } catch {
     return null;
   }

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -45,6 +45,43 @@ export const hex2RGB = (str: string): [number, number, number] => {
   throw new Error('Invalid hex string provided');
 };
 
+/**
+ * Returns the relative luminance of an sRGB color (WCAG 2.0 formula).
+ */
+const relativeLuminance = (r: number, g: number, b: number): number => {
+  const [rs, gs, bs] = [r, g, b].map((c) => {
+    const s = c / 255;
+    return s <= 0.03928 ? s / 12.92 : ((s + 0.055) / 1.055) ** 2.4;
+  });
+  return 0.2126 * rs + 0.7152 * gs + 0.0722 * bs;
+};
+
+/**
+ * Returns the WCAG contrast ratio between two relative luminances.
+ */
+const contrastRatio = (l1: number, l2: number): number => {
+  const lighter = Math.max(l1, l2);
+  const darker = Math.min(l1, l2);
+  return (lighter + 0.05) / (darker + 0.05);
+};
+
+/**
+ * Returns '#FFFFFF' or '#000000' depending on which has better contrast
+ * against the given background color. Returns null if the value is not
+ * a valid hex color (e.g. CSS gradients).
+ */
+export const getContrastText = (bgColor: string): string | null => {
+  try {
+    const [r, g, b] = hex2RGB(bgColor);
+    const bgLuminance = relativeLuminance(r, g, b);
+    const whiteContrast = contrastRatio(1, bgLuminance);
+    const blackContrast = contrastRatio(bgLuminance, 0);
+    return whiteContrast >= blackContrast ? '#FFFFFF' : '#000000';
+  } catch {
+    return null;
+  }
+};
+
 export const convertRemToPixels = (rem: number): number => {
   if (
     document.documentElement &&


### PR DESCRIPTION
## Summary

When consumers apply custom branding colors (e.g. a dark navbar on a light theme), text can become unreadable because it doesn't adapt to the background it sits on.

This PR makes the **Button** (primary variant) and **Navbar** components automatically choose between white or black text based on their background color, using WCAG contrast ratio calculation.

- No new tokens, no API changes, no consumer configuration needed
- Existing themes render identically


Relates to [CUI-3](https://scality.atlassian.net/browse/CUI-3)

Check this for the [WCAG formula](https://www.neilbickford.com/blog/2020/10/18/computing-wcag-contrast-ratios/)

[CUI-3]: https://scality.atlassian.net/browse/CUI-3?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ