### PR TITLE
feat: add Drawer component

### DIFF
--- a/src/lib/components/drawer/Drawer.component.test.tsx
+++ b/src/lib/components/drawer/Drawer.component.test.tsx
@@ -1,0 +1,108 @@
+import '@testing-library/jest-dom';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import React from 'react';
+import { getWrapper } from '../../testUtils';
+import { Drawer } from './Drawer.component';
+
+describe('Drawer', () => {
+  const { Wrapper } = getWrapper();
+
+  it('should not be visible when closed', () => {
+    render(
+      <Wrapper>
+        <Drawer isOpen={false} close={jest.fn()} title="Test">
+          <p>Content</p>
+        </Drawer>
+      </Wrapper>,
+    );
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+  });
+
+  it('should display title and content when open', () => {
+    render(
+      <Wrapper>
+        <Drawer isOpen={true} close={jest.fn()} title="My Drawer">
+          <p>Some content</p>
+        </Drawer>
+      </Wrapper>,
+    );
+    expect(screen.getByText('My Drawer')).toBeVisible();
+    expect(screen.getByText('Some content')).toBeVisible();
+  });
+
+  it('should display footer when provided', () => {
+    render(
+      <Wrapper>
+        <Drawer
+          isOpen={true}
+          close={jest.fn()}
+          title="Test"
+          footer={<button type="button">Save</button>}
+        >
+          <p>Content</p>
+        </Drawer>
+      </Wrapper>,
+    );
+    expect(screen.getByRole('button', { name: 'Save' })).toBeVisible();
+  });
+
+  it('should close when clicking the close button', async () => {
+    const closeFn = jest.fn();
+    render(
+      <Wrapper>
+        <Drawer isOpen={true} close={closeFn} title="Test">
+          <p>Content</p>
+        </Drawer>
+      </Wrapper>,
+    );
+    await userEvent.click(screen.getByRole('button', { name: /close/i }));
+    expect(closeFn).toHaveBeenCalledTimes(1);
+  });
+
+  it('should close when pressing Escape', async () => {
+    const closeFn = jest.fn();
+    render(
+      <Wrapper>
+        <Drawer isOpen={true} close={closeFn} title="Test">
+          <p>Content</p>
+        </Drawer>
+      </Wrapper>,
+    );
+    await userEvent.keyboard('{Escape}');
+    expect(closeFn).toHaveBeenCalledTimes(1);
+  });
+
+  it('should close when clicking outside the drawer', async () => {
+    const closeFn = jest.fn();
+    render(
+      <Wrapper>
+        <Drawer isOpen={true} close={closeFn} title="Test" overlay={true}>
+          <p>Content</p>
+        </Drawer>
+      </Wrapper>,
+    );
+    const dialog = screen.getByRole('dialog');
+    const backdrop = dialog.previousElementSibling as HTMLElement;
+    await userEvent.click(backdrop);
+    expect(closeFn).toHaveBeenCalledTimes(1);
+  });
+
+  it('should hide close button when showCloseButton is false', () => {
+    render(
+      <Wrapper>
+        <Drawer
+          isOpen={true}
+          close={jest.fn()}
+          title="Test"
+          showCloseButton={false}
+        >
+          <p>Content</p>
+        </Drawer>
+      </Wrapper>,
+    );
+    expect(
+      screen.queryByRole('button', { name: /close/i }),
+    ).not.toBeInTheDocument();
+  });
+});

--- a/src/lib/components/drawer/Drawer.component.tsx
+++ b/src/lib/components/drawer/Drawer.component.tsx
@@ -1,0 +1,207 @@
+import { CSSProperties, type ReactNode, useCallback, useEffect, useLayoutEffect, useRef, useState } from 'react';
+import { createPortal } from 'react-dom';
+import styled from 'styled-components';
+import { spacing } from '../../spacing';
+import { zIndex } from '../../style/theme';
+import { getThemePropSelector } from '../../utils';
+import { Button } from '../buttonv2/Buttonv2.component';
+import { Icon } from '../icon/Icon.component';
+import { Text } from '../text/Text.component';
+
+type DrawerPosition = 'left' | 'right' | 'top' | 'bottom';
+
+type Props = {
+  isOpen: boolean;
+  close: () => void;
+  title: ReactNode;
+  position?: DrawerPosition;
+  size?: CSSProperties['width'];
+  footer?: ReactNode;
+  overlay?: boolean;
+  showCloseButton?: boolean;
+  children: ReactNode;
+};
+
+const TRANSITION_DURATION = '250ms';
+
+const DrawerBackdrop = styled.div<{ $overlay: boolean }>`
+  position: fixed;
+  inset: 0;
+  z-index: ${zIndex.overlay};
+  background: ${({ $overlay }) => ($overlay ? 'rgba(0, 0, 0, 0.3)' : 'transparent')};
+`;
+
+function getTransform(position: DrawerPosition, isOpen: boolean): string {
+  if (isOpen) return 'translate3d(0, 0, 0)';
+  switch (position) {
+    case 'left':
+      return 'translate3d(-100%, 0, 0)';
+    case 'right':
+      return 'translate3d(100%, 0, 0)';
+    case 'top':
+      return 'translate3d(0, -100%, 0)';
+    case 'bottom':
+      return 'translate3d(0, 100%, 0)';
+  }
+}
+
+const DrawerPanel = styled.div<{
+  $position: DrawerPosition;
+  $size: CSSProperties['width'];
+  $isOpen: boolean;
+}>`
+  position: fixed;
+  z-index: ${zIndex.drawer};
+  background-color: ${getThemePropSelector('backgroundLevel2')};
+  color: ${getThemePropSelector('textPrimary')};
+  display: flex;
+  flex-direction: column;
+  box-shadow: 2px 0 8px rgba(0, 0, 0, 0.3);
+  transition: transform ${TRANSITION_DURATION} ease-in-out;
+  transform: ${({ $position, $isOpen }) => getTransform($position, $isOpen)};
+
+  ${({ $position, $size, theme }) => {
+    const borderSide = $position === 'left' ? 'right' : $position === 'right' ? 'left' : $position === 'top' ? 'bottom' : 'top';
+    const border = `border-${borderSide}: 1px solid ${theme.border};`;
+    switch ($position) {
+      case 'left':
+        return `top: 0; left: 0; bottom: 0; width: ${$size}; ${border}`;
+      case 'right':
+        return `top: 0; right: 0; bottom: 0; width: ${$size}; ${border}`;
+      case 'top':
+        return `top: 0; left: 0; right: 0; height: ${$size}; ${border}`;
+      case 'bottom':
+        return `bottom: 0; left: 0; right: 0; height: ${$size}; ${border}`;
+    }
+  }}
+`;
+
+const DrawerHeader = styled.div`
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: ${spacing.r16};
+  background-color: ${getThemePropSelector('backgroundLevel3')};
+`;
+
+const DrawerBody = styled.div`
+  flex: 1;
+  overflow-y: auto;
+  padding: ${spacing.r16};
+  background-color: ${getThemePropSelector('backgroundLevel4')};
+`;
+
+const DrawerFooter = styled.div`
+  padding: ${spacing.r16};
+  background-color: ${getThemePropSelector('backgroundLevel3')};
+  display: flex;
+  gap: ${spacing.r8};
+  justify-content: flex-end;
+`;
+
+const Drawer = ({
+  isOpen,
+  close,
+  title,
+  position = 'left',
+  size = '400px',
+  footer,
+  overlay = false,
+  showCloseButton = true,
+  children,
+}: Props) => {
+  const drawerContainer = useRef(document.createElement('div'));
+  const panelRef = useRef<HTMLDivElement>(null);
+  const [mounted, setMounted] = useState(isOpen);
+  const [active, setActive] = useState(false);
+
+  useLayoutEffect(() => {
+    const container = drawerContainer.current;
+    document.body?.prepend(container);
+    return () => {
+      document.body?.removeChild(container);
+    };
+  }, []);
+
+  useEffect(() => {
+    if (isOpen) {
+      setMounted(true);
+    } else {
+      setActive(false);
+    }
+  }, [isOpen]);
+
+  useEffect(() => {
+    if (mounted && isOpen) {
+      const frame = requestAnimationFrame(() => {
+        setActive(true);
+        panelRef.current?.focus();
+      });
+      return () => cancelAnimationFrame(frame);
+    }
+  }, [mounted, isOpen]);
+
+  const stableClose = useCallback(close, [close]);
+
+  useEffect(() => {
+    if (isOpen) {
+      const handleEsc = (event: KeyboardEvent) => {
+        if (event.key === 'Escape') {
+          stableClose();
+        }
+      };
+      document.addEventListener('keydown', handleEsc);
+      return () => {
+        document.removeEventListener('keydown', handleEsc);
+      };
+    }
+  }, [isOpen, stableClose]);
+
+  const handleTransitionEnd = () => {
+    if (!isOpen) setMounted(false);
+  };
+
+  if (!mounted) return null;
+
+  return createPortal(
+    <>
+      <DrawerBackdrop $overlay={overlay} onClick={stableClose} />
+      <DrawerPanel
+        ref={panelRef}
+        className="sc-drawer"
+        $position={position}
+        $size={size}
+        $isOpen={active}
+        role="dialog"
+        tabIndex={-1}
+        aria-modal={overlay ? 'true' : undefined}
+        aria-labelledby="drawer_label"
+        onTransitionEnd={handleTransitionEnd}
+      >
+        <DrawerHeader className="sc-drawer-header">
+          <Text variant="Larger" id="drawer_label">
+            {title}
+          </Text>
+          {showCloseButton && (
+            <Button
+              icon={<Icon name="Close" />}
+              onClick={stableClose}
+              tooltip={{ overlay: 'Close' }}
+              aria-label="Close"
+            />
+          )}
+        </DrawerHeader>
+        <DrawerBody className="sc-drawer-body">{children}</DrawerBody>
+        {footer && (
+          <DrawerFooter className="sc-drawer-footer">
+            {footer}
+          </DrawerFooter>
+        )}
+      </DrawerPanel>
+    </>,
+    drawerContainer.current,
+  );
+};
+
+export { Drawer };
+export type { DrawerPosition };

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -14,6 +14,7 @@ export {
 } from './components/constants';
 export type { Status } from './components/constants';
 export { Layout } from './components/layout/Layout.component';
+export { Drawer } from './components/drawer/Drawer.component';
 export { Loader } from './components/loader/Loader.component';
 export { Modal } from './components/modal/Modal.component';
 export { Navbar } from './components/navbar/Navbar.component';

--- a/src/lib/next.ts
+++ b/src/lib/next.ts
@@ -17,6 +17,7 @@ export { CoreUiThemeProvider } from './components/coreuithemeprovider/CoreUiThem
 export { Box } from './components/box/Box';
 export { Input } from './components/inputv2/inputv2';
 export { Accordion } from './components/accordion/Accordion.component';
+export { Drawer } from './components/drawer/Drawer.component';
 export { Editor } from './components/editor';
 export type { EditorProps } from './components/editor';
 

--- a/src/lib/style/theme.ts
+++ b/src/lib/style/theme.ts
@@ -310,6 +310,7 @@ export const zIndex = {
   tooltip: 9990,
   notification: 9000,
   modal: 8500,
+  drawer: 8200,
   overlay: 8000,
   dropdown: 7000,
   nav: 500,

--- a/stories/drawer.stories.tsx
+++ b/stories/drawer.stories.tsx
@@ -1,0 +1,135 @@
+import { useState } from 'react';
+import { Button } from '../src/lib/components/buttonv2/Buttonv2.component';
+import { Drawer } from '../src/lib/components/drawer/Drawer.component';
+import { Wrapper } from './common';
+
+export default {
+  title: 'Components/Feedback/Drawer',
+  component: Drawer,
+  decorators: [
+    (story) => <Wrapper style={{ minHeight: '30vh' }}>{story()}</Wrapper>,
+  ],
+  argTypes: {
+    position: {
+      control: 'select',
+      options: ['left', 'right', 'top', 'bottom'],
+    },
+    size: { control: 'text' },
+    overlay: { control: 'boolean' },
+    showCloseButton: { control: 'boolean' },
+  },
+};
+
+export const Default = {
+  render: (args) => {
+    const [isOpen, setIsOpen] = useState(false);
+    return (
+      <>
+        <Button onClick={() => setIsOpen(true)} label="Open Drawer" />
+        <Drawer {...args} isOpen={isOpen} close={() => setIsOpen(false)} />
+      </>
+    );
+  },
+  args: {
+    title: 'Drawer Title',
+    position: 'left',
+    size: '400px',
+    overlay: false,
+    children: (
+      <div>
+        <p>This is the drawer content.</p>
+        <p>The app remains visible and interactive behind the drawer.</p>
+      </div>
+    ),
+  },
+};
+
+export const WithFooter = {
+  render: (args) => {
+    const [isOpen, setIsOpen] = useState(false);
+    return (
+      <>
+        <Button onClick={() => setIsOpen(true)} label="Open Drawer" />
+        <Drawer
+          {...args}
+          isOpen={isOpen}
+          close={() => setIsOpen(false)}
+          footer={
+            <>
+              <Button
+                label="Cancel"
+                variant="outline"
+                onClick={() => setIsOpen(false)}
+                style={{ minWidth: '6rem' }}
+              />
+              <Button
+                label="Save"
+                variant="primary"
+                onClick={() => setIsOpen(false)}
+                style={{ minWidth: '6rem' }}
+              />
+            </>
+          }
+        />
+      </>
+    );
+  },
+  args: {
+    title: 'Settings',
+    position: 'left',
+    size: '400px',
+    overlay: false,
+    children: (
+      <div>
+        <p>Drawer with footer actions.</p>
+        <p>Use footer for save, cancel, or reset buttons.</p>
+      </div>
+    ),
+  },
+};
+
+export const WithOverlay = {
+  render: (args) => {
+    const [isOpen, setIsOpen] = useState(false);
+    return (
+      <>
+        <Button
+          onClick={() => setIsOpen(true)}
+          label="Open Drawer with Overlay"
+        />
+        <Drawer {...args} isOpen={isOpen} close={() => setIsOpen(false)} />
+      </>
+    );
+  },
+  args: {
+    title: 'Overlay Drawer',
+    position: 'left',
+    size: '400px',
+    overlay: true,
+    children: (
+      <div>
+        <p>This drawer has a backdrop overlay.</p>
+        <p>Click the overlay or press Escape to close.</p>
+      </div>
+    ),
+  },
+};
+
+export const RightPosition = {
+  render: (args) => {
+    const [isOpen, setIsOpen] = useState(false);
+    return (
+      <>
+        <Button onClick={() => setIsOpen(true)} label="Open Right Drawer" />
+        <Drawer {...args} isOpen={isOpen} close={() => setIsOpen(false)} />
+      </>
+    );
+  },
+  args: {
+    title: 'Right Drawer',
+    position: 'right',
+    size: '350px',
+    overlay: false,
+    children: <p>Drawer sliding in from the right.</p>,
+  },
+};


### PR DESCRIPTION
## Summary

- Adds a `Drawer` component: a slide-in panel that can open from any edge (left/right/top/bottom)
- Supports optional overlay backdrop, configurable size, footer slot, and Escape key to close
- Renders via portal (same pattern as Modal) with dedicated `drawer` zIndex (8200, between overlay and modal)

## Context

Needed by the Data Browser theme customization feature (DBR-4) as the container for the branding editor panel.

Ref: https://scality.atlassian.net/browse/CUI-10