### PR TITLE
Remove rounded edges on progress bar

### DIFF
--- a/src/lib/components/circularprogressbar/CircularProgressBar.component.style.ts
+++ b/src/lib/components/circularprogressbar/CircularProgressBar.component.style.ts
@@ -21,7 +21,6 @@ export const ProgressCircle = styled.circle<{
     ((100 - percent) / 100) * circumference};
   stroke: ${(props) => props.color || props.theme.statusHealthy};
   stroke-width: ${(props) => props.strokeWidth};
-  stroke-linecap: round;
   fill: none;
 `;
 export const BackgroundCircle = styled.circle<{ backgroundColor?: string }>`

--- a/src/lib/components/circularprogressbar/CircularProgressBar.component.tsx
+++ b/src/lib/components/circularprogressbar/CircularProgressBar.component.tsx
@@ -1,9 +1,10 @@
 import {
-  CircularProgressBarContainer,
-  Title,
-  ProgressCircle,
   BackgroundCircle,
+  CircularProgressBarContainer,
+  ProgressCircle,
+  Title,
 } from './CircularProgressBar.component.style';
+
 type Props = {
   percent: number;
   radius: number;
@@ -14,6 +15,29 @@ type Props = {
   children?: JSX.Element;
 };
 
+/**
+ *
+ * 
+ * @example 
+ * <CircularProgressBar 
+ * title="Total Capacity" 
+ * percent={60} 
+ * radius={70} 
+ * color="red" 
+ * backgroundColor="blue" 
+ * strokeWidth={10} 
+ * > 
+ * 	<text
+        x="50%"
+        y="50%"
+        dominantBaseline="middle"
+        textAnchor="middle"  
+        fontSize={fontSize.smaller}
+      >
+        text content
+      </text> 
+    </CircularProgressBar>
+ */
 function CircularProgressBar({
   percent,
   radius,


### PR DESCRIPTION
Remove the edges on the circular progress bar

Add an exemple of the text svg wrapper to place the content in center 