### PR TITLE
fix: add types condition to exports subpath for bundler resolution

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,11 @@
     },
     "./eslint-plugin": "./src/lib/valalint/index.mjs",
     "./dist/*.css": "./dist/*.css",
-    "./dist/*": "./dist/*"
+    "./dist/*": {
+      "types": "./dist/*.d.ts",
+      "import": "./dist/*.js",
+      "default": "./dist/*.js"
+    }
   },
   "sideEffects": false,
   "peerDependencies": {


### PR DESCRIPTION
## Summary

Sub-path imports (`@scality/core-ui/dist/next`, `@scality/core-ui/dist/style/theme`) fail to resolve types when consumers use `moduleResolution: "bundler"`.

This adds proper `types` conditions to the `exports` field so type resolution works out of the box with any TypeScript module resolution strategy.

Fixes CUI-15