### PR TITLE
fix export, bump version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@scality/core-ui",
-  "version": "0.205.0",
+  "version": "0.206.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@scality/core-ui",
-      "version": "0.205.0",
+      "version": "0.206.0",
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
         "@codemirror/lang-json": "^6.0.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@scality/core-ui",
-  "version": "0.205.0",
+  "version": "0.206.0",
   "description": "Scality common React component library",
   "author": "Scality Engineering",
   "license": "SEE LICENSE IN LICENSE",
@@ -14,7 +14,9 @@
       "require": "./dist/index.js",
       "types": "./dist/index.d.ts"
     },
-    "./eslint-plugin": "./src/lib/valalint/index.js"
+    "./eslint-plugin": "./src/lib/valalint/index.js",
+    "./dist/*.css": "./dist/*.css",
+    "./dist/*": "./dist/*"
   },
   "sideEffects": false,
   "peerDependencies": {


### PR DESCRIPTION
This PR is intended to fix issue when using core-ui:
` Package subpath './dist/next' is not defined by "exports" in /app/node_modules/@scality/core-ui/package.json`