### PR TITLE
Use formatISONumber instead of raw number in jsx

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -75,6 +75,7 @@
         "@types/styled-system": "^5.1.15",
         "@types/uuid": "^10.0.0",
         "@typescript-eslint/eslint-plugin": "^8.56.1",
+        "@typescript-eslint/rule-tester": "^8.57.0",
         "copyfiles": "^2.4.1",
         "eslint": "^8.15.0",
         "eslint-config-react-app": "^7.0.1",
@@ -6524,15 +6525,15 @@
       }
     },
     "node_modules/@typescript-eslint/parser": {
-      "version": "8.56.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.56.1.tgz",
-      "integrity": "sha512-klQbnPAAiGYFyI02+znpBRLyjL4/BrBd0nyWkdC0s/6xFLkXYQ8OoRrSkqacS1ddVxf/LDyODIKbQ5TgKAf/Fg==",
+      "version": "8.57.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.57.0.tgz",
+      "integrity": "sha512-XZzOmihLIr8AD1b9hL9ccNMzEMWt/dE2u7NyTY9jJG6YNiNthaD5XtUHVF2uCXZ15ng+z2hT3MVuxnUYhq6k1g==",
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/scope-manager": "8.56.1",
-        "@typescript-eslint/types": "8.56.1",
-        "@typescript-eslint/typescript-estree": "8.56.1",
-        "@typescript-eslint/visitor-keys": "8.56.1",
+        "@typescript-eslint/scope-manager": "8.57.0",
+        "@typescript-eslint/types": "8.57.0",
+        "@typescript-eslint/typescript-estree": "8.57.0",
+        "@typescript-eslint/visitor-keys": "8.57.0",
         "debug": "^4.4.3"
       },
       "engines": {
@@ -6547,10 +6548,146 @@
         "typescript": ">=4.8.4 <6.0.0"
       }
     },
+    "node_modules/@typescript-eslint/parser/node_modules/@typescript-eslint/project-service": {
+      "version": "8.57.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.57.0.tgz",
+      "integrity": "sha512-pR+dK0BlxCLxtWfaKQWtYr7MhKmzqZxuii+ZjuFlZlIGRZm22HnXFqa2eY+90MUz8/i80YJmzFGDUsi8dMOV5w==",
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/tsconfig-utils": "^8.57.0",
+        "@typescript-eslint/types": "^8.57.0",
+        "debug": "^4.4.3"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4 <6.0.0"
+      }
+    },
+    "node_modules/@typescript-eslint/parser/node_modules/@typescript-eslint/scope-manager": {
+      "version": "8.57.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.57.0.tgz",
+      "integrity": "sha512-nvExQqAHF01lUM66MskSaZulpPL5pgy5hI5RfrxviLgzZVffB5yYzw27uK/ft8QnKXI2X0LBrHJFr1TaZtAibw==",
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "8.57.0",
+        "@typescript-eslint/visitor-keys": "8.57.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/parser/node_modules/@typescript-eslint/tsconfig-utils": {
+      "version": "8.57.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.57.0.tgz",
+      "integrity": "sha512-LtXRihc5ytjJIQEH+xqjB0+YgsV4/tW35XKX3GTZHpWtcC8SPkT/d4tqdf1cKtesryHm2bgp6l555NYcT2NLvA==",
+      "license": "MIT",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4 <6.0.0"
+      }
+    },
+    "node_modules/@typescript-eslint/parser/node_modules/@typescript-eslint/types": {
+      "version": "8.57.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.57.0.tgz",
+      "integrity": "sha512-dTLI8PEXhjUC7B9Kre+u0XznO696BhXcTlOn0/6kf1fHaQW8+VjJAVHJ3eTI14ZapTxdkOmc80HblPQLaEeJdg==",
+      "license": "MIT",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/parser/node_modules/@typescript-eslint/typescript-estree": {
+      "version": "8.57.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.57.0.tgz",
+      "integrity": "sha512-m7faHcyVg0BT3VdYTlX8GdJEM7COexXxS6KqGopxdtkQRvBanK377QDHr4W/vIPAR+ah9+B/RclSW5ldVniO1Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/project-service": "8.57.0",
+        "@typescript-eslint/tsconfig-utils": "8.57.0",
+        "@typescript-eslint/types": "8.57.0",
+        "@typescript-eslint/visitor-keys": "8.57.0",
+        "debug": "^4.4.3",
+        "minimatch": "^10.2.2",
+        "semver": "^7.7.3",
+        "tinyglobby": "^0.2.15",
+        "ts-api-utils": "^2.4.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4 <6.0.0"
+      }
+    },
+    "node_modules/@typescript-eslint/parser/node_modules/@typescript-eslint/visitor-keys": {
+      "version": "8.57.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.57.0.tgz",
+      "integrity": "sha512-zm6xx8UT/Xy2oSr2ZXD0pZo7Jx2XsCoID2IUh9YSTFRu7z+WdwYTRk6LhUftm1crwqbuoF6I8zAFeCMw0YjwDg==",
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "8.57.0",
+        "eslint-visitor-keys": "^5.0.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/parser/node_modules/eslint-visitor-keys": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-5.0.1.tgz",
+      "integrity": "sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/parser/node_modules/semver": {
+      "version": "7.7.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/@typescript-eslint/project-service": {
       "version": "8.56.1",
       "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.56.1.tgz",
       "integrity": "sha512-TAdqQTzHNNvlVFfR+hu2PDJrURiwKsUvxFn1M0h95BB8ah5jejas08jUWG4dBA68jDMI988IvtfdAI53JzEHOQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@typescript-eslint/tsconfig-utils": "^8.56.1",
@@ -6568,10 +6705,228 @@
         "typescript": ">=4.8.4 <6.0.0"
       }
     },
+    "node_modules/@typescript-eslint/rule-tester": {
+      "version": "8.57.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/rule-tester/-/rule-tester-8.57.0.tgz",
+      "integrity": "sha512-qs4OapXmAIj3so85/20lQG1WrBSSvDE/3b42Orl3lpZkaOlNXtbfKzL+9EPaY5wSEgdlhKEpympAMFHPG9i72Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/parser": "8.57.0",
+        "@typescript-eslint/typescript-estree": "8.57.0",
+        "@typescript-eslint/utils": "8.57.0",
+        "ajv": "^6.12.6",
+        "json-stable-stringify-without-jsonify": "^1.0.1",
+        "lodash.merge": "4.6.2",
+        "semver": "^7.7.3"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0"
+      }
+    },
+    "node_modules/@typescript-eslint/rule-tester/node_modules/@typescript-eslint/project-service": {
+      "version": "8.57.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.57.0.tgz",
+      "integrity": "sha512-pR+dK0BlxCLxtWfaKQWtYr7MhKmzqZxuii+ZjuFlZlIGRZm22HnXFqa2eY+90MUz8/i80YJmzFGDUsi8dMOV5w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/tsconfig-utils": "^8.57.0",
+        "@typescript-eslint/types": "^8.57.0",
+        "debug": "^4.4.3"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4 <6.0.0"
+      }
+    },
+    "node_modules/@typescript-eslint/rule-tester/node_modules/@typescript-eslint/scope-manager": {
+      "version": "8.57.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.57.0.tgz",
+      "integrity": "sha512-nvExQqAHF01lUM66MskSaZulpPL5pgy5hI5RfrxviLgzZVffB5yYzw27uK/ft8QnKXI2X0LBrHJFr1TaZtAibw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "8.57.0",
+        "@typescript-eslint/visitor-keys": "8.57.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/rule-tester/node_modules/@typescript-eslint/tsconfig-utils": {
+      "version": "8.57.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.57.0.tgz",
+      "integrity": "sha512-LtXRihc5ytjJIQEH+xqjB0+YgsV4/tW35XKX3GTZHpWtcC8SPkT/d4tqdf1cKtesryHm2bgp6l555NYcT2NLvA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4 <6.0.0"
+      }
+    },
+    "node_modules/@typescript-eslint/rule-tester/node_modules/@typescript-eslint/types": {
+      "version": "8.57.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.57.0.tgz",
+      "integrity": "sha512-dTLI8PEXhjUC7B9Kre+u0XznO696BhXcTlOn0/6kf1fHaQW8+VjJAVHJ3eTI14ZapTxdkOmc80HblPQLaEeJdg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/rule-tester/node_modules/@typescript-eslint/typescript-estree": {
+      "version": "8.57.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.57.0.tgz",
+      "integrity": "sha512-m7faHcyVg0BT3VdYTlX8GdJEM7COexXxS6KqGopxdtkQRvBanK377QDHr4W/vIPAR+ah9+B/RclSW5ldVniO1Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/project-service": "8.57.0",
+        "@typescript-eslint/tsconfig-utils": "8.57.0",
+        "@typescript-eslint/types": "8.57.0",
+        "@typescript-eslint/visitor-keys": "8.57.0",
+        "debug": "^4.4.3",
+        "minimatch": "^10.2.2",
+        "semver": "^7.7.3",
+        "tinyglobby": "^0.2.15",
+        "ts-api-utils": "^2.4.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4 <6.0.0"
+      }
+    },
+    "node_modules/@typescript-eslint/rule-tester/node_modules/@typescript-eslint/utils": {
+      "version": "8.57.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.57.0.tgz",
+      "integrity": "sha512-5iIHvpD3CZe06riAsbNxxreP+MuYgVUsV0n4bwLH//VJmgtt54sQeY2GszntJ4BjYCpMzrfVh2SBnUQTtys2lQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-community/eslint-utils": "^4.9.1",
+        "@typescript-eslint/scope-manager": "8.57.0",
+        "@typescript-eslint/types": "8.57.0",
+        "@typescript-eslint/typescript-estree": "8.57.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.0.0"
+      }
+    },
+    "node_modules/@typescript-eslint/rule-tester/node_modules/@typescript-eslint/visitor-keys": {
+      "version": "8.57.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.57.0.tgz",
+      "integrity": "sha512-zm6xx8UT/Xy2oSr2ZXD0pZo7Jx2XsCoID2IUh9YSTFRu7z+WdwYTRk6LhUftm1crwqbuoF6I8zAFeCMw0YjwDg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "8.57.0",
+        "eslint-visitor-keys": "^5.0.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/rule-tester/node_modules/ajv": {
+      "version": "6.14.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.14.0.tgz",
+      "integrity": "sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.4.1",
+        "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/@typescript-eslint/rule-tester/node_modules/eslint-visitor-keys": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-5.0.1.tgz",
+      "integrity": "sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/rule-tester/node_modules/json-schema-traverse": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@typescript-eslint/rule-tester/node_modules/semver": {
+      "version": "7.7.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/@typescript-eslint/scope-manager": {
       "version": "8.56.1",
       "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.56.1.tgz",
       "integrity": "sha512-YAi4VDKcIZp0O4tz/haYKhmIDZFEUPOreKbfdAN3SzUDMcPhJ8QI99xQXqX+HoUVq8cs85eRKnD+rne2UAnj2w==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@typescript-eslint/types": "8.56.1",
@@ -6589,6 +6944,7 @@
       "version": "8.56.1",
       "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.56.1.tgz",
       "integrity": "sha512-qOtCYzKEeyr3aR9f28mPJqBty7+DBqsdd63eO0yyDwc6vgThj2UjWfJIcsFeSucYydqcuudMOprZ+x1SpF3ZuQ==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -6630,6 +6986,7 @@
       "version": "8.56.1",
       "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.56.1.tgz",
       "integrity": "sha512-dbMkdIUkIkchgGDIv7KLUpa0Mda4IYjo4IAMJUZ+3xNoUXxMsk9YtKpTHSChRS85o+H9ftm51gsK1dZReY9CVw==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -6643,6 +7000,7 @@
       "version": "8.56.1",
       "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.56.1.tgz",
       "integrity": "sha512-qzUL1qgalIvKWAf9C1HpvBjif+Vm6rcT5wZd4VoMb9+Km3iS3Cv9DY6dMRMDtPnwRAFyAi7YXJpTIEXLvdfPxg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@typescript-eslint/project-service": "8.56.1",
@@ -6670,6 +7028,7 @@
       "version": "7.7.4",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
       "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+      "dev": true,
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
@@ -6706,6 +7065,7 @@
       "version": "8.56.1",
       "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.56.1.tgz",
       "integrity": "sha512-KiROIzYdEV85YygXw6BI/Dx4fnBlFQu6Mq4QE4MOH9fFnhohw6wX/OAvDY2/C+ut0I3RSPKenvZJIVYqJNkhEw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@typescript-eslint/types": "8.56.1",
@@ -6723,6 +7083,7 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-5.0.1.tgz",
       "integrity": "sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA==",
+      "dev": true,
       "license": "Apache-2.0",
       "engines": {
         "node": "^20.19.0 || ^22.13.0 || >=24"

--- a/package.json
+++ b/package.json
@@ -72,6 +72,7 @@
     "@types/styled-system": "^5.1.15",
     "@types/uuid": "^10.0.0",
     "@typescript-eslint/eslint-plugin": "^8.56.1",
+    "@typescript-eslint/rule-tester": "^8.57.0",
     "copyfiles": "^2.4.1",
     "eslint": "^8.15.0",
     "eslint-config-react-app": "^7.0.1",

--- a/src/lib/valalint/index.js
+++ b/src/lib/valalint/index.js
@@ -1,16 +1,19 @@
 import tsParser from '@typescript-eslint/parser';
 import technicalSentenceCase from './rules/technical-sentence-case.js';
 import modalButtonForbiddenLabel from './rules/modal-button-forbidden-label.js';
+import noRawNumberInJsx from './rules/no-raw-number-in-jsx.js';
 
 const rules = {
     'technical-sentence-case': technicalSentenceCase,
     'modal-button-forbidden-label': modalButtonForbiddenLabel,
+    'no-raw-number-in-jsx': noRawNumberInJsx,
 };
 
 /** Default rule severity for the recommended config. */
 const recommendedRules = {
     'valalint/technical-sentence-case': 'warn',
     'valalint/modal-button-forbidden-label': 'warn',
+    'valalint/no-raw-number-in-jsx': 'warn',
 };
 
 const plugin = {
@@ -38,6 +41,7 @@ plugin.configs['flat/recommended'] = {
             ecmaFeatures: {
                 jsx: true,
             },
+            project: true,
         },
     },
 };

--- a/src/lib/valalint/rules/no-raw-number-in-jsx.js
+++ b/src/lib/valalint/rules/no-raw-number-in-jsx.js
@@ -1,0 +1,64 @@
+import ts from 'typescript';
+
+/**
+ * Returns true when the TypeScript type — or any member of a union — is a
+ * numeric type (number primitive or a number literal type such as `42`).
+ */
+function typeIncludesNumber(type) {
+    if (type.flags & ts.TypeFlags.Number) return true;
+    if (type.flags & ts.TypeFlags.NumberLiteral) return true;
+    // Handle union types: `number | undefined`, `number | null`, `string | number`, …
+    if (type.flags & ts.TypeFlags.Union) {
+        return type.types.some(t => typeIncludesNumber(t));
+    }
+    return false;
+}
+
+const noRawNumberInJsx = {
+    meta: {
+        type: 'suggestion',
+        docs: {
+            description:
+                'Disallow raw numeric expressions in JSX text; use formatISONumber() instead',
+            category: 'Best Practices',
+            recommended: false,
+        },
+        schema: [],
+        messages: {
+            rawNumber:
+                'Avoid rendering raw numbers in JSX text. ' +
+                'Use formatISONumber(value) to apply proper ISO formatting ' +
+                '(space as thousands separator, leading zero before decimal point).',
+        },
+    },
+
+    create(context) {
+        // Type-aware rule: opt out gracefully when no TypeScript program is available.
+        const services = context.sourceCode?.parserServices ?? context.parserServices;
+        if (!services?.program) return {};
+
+        const checker = services.program.getTypeChecker();
+
+        return {
+            JSXExpressionContainer(node) {
+                // Only flag children positions — attribute values are intentionally excluded.
+                // A child container's direct parent is JSXElement; an attribute value's is JSXAttribute.
+                if (node.parent.type !== 'JSXElement') return;
+
+                const { expression } = node;
+
+                // Skip {/* JSX comments */}
+                if (expression.type === 'JSXEmptyExpression') return;
+
+                const tsNode = services.esTreeNodeToTSNodeMap.get(expression);
+                const type = checker.getTypeAtLocation(tsNode);
+
+                if (typeIncludesNumber(type)) {
+                    context.report({ node, messageId: 'rawNumber' });
+                }
+            },
+        };
+    },
+};
+
+export default noRawNumberInJsx;

--- a/src/lib/valalint/rules/no-raw-number-in-jsx.test.js
+++ b/src/lib/valalint/rules/no-raw-number-in-jsx.test.js
@@ -1,0 +1,237 @@
+/**
+ * @jest-environment node
+ */
+import { RuleTester } from '@typescript-eslint/rule-tester';
+import rule from './no-raw-number-in-jsx.js';
+import path from 'path';
+
+// Jest runs from the project root, so process.cwd() is the workspace root
+// where tsconfig.json lives.
+const tsconfigRootDir = process.cwd();
+
+// Virtual filename placed at the workspace root so it is matched by the
+// allowDefaultProject glob ('*.tsx') and uses the workspace tsconfig.
+const filename = path.join(tsconfigRootDir, 'test.tsx');
+
+const tester = new RuleTester({
+    languageOptions: {
+        parserOptions: {
+            ecmaFeatures: { jsx: true },
+            ecmaVersion: 2020,
+            projectService: {
+                allowDefaultProject: ['*.tsx'],
+                defaultProject: 'tsconfig.json',
+            },
+            tsconfigRootDir,
+        },
+    },
+});
+
+const ERROR =
+    'Avoid rendering raw numbers in JSX text. Use formatISONumber(value) to apply proper ISO formatting (space as thousands separator, leading zero before decimal point).';
+
+tester.run('no-raw-number-in-jsx', rule, {
+    // ─── Valid ────────────────────────────────────────────────────────────────
+    valid: [
+        // ── Numbers in JSX attribute values — never flagged ───────────────────
+        {
+            // Numeric literal in an attribute
+            code: 'const el = <input value={42} />;',
+            filename,
+        },
+        {
+            // Typed number variable in an attribute
+            code: 'declare const max: number; const el = <Chart max={max} />;',
+            filename,
+        },
+        {
+            // Multiple numeric attributes
+            code: 'declare const n: number; const el = <Slider step={0.5} min={0} max={n} />;',
+            filename,
+        },
+
+        // ── String types in JSX children — not flagged ────────────────────────
+        {
+            code: 'declare const name: string; const el = <Text>{name}</Text>;',
+            filename,
+        },
+        {
+            code: 'const el = <Text>{"hello"}</Text>;',
+            filename,
+        },
+        {
+            code: 'const el = <Text>{`template`}</Text>;',
+            filename,
+        },
+        {
+            // Template literal containing a number expression is still a string
+            // eslint-disable-next-line no-template-curly-in-string
+            code: 'declare const count: number; const el = <Text>{`Total: ${count}`}</Text>;',
+            filename,
+        },
+
+        // ── formatISONumber returns string — not flagged ───────────────────────
+        {
+            code: 'declare function formatISONumber(n: number, opts?: object): string; declare const count: number; const el = <Text>{formatISONumber(count)}</Text>;',
+            filename,
+        },
+
+        // ── Methods that return strings — not flagged ──────────────────────────
+        {
+            // Number.prototype.toFixed returns string
+            code: 'declare const value: number; const el = <Text>{value.toFixed(2)}</Text>;',
+            filename,
+        },
+        {
+            // Number.prototype.toPrecision returns string
+            code: 'declare const value: number; const el = <Text>{value.toPrecision(4)}</Text>;',
+            filename,
+        },
+        {
+            // String.prototype.toUpperCase returns string
+            code: 'declare const label: string; const el = <Text>{label.toUpperCase()}</Text>;',
+            filename,
+        },
+
+        // ── Other non-numeric types — not flagged ─────────────────────────────
+        {
+            code: 'const el = <Text>{null}</Text>;',
+            filename,
+        },
+        {
+            code: 'declare const flag: boolean; const el = <Text>{flag}</Text>;',
+            filename,
+        },
+        {
+            // string + number → string (TS widens to string)
+            code: 'declare const count: number; const el = <Text>{count + " items"}</Text>;',
+            filename,
+        },
+        {
+            // Conditional producing string
+            code: 'declare const flag: boolean; const el = <Text>{flag ? "yes" : "no"}</Text>;',
+            filename,
+        },
+
+        // ── JSX comment — not flagged ──────────────────────────────────────────
+        {
+            code: 'const el = <Text>{/* comment */}</Text>;',
+            filename,
+        },
+    ],
+
+    // ─── Invalid ──────────────────────────────────────────────────────────────
+    invalid: [
+        // ── Numeric literals (TypeFlags.NumberLiteral) ─────────────────────────
+        {
+            code: 'const el = <Text>{42}</Text>;',
+            filename,
+            errors: [{ message: ERROR }],
+        },
+        {
+            code: 'const el = <Text>{0}</Text>;',
+            filename,
+            errors: [{ message: ERROR }],
+        },
+        {
+            code: 'const el = <Text>{3.14}</Text>;',
+            filename,
+            errors: [{ message: ERROR }],
+        },
+
+        // ── Typed number variables (TypeFlags.Number) ─────────────────────────
+        {
+            code: 'declare const count: number; const el = <Text>{count}</Text>;',
+            filename,
+            errors: [{ message: ERROR }],
+        },
+        {
+            // Works on any element tag
+            code: 'declare const price: number; const el = <Tooltip>{price}</Tooltip>;',
+            filename,
+            errors: [{ message: ERROR }],
+        },
+
+        // ── Arithmetic that produces a number ─────────────────────────────────
+        {
+            // number + number → number
+            code: 'declare const a: number; declare const b: number; const el = <Text>{a + b}</Text>;',
+            filename,
+            errors: [{ message: ERROR }],
+        },
+        {
+            code: 'declare const total: number; declare const tax: number; const el = <Text>{total - tax}</Text>;',
+            filename,
+            errors: [{ message: ERROR }],
+        },
+        {
+            code: 'declare const bytes: number; const el = <Text>{bytes / 1024}</Text>;',
+            filename,
+            errors: [{ message: ERROR }],
+        },
+
+        // ── Unary minus on a number ───────────────────────────────────────────
+        {
+            code: 'declare const n: number; const el = <Text>{-n}</Text>;',
+            filename,
+            errors: [{ message: ERROR }],
+        },
+
+        // ── Properties that return number ─────────────────────────────────────
+        {
+            // Array.length → number
+            code: 'declare const items: string[]; const el = <Text>{items.length}</Text>;',
+            filename,
+            errors: [{ message: ERROR }],
+        },
+
+        // ── Functions that return number ───────────────────────────────────────
+        {
+            code: 'declare function getCount(): number; const el = <Text>{getCount()}</Text>;',
+            filename,
+            errors: [{ message: ERROR }],
+        },
+
+        // ── Union types that include number ───────────────────────────────────
+        {
+            // number | undefined — when defined it would render an unformatted number
+            code: 'declare const count: number | undefined; const el = <Text>{count}</Text>;',
+            filename,
+            errors: [{ message: ERROR }],
+        },
+        {
+            // string | number
+            code: 'declare const value: string | number; const el = <Text>{value}</Text>;',
+            filename,
+            errors: [{ message: ERROR }],
+        },
+
+        // ── Real-world patterns ────────────────────────────────────────────────
+        {
+            // Numeric literal mixed with JSX text siblings
+            code: 'const el = <Text>Total: {1234567}</Text>;',
+            filename,
+            errors: [{ message: ERROR }],
+        },
+        {
+            // Multiple violations in the same element
+            code: 'declare const a: number; declare const b: number; const el = <Text>{a}{b}</Text>;',
+            filename,
+            errors: [{ message: ERROR }, { message: ERROR }],
+        },
+        {
+            // Nested expressions
+            code: 'declare const a: number; declare const b: number; const el = <Text><span>{a}</span></Text>;',
+            filename,
+            errors: [{ message: ERROR }],
+        },
+    ],
+});
+
+// RuleTester.run() throws if any case fails, so reaching this line means all
+// cases passed. Jest needs at least one explicit assertion per test file.
+describe('no-raw-number-in-jsx', () => {
+    it('passes all RuleTester cases', () => {
+        expect(true).toBe(true);
+    });
+});


### PR DESCRIPTION
Approved but bad branch name in #1030

This valalint typescript-eslint rules is aimed at enforcing 4.5.2 Numbers format of the design system by disallowing raw numbers in jsx text and suggesting the usage of core-ui formatISONumber. https://docs.google.com/document/d/1bkqSTc5T2HetzePuKZSwywuGQePaUJK9kNCJ2yrSu8w/edit?tab=t.0#heading=h.b8f9v5oobofw