### PR TITLE
Improve Style for horizontal separator (vertical line) in Stack

### DIFF
--- a/src/lib/spacing.tsx
+++ b/src/lib/spacing.tsx
@@ -35,8 +35,8 @@ export const spacing = {
 
 const HSeparator = styled.div`
   background: ${(props) => props.theme.border};
-  width: 1px;
-  align-self: stretch; 
+  width: ${spacing.r1};
+  align-self: stretch;
   flex-shrink: 0;
   margin: ${spacing.r12} 0px;
 `;

--- a/src/lib/spacing.tsx
+++ b/src/lib/spacing.tsx
@@ -34,7 +34,7 @@ export const spacing = {
 };
 
 const HSeparator = styled.div`
-  background: ${(props) => props.theme.backgroundLevel1};
+  background: ${(props) => props.theme.border};
   width: 1px;
   align-self: stretch; 
   flex-shrink: 0;

--- a/src/lib/spacing.tsx
+++ b/src/lib/spacing.tsx
@@ -34,9 +34,11 @@ export const spacing = {
 };
 
 const HSeparator = styled.div`
-  min-height: ${spacing.r40};
-  min-width: ${spacing.r2};
-  background: ${(props) => props.theme.border};
+  background: ${(props) => props.theme.backgroundLevel1};
+  width: 1px;
+  align-self: stretch; 
+  flex-shrink: 0;
+  margin: ${spacing.r12} 0px;
 `;
 
 const VSeparator = styled.div`


### PR DESCRIPTION
Change the style for the horizontal Stack separator (vertical line)
Before:
<img width="602" height="104" alt="image" src="https://github.com/user-attachments/assets/f6fb548a-46f1-4ae6-9837-72a21db81505" />


After discussion on the separator color, decision is to keep the border color. Black color (backgroundLevel1) separator was barely visible on some screen or on some background.

Now:
<img width="846" height="123" alt="image" src="https://github.com/user-attachments/assets/a859e49d-acfb-4a83-8f35-f12a7fb0d4cd" />


