### PR TITLE
Remove extension from dynamic import to solve issue with testing

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@scality/core-ui",
-  "version": "0.206.0",
+  "version": "0.208.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@scality/core-ui",
-      "version": "0.206.0",
+      "version": "0.208.0",
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
         "@codemirror/lang-json": "^6.0.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@scality/core-ui",
-  "version": "0.207.0",
+  "version": "0.208.0",
   "description": "Scality common React component library",
   "author": "Scality Engineering",
   "license": "SEE LICENSE IN LICENSE",

--- a/src/lib/components/icon/Icon.component.tsx
+++ b/src/lib/components/icon/Icon.component.tsx
@@ -1,14 +1,14 @@
-import { SizeProp } from '@fortawesome/fontawesome-svg-core';
+import type { SizeProp } from '@fortawesome/fontawesome-svg-core';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import {
-  CSSProperties,
-  HTMLProps,
-  PropsWithChildren,
+  type CSSProperties,
+  type HTMLProps,
+  type PropsWithChildren,
   useEffect,
   useState,
 } from 'react';
 import styled, { css } from 'styled-components';
-import { CoreUITheme } from '../../style/theme';
+import type { CoreUITheme } from '../../style/theme';
 import { Loader } from '../loader/Loader.component';
 import { Bucket, Buckets, RemoteGroup, RemoteUser } from './CustomsIcons';
 import { iconTable } from './iconTable';
@@ -114,8 +114,8 @@ export const IconWrapper = styled.div<{ size: SizeProp }>`
         height: 1.5rem;
       `
             : `
-        width: ${parseInt(props.size.replace('x', '')) * 2}rem;
-        height: ${parseInt(props.size.replace('x', '')) * 2}rem;
+        width: ${parseInt(props.size.replace('x', ''), 10) * 2}rem;
+        height: ${parseInt(props.size.replace('x', ''), 10) * 2}rem;
       `}
     `;
   }}
@@ -157,9 +157,12 @@ function NonWrappedIcon({
     // Handle FontAwesome icons with dynamic import
     import(
       /* webpackExclude: /import\.macro\.js$/ */
-      `@fortawesome/${fontAwesomeType}/${iconClass}.js`).then((module) => {
+      /* webpackInclude: /\.js$/ */
+      `@fortawesome/${fontAwesomeType}/${iconClass}`).then((module) => {
         setIcon(module[iconClass]);
         iconCache[cacheKey] = module[iconClass];
+      }).catch((err) => {
+        console.warn(`Icon ${iconClass} could not be loaded:`, err.message);
       });
     return () => setIcon(undefined);
   }, [name, iconInfo]);


### PR DESCRIPTION
## Initial issue
**CI/PR Blocked**: rstest was failing due to an unhandledRejection caused by a path resolution error (.js.js) during dynamic icon imports.

## Secondary issue
**Storybook Broken**: Removing the extension caused Webpack to crawl all @fortawesome files, including .d.ts files, triggering "interface is a reserved keyword" errors.

## Fixes

**Path Correction**: Refined the template literal to prevent double .js extensions in the test environment.

**Added .catch()**: Handled the import promise to prevent unhandledRejection from crashing the test runner.

Added /* webpackInclude: /\.js$/ */ : Restricted Webpack's dynamic context to only JS files, fixing the Storybook build.


## Tests
rstest: CI now passes (no more unhandled promise rejections).
Storybook: MDX and Icon stories load without module parse errors.
Icon still load correctly