### PR TITLE
fix: configure git credentials for gh-pages storybook deploy

### DIFF
--- a/.github/workflows/github-pages.yml
+++ b/.github/workflows/github-pages.yml
@@ -14,6 +14,8 @@ jobs:
         with:
           node-version: 20
       - run: npm ci
+      - name: Configure git credentials
+        run: git config --global url."https://x-access-token:${{ github.token }}@github.com/".insteadOf "https://github.com/"
       - run: npm run storybook:deploy
         env:
           STORYBOOK_DISABLE_TELEMETRY: 1


### PR DESCRIPTION
## Summary

The `gh-pages` package clones the repo into a temp directory during deploy, bypassing the credentials configured by `actions/checkout`. Added a `git config --global url.…insteadOf` step to inject the `GITHUB_TOKEN` into all HTTPS git requests globally, so `gh-pages` can authenticate when pushing to the `gh-pages` branch.

## Test plan

- [ ] Verify the `Deploy Storybook` workflow succeeds on push to `development/1.0`

🤖 Generated with [Claude Code](https://claude.com/claude-code)