### PR TITLE
remove cursor pointer for iconhelper as it is not clickable

### DIFF
--- a/src/lib/components/iconhelper/IconHelper.tsx
+++ b/src/lib/components/iconhelper/IconHelper.tsx
@@ -23,7 +23,6 @@ const HelpButton = styled.button`
   border: none;
   padding: 0;
   margin: 0;
-  cursor: pointer;
   color: inherit;
   font: inherit;              /* Inherit font sizing */
   vertical-align: text-bottom;     /* Align with text */


### PR DESCRIPTION
Icon helper is not clickable so cursor should not be 'pointer'
