### PR TITLE
CUI-18: fix misleading pointer cursor on IconHelp button

### DIFF
--- a/src/lib/components/iconhelper/IconHelper.tsx
+++ b/src/lib/components/iconhelper/IconHelper.tsx
@@ -26,7 +26,8 @@ const HelpButton = styled.button`
   color: inherit;
   font: inherit;              /* Inherit font sizing */
   vertical-align: text-bottom;     /* Align with text */
-  line-height: 1;    
+  line-height: 1;
+  cursor: default;
   &:focus-visible {
     outline: 2px dashed ${(props) => props.theme.selectedActive};
     outline-offset: 2px;


### PR DESCRIPTION
Fix the `IconHelp` button showing a pointer cursor on hover despite having no click action.

Added `cursor: default` to the `HelpButton` styled component to override the browser's default pointer cursor for `<button>` elements. The `<button>` element is kept for keyboard accessibility.

JIRA: [CUI-18](https://scality.atlassian.net/browse/CUI-18)

[CUI-18]: https://scality.atlassian.net/browse/CUI-18?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ