### PR TITLE
fix: add types condition to exports subpath for bundler resolution

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,11 @@
     },
     "./eslint-plugin": "./src/lib/valalint/index.mjs",
     "./dist/*.css": "./dist/*.css",
-    "./dist/*": "./dist/*"
+    "./dist/*": {
+      "types": "./dist/*.d.ts",
+      "import": "./dist/*.js",
+      "default": "./dist/*.js"
+    }
   },
   "sideEffects": false,
   "peerDependencies": {


### PR DESCRIPTION
## Summary

- Fixes TypeScript `moduleResolution: "bundler"` failing to resolve types for sub-path imports (e.g. `@scality/core-ui/dist/next`, `@scality/core-ui/dist/style/theme`)
- Replaces the simple `"./dist/*": "./dist/*"` wildcard with an object providing explicit `types`, `import`, and `default` conditions
- Backward compatible — no change for existing consumers using `node` or `node16` resolution

Fixes CUI-15

## Test plan

- [ ] Verify TypeScript projects with `moduleResolution: "bundler"` can resolve types for `@scality/core-ui/dist/next` and `@scality/core-ui/dist/style/theme` without tsconfig `paths` workarounds
- [ ] Verify existing imports (`@scality/core-ui`, `@scality/core-ui/dist/*.css`) still work