### PR TITLE
CUI-5: Prevent Select from triggering implicit form submission on Enter

### DIFF
--- a/src/lib/components/form/Form.component.tsx
+++ b/src/lib/components/form/Form.component.tsx
@@ -4,7 +4,6 @@ import {
   FormHTMLAttributes,
   forwardRef,
   isValidElement,
-  KeyboardEvent,
   ReactElement,
   ReactNode,
   useContext,
@@ -272,22 +271,6 @@ const FormSection = ({
   );
 };
 
-const TEXT_INPUT_TYPES = ['text', 'search', 'url', 'tel', 'password', 'email', 'number'];
-
-const preventImplicitSubmission = (
-  event: KeyboardEvent<HTMLFormElement>,
-) => {
-  if (event.key !== 'Enter') return;
-  const target = event.target as HTMLElement;
-  const isTextInput =
-    target instanceof HTMLInputElement &&
-    TEXT_INPUT_TYPES.includes(target.type) &&
-    !target.readOnly;
-  if (!isTextInput && !(target instanceof HTMLButtonElement)) {
-    event.preventDefault();
-  }
-};
-
 const PageForm = forwardRef<HTMLFormElement, PageFormProps>(
   (
     { layout, leftActions, rightActions, children, banner, ...formProps },
@@ -296,16 +279,7 @@ const PageForm = forwardRef<HTMLFormElement, PageFormProps>(
     const requireMode = useContext(RequireModeContext);
     return (
       <ScrollbarWrapper>
-        <StyledForm
-          {...formProps}
-          onKeyDown={(event) => {
-            preventImplicitSubmission(event);
-            formProps.onKeyDown?.(event);
-          }}
-          noValidate
-          ref={ref}
-          layout={layout}
-        >
+        <StyledForm {...formProps} noValidate ref={ref} layout={layout}>
           <FixedHeader layoutKind="page">
             <PaddedForHeaderAndFooterContent>
               <Wrap>
@@ -369,15 +343,7 @@ const TabForm = forwardRef<HTMLFormElement, TabFormProps>(
   ({ leftActions, rightActions, children, banner, ...formProps }, ref) => {
     return (
       <ScrollbarWrapper>
-        <StyledForm
-          {...formProps}
-          onKeyDown={(event) => {
-            preventImplicitSubmission(event);
-            formProps.onKeyDown?.(event);
-          }}
-          noValidate
-          ref={ref}
-        >
+        <StyledForm {...formProps} noValidate ref={ref}>
           <FixedHeader layoutKind="tab">
             <Wrap>
               <div>{leftActions}</div>

--- a/src/lib/components/form/Form.component.tsx
+++ b/src/lib/components/form/Form.component.tsx
@@ -4,6 +4,7 @@ import {
   FormHTMLAttributes,
   forwardRef,
   isValidElement,
+  KeyboardEvent,
   ReactElement,
   ReactNode,
   useContext,
@@ -271,6 +272,22 @@ const FormSection = ({
   );
 };
 
+const TEXT_INPUT_TYPES = ['text', 'search', 'url', 'tel', 'password', 'email', 'number'];
+
+const preventImplicitSubmission = (
+  event: KeyboardEvent<HTMLFormElement>,
+) => {
+  if (event.key !== 'Enter') return;
+  const target = event.target as HTMLElement;
+  const isTextInput =
+    target instanceof HTMLInputElement &&
+    TEXT_INPUT_TYPES.includes(target.type) &&
+    !target.readOnly;
+  if (!isTextInput && !(target instanceof HTMLButtonElement)) {
+    event.preventDefault();
+  }
+};
+
 const PageForm = forwardRef<HTMLFormElement, PageFormProps>(
   (
     { layout, leftActions, rightActions, children, banner, ...formProps },
@@ -279,7 +296,16 @@ const PageForm = forwardRef<HTMLFormElement, PageFormProps>(
     const requireMode = useContext(RequireModeContext);
     return (
       <ScrollbarWrapper>
-        <StyledForm {...formProps} noValidate ref={ref} layout={layout}>
+        <StyledForm
+          {...formProps}
+          onKeyDown={(event) => {
+            preventImplicitSubmission(event);
+            formProps.onKeyDown?.(event);
+          }}
+          noValidate
+          ref={ref}
+          layout={layout}
+        >
           <FixedHeader layoutKind="page">
             <PaddedForHeaderAndFooterContent>
               <Wrap>
@@ -343,7 +369,15 @@ const TabForm = forwardRef<HTMLFormElement, TabFormProps>(
   ({ leftActions, rightActions, children, banner, ...formProps }, ref) => {
     return (
       <ScrollbarWrapper>
-        <StyledForm {...formProps} noValidate ref={ref}>
+        <StyledForm
+          {...formProps}
+          onKeyDown={(event) => {
+            preventImplicitSubmission(event);
+            formProps.onKeyDown?.(event);
+          }}
+          noValidate
+          ref={ref}
+        >
           <FixedHeader layoutKind="tab">
             <Wrap>
               <div>{leftActions}</div>

--- a/src/lib/components/form/Form.test.tsx
+++ b/src/lib/components/form/Form.test.tsx
@@ -1,50 +1,9 @@
-import { act, screen, render, waitFor } from '@testing-library/react';
+import { act, screen, render } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import React from 'react';
 import { Form, FormSection, FormGroup } from './Form.component';
-import { Select } from '../selectv2/Selectv2.component';
-
-const SelectWrapper = ({
-  value,
-  onChange,
-}: {
-  value: string;
-  onChange: (v: string) => void;
-}) => (
-  <Select value={value} onChange={onChange}>
-    <Select.Option value="a">Option A</Select.Option>
-    <Select.Option value="b">Option B</Select.Option>
-  </Select>
-);
 
 describe('Form', () => {
-  it('should not submit when pressing Enter on a Select element', async () => {
-    const onSubmit = jest.fn((e) => e.preventDefault());
-    render(
-      <Form
-        layout={{ kind: 'page', title: 'Test Form' }}
-        onSubmit={onSubmit}
-        rightActions={
-          <button type="submit">Submit</button>
-        }
-      >
-        <FormSection>
-          <FormGroup
-            id="select-field"
-            label="Pick one"
-            content={<SelectWrapper value="" onChange={() => {}} />}
-          />
-        </FormSection>
-      </Form>,
-    );
-    await waitFor(() => screen.queryAllByRole('img', { hidden: true }));
-
-    userEvent.tab();
-    await act(() => userEvent.keyboard('{Enter}'));
-
-    expect(onSubmit).not.toHaveBeenCalled();
-  });
-
   it('should submit when pressing Enter on a text input', async () => {
     const onSubmit = jest.fn((e) => e.preventDefault());
     render(

--- a/src/lib/components/form/Form.test.tsx
+++ b/src/lib/components/form/Form.test.tsx
@@ -1,0 +1,74 @@
+import { act, screen, render, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import React from 'react';
+import { Form, FormSection, FormGroup } from './Form.component';
+import { Select } from '../selectv2/Selectv2.component';
+
+const SelectWrapper = ({
+  value,
+  onChange,
+}: {
+  value: string;
+  onChange: (v: string) => void;
+}) => (
+  <Select value={value} onChange={onChange}>
+    <Select.Option value="a">Option A</Select.Option>
+    <Select.Option value="b">Option B</Select.Option>
+  </Select>
+);
+
+describe('Form', () => {
+  it('should not submit when pressing Enter on a Select element', async () => {
+    const onSubmit = jest.fn((e) => e.preventDefault());
+    render(
+      <Form
+        layout={{ kind: 'page', title: 'Test Form' }}
+        onSubmit={onSubmit}
+        rightActions={
+          <button type="submit">Submit</button>
+        }
+      >
+        <FormSection>
+          <FormGroup
+            id="select-field"
+            label="Pick one"
+            content={<SelectWrapper value="" onChange={() => {}} />}
+          />
+        </FormSection>
+      </Form>,
+    );
+    await waitFor(() => screen.queryAllByRole('img', { hidden: true }));
+
+    userEvent.tab();
+    await act(() => userEvent.keyboard('{Enter}'));
+
+    expect(onSubmit).not.toHaveBeenCalled();
+  });
+
+  it('should submit when pressing Enter on a text input', async () => {
+    const onSubmit = jest.fn((e) => e.preventDefault());
+    render(
+      <Form
+        layout={{ kind: 'page', title: 'Test Form' }}
+        onSubmit={onSubmit}
+        rightActions={
+          <button type="submit">Submit</button>
+        }
+      >
+        <FormSection>
+          <FormGroup
+            id="text-field"
+            label="Name"
+            content={<input type="text" id="text-field" />}
+          />
+        </FormSection>
+      </Form>,
+    );
+
+    const input = screen.getByRole('textbox');
+    await act(() => userEvent.click(input));
+    await act(() => userEvent.keyboard('{Enter}'));
+
+    expect(onSubmit).toHaveBeenCalled();
+  });
+});

--- a/src/lib/components/selectv2/Selectv2.component.tsx
+++ b/src/lib/components/selectv2/Selectv2.component.tsx
@@ -503,7 +503,15 @@ function SelectBox<
 
   return (
     <ScrollbarWrapper>
-      <>
+      {/* Consume Enter so react-select (which renders a real <input>) doesn't
+          trigger the browser's implicit <form> submission. display:contents
+          keeps this wrapper out of layout — no box, no width/flex impact. */}
+      <div
+        style={{ display: 'contents' }}
+        onKeyDown={(event) => {
+          if (event.key === 'Enter') event.preventDefault();
+        }}
+      >
         {options && (
           <SelectStyle
             inputId={id}
@@ -558,7 +566,7 @@ function SelectBox<
             {...rest}
           />
         )}
-      </>
+      </div>
     </ScrollbarWrapper>
   );
 }

--- a/src/lib/components/selectv2/selectv2.test.tsx
+++ b/src/lib/components/selectv2/selectv2.test.tsx
@@ -220,6 +220,43 @@ describe('SelectV2', () => {
     expect(select).toHaveTextContent('Item 1');
   });
 
+  it('should not trigger implicit form submission when Enter is pressed on a closed Select', async () => {
+    const onSubmit = jest.fn((e) => e.preventDefault());
+    render(
+      <form onSubmit={onSubmit}>
+        <SelectWrapper />
+        <button type="submit">Submit</button>
+      </form>,
+    );
+    await waitFor(() => screen.queryAllByRole('img', { hidden: true }));
+
+    userEvent.tab();
+    await act(() => userEvent.keyboard('{Enter}'));
+
+    expect(onSubmit).not.toHaveBeenCalled();
+  });
+
+  it('should not trigger implicit form submission when Enter is pressed on a searchable Select', async () => {
+    const onSubmit = jest.fn((e) => e.preventDefault());
+    render(
+      <form onSubmit={onSubmit}>
+        <SelectWrapper>{optionsWithScrollSearchBar}</SelectWrapper>
+        <button type="submit">Submit</button>
+      </form>,
+    );
+    await waitFor(() => screen.queryAllByRole('img', { hidden: true }));
+
+    const select = selectors.select(true);
+    await act(() => userEvent.click(select));
+    const input = selectors.input();
+    await act(() => userEvent.type(input, 'Item 9'));
+    await act(() => userEvent.keyboard('{Enter}'));
+
+    // Enter still selects the highlighted option, it just doesn't submit the form
+    expect(select).toHaveTextContent('Item 9');
+    expect(onSubmit).not.toHaveBeenCalled();
+  });
+
   it('should scroll to selected value when opening select', async () => {
     render(
       <SelectWrapper value={optionsWithScrollSearchBar[9].props.value}>


### PR DESCRIPTION
## TL;DR

Pressing **Enter** on a `Select` inside any `<form>` no longer submits the form. The Select widget now consumes Enter itself — matching the WAI-ARIA combobox pattern — so the fix works in every `<form>`, not just core-ui's own `<Form>`.

## Context

`CUI-5`: pressing Enter on a `Select` triggered the browser's implicit form submission. Most visible on a **searchable** Select (>8 options) — pressing Enter in its search input submitted the form whenever the query was empty or matched no option, instead of staying inside the combobox.

## Approach

**Root cause.** react-select renders a real `<input>`; the browser's [implicit submission](https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#implicit-submission) treats it like any text field and submits the enclosing `<form>` on Enter whenever react-select doesn't consume Enter itself (menu closed, or search field with no highlighted option).

**The fix** — wrap react-select in a zero-layout `display: contents` div and swallow Enter's default action on the **bubble** phase, after react-select has already done its own work:

```tsx
<div
  style={{ display: 'contents' }}                        // ← no layout box: zero width/flex/margin impact
  onKeyDown={(event) => {
    if (event.key === 'Enter') event.preventDefault();   // ← kills implicit submit, not react-select's own handling
  }}
>
  <ReactSelect ... />
</div>
```

Belongs in the widget, not the form: a combobox owns its keyboard behaviour ([WAI-ARIA combobox pattern](https://www.w3.org/WAI/ARIA/apg/patterns/combobox/)), and a form-level fix would only work inside core-ui's own `<Form>` — not when a consumer wraps the Select in their own `<form>`. See the alternatives below.

**Alternatives considered:**

| Approach | Why rejected |
| --- | --- |
| Form-level handler with a text-input whitelist | Only blocked Enter on readonly inputs, so a **searchable** Select still submitted; and did nothing inside a consumer's own `<form>`. Flagged in review ([discussion](https://github.com/scality/core-ui/pull/1014#discussion_r2857815199)). |
| `preventDefault()` inside react-select's `onKeyDown` prop | react-select [checks `event.defaultPrevented`](https://github.com/jedwatson/react-select/blob/v3.2.0/packages/react-select/src/Select.js#L1237-L1241) and skips *all* keyboard handling if set — breaks menu open / option select. |
| `stopPropagation()` inside react-select's `onKeyDown` prop | Implicit submission is a browser default action, not event bubbling — `stopPropagation()` cannot prevent it. |

## Review focus

- 🟡 **`selectv2/Selectv2.component.tsx › SelectBox`** — Enter is now consumed for *every* Select in every consuming app. This is spec-correct (a combobox shouldn't submit its form), but it is a behaviour change: confirm no flow relied on Enter-to-submit while a Select was focused. The bubble-phase `preventDefault()` leaves react-select's own selection intact (verified by the searchable test).
- ⚪ **`selectv2/selectv2.test.tsx`** — two regression tests (closed Select, searchable Select); the searchable one also asserts Enter still *selects* the highlighted option.
- ⚪ **`form/Form.test.tsx`** — guards the opposite contract: a plain text input inside `<Form>` still submits on Enter.

## How to test

1. Render a `Select` inside a `<form>` with a `type="submit"` button (Storybook: `npm run storybook`, then a Select story wrapped in a form).
2. **Non-searchable** (≤8 options): focus the Select, press **Enter** → menu opens, **form does not submit**.
3. **Searchable** (>8 options): open it, type a query (including an empty / no-match query), press **Enter** → highlighted option is selected (or nothing, if none), **form does not submit**.
4. **Regression:** a plain `<input type="text">` in the same form → **Enter still submits**.

## References

- **[CUI-5](https://scality.atlassian.net/browse/CUI-5)** — Bug: Enter on a Select's search input submits the form when the query is empty or matches no option.
- **[Review discussion r2857815199](https://github.com/scality/core-ui/pull/1014#discussion_r2857815199)** — @JBWatenbergScality flagged that the original form-level approach still let a searchable Select submit; drove the move into the widget.

[CUI-5]: https://scality.atlassian.net/browse/CUI-5?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ