### PR TITLE
fix: harden CI/CD workflows against supply-chain and token exposure risks

### DIFF
--- a/.github/workflows/github-pages.yml
+++ b/.github/workflows/github-pages.yml
@@ -8,12 +8,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
       - uses: actions/setup-node@v4
         with:
           node-version: 20
-      - run: |
-          git remote set-url origin https://${{ github.actor }}:${{ secrets.GITHUB_TOKEN }}@github.com/$GITHUB_REPOSITORY
-          npm ci
-          npm run storybook:deploy
+      - run: npm ci
+      - run: npm run storybook:deploy
         env:
           STORYBOOK_DISABLE_TELEMETRY: 1

--- a/.github/workflows/post-release.yml
+++ b/.github/workflows/post-release.yml
@@ -9,21 +9,36 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+        with:
+          token: ${{ secrets.GIT_ACCESS_TOKEN }}
       - name: Install node
         uses: actions/setup-node@v2
         with:
           node-version: "16"
       - run: echo "nextVersion=$(npm version --no-git-tag minor)" >> $GITHUB_ENV
+      - name: Push version bump branch
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git checkout -b feature/bump-core-ui-version-to-${{ env.nextVersion }}
+          git add package.json package-lock.json
+          git commit -m "Bump core-ui version to ${{ env.nextVersion }}"
+          git push origin feature/bump-core-ui-version-to-${{ env.nextVersion }}
       - name: Create Pull Request
-        uses: peter-evans/create-pull-request@v3
+        uses: actions/github-script@v5
         id: cpr
         with:
-          token: ${{ secrets.GIT_ACCESS_TOKEN }}
-          branch: feature/bump-core-ui-version-to-${{ env.nextVersion }}
-          commit-message: Bump core-ui version to  ${{ env.nextVersion }}
-          title: Bump core-ui version to  ${{ env.nextVersion }}
-          body: ""
-          base: ${{ github.event.repository.default_branch }}
+          github-token: ${{ secrets.GIT_ACCESS_TOKEN }}
+          script: |
+            const pr = await github.rest.pulls.create({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              head: `feature/bump-core-ui-version-to-${process.env.nextVersion}`,
+              base: context.payload.repository.default_branch,
+              title: `Bump core-ui version to ${process.env.nextVersion}`,
+              body: ''
+            });
+            core.setOutput('pull-request-number', String(pr.data.number));
       - uses: actions/github-script@v5
         if: ${{ steps.cpr.outputs.pull-request-number }}
         with:
@@ -60,6 +75,6 @@ jobs:
         with:
           node-version: "25"
           registry-url: "https://registry.npmjs.org"
-      - run: npm install
+      - run: npm ci
       - run: npm run build
       - run: npm publish


### PR DESCRIPTION
## Security: harden CI/CD workflows

Three vulnerabilities identified during a security audit of the GitHub Actions workflows have been addressed.

### 1. Token exposed in git remote URL (`github-pages.yml`)
The `Deploy Storybook` workflow was constructing the git remote URL with `${{ secrets.GITHUB_TOKEN }}` interpolated directly into the shell command, risking token leakage in runner logs. The token is now passed to `actions/checkout` via its `token:` input, which handles credential storage safely and opaquely.

### 2. Non-reproducible npm install before publish (`post-release.yml`)
The `publish-npm` job was using `npm install`, which can silently resolve dependency versions that differ from the reviewed lockfile. Replaced with `npm ci` to guarantee the published package is built from an exact, reproducible dependency tree.

### 3. Third-party action with PAT access replaced (`post-release.yml`)
The `bump-version` job delegated branch creation and PR opening to the `peter-evans/create-pull-request@v3` third-party action, which was granted the `GIT_ACCESS_TOKEN` PAT. This introduced a supply-chain risk: a compromised or tag-moved action could exfiltrate the token or make arbitrary changes to the repository. The action has been replaced with a native shell step (for the git commit/push) and `actions/github-script` (already present in the same job) for PR creation via the GitHub REST API — eliminating the third-party dependency entirely.