### PR TITLE
Valallint raw number reduce falsepositive

### DIFF
--- a/src/lib/valalint/rules/no-raw-number-in-jsx.mjs
+++ b/src/lib/valalint/rules/no-raw-number-in-jsx.mjs
@@ -1,16 +1,38 @@
 import ts from 'typescript';
 
 /**
- * Returns true when the TypeScript type — or any member of a union — is a
- * numeric type (number primitive or a number literal type such as `42`).
+ * Returns true when the TypeScript type is a numeric type (number primitive or
+ * a number literal type such as `42`), or a union where number is the only
+ * non-nullish type (e.g., `number | undefined`, `number | null`).
+ *
+ * Does NOT match broad types like ReactNode where number is just one of many
+ * non-nullish options.
  */
-function typeIncludesNumber(type) {
+function isPureNumberType(type) {
     if (type.flags & ts.TypeFlags.Number) return true;
     if (type.flags & ts.TypeFlags.NumberLiteral) return true;
-    // Handle union types: `number | undefined`, `number | null`, `string | number`, …
+
+    // Handle union types: only flag if number is the primary type
+    // (i.e., the only non-nullish member)
     if (type.flags & ts.TypeFlags.Union) {
-        return type.types.some(t => typeIncludesNumber(t));
+        let hasNumber = false;
+        let hasOtherNonNullishType = false;
+
+        for (const t of type.types) {
+            // Check if this member is a number
+            if (t.flags & ts.TypeFlags.Number || t.flags & ts.TypeFlags.NumberLiteral) {
+                hasNumber = true;
+            }
+            // Check if this member is a non-nullish, non-number type
+            else if (!(t.flags & (ts.TypeFlags.Null | ts.TypeFlags.Undefined | ts.TypeFlags.Void))) {
+                hasOtherNonNullishType = true;
+            }
+        }
+
+        // Only flag if we have number and no other non-nullish types
+        return hasNumber && !hasOtherNonNullishType;
     }
+
     return false;
 }
 
@@ -53,7 +75,7 @@ const noRawNumberInJsx = {
                 const tsNode = services.esTreeNodeToTSNodeMap.get(expression);
                 const type = checker.getTypeAtLocation(tsNode);
 
-                if (typeIncludesNumber(type)) {
+                if (isPureNumberType(type)) {
                     context.report({ node, messageId: 'rawNumber' });
                 }
             },

--- a/src/lib/valalint/rules/no-raw-number-in-jsx.test.js
+++ b/src/lib/valalint/rules/no-raw-number-in-jsx.test.js
@@ -118,6 +118,28 @@ tester.run('no-raw-number-in-jsx', rule, {
             code: 'const el = <Text>{/* comment */}</Text>;',
             filename,
         },
+
+        // ── Broad union types containing number — not flagged ─────────────────
+        {
+            // string | number — broad union, not a pure number type
+            code: 'declare const value: string | number; const el = <Text>{value}</Text>;',
+            filename,
+        },
+        {
+            // boolean | number — broad union
+            code: 'declare const value: boolean | number; const el = <Text>{value}</Text>;',
+            filename,
+        },
+        {
+            // ReactNode type — includes number but is not a pure number type
+            code: 'import type { ReactNode } from "react"; declare const content: ReactNode; const el = <Text>{content}</Text>;',
+            filename,
+        },
+        {
+            // string | number | null — multiple non-nullish types
+            code: 'declare const value: string | number | null; const el = <Text>{value}</Text>;',
+            filename,
+        },
     ],
 
     // ─── Invalid ──────────────────────────────────────────────────────────────
@@ -192,16 +214,22 @@ tester.run('no-raw-number-in-jsx', rule, {
             errors: [{ message: ERROR }],
         },
 
-        // ── Union types that include number ───────────────────────────────────
+        // ── Pure number types with nullish companions ─────────────────────────
         {
-            // number | undefined — when defined it would render an unformatted number
+            // number | undefined — pure number type, only null/undefined companions
             code: 'declare const count: number | undefined; const el = <Text>{count}</Text>;',
             filename,
             errors: [{ message: ERROR }],
         },
         {
-            // string | number
-            code: 'declare const value: string | number; const el = <Text>{value}</Text>;',
+            // number | null — pure number type with null
+            code: 'declare const count: number | null; const el = <Text>{count}</Text>;',
+            filename,
+            errors: [{ message: ERROR }],
+        },
+        {
+            // number | null | undefined — pure number type with multiple nullish
+            code: 'declare const count: number | null | undefined; const el = <Text>{count}</Text>;',
             filename,
             errors: [{ message: ERROR }],
         },


### PR DESCRIPTION
Reduce the number of false positive with the rule no raw number in jsx by not raising warning for types that includes but are not necessarly number. Aka `<Text>{reactNode}</Text>` does not raise a warning anymore because it allows number. Only `number[[ | undefined] | null]` does.