### PR TITLE
fix(Tooltip): prevent long words from overflowing tooltip container

### DIFF
--- a/src/lib/components/tooltip/Tooltip.component.tsx
+++ b/src/lib/components/tooltip/Tooltip.component.tsx
@@ -63,6 +63,7 @@ const TooltipOverLayContainer = styled.div<{
 
 const TooltipText = styled.div`
   width: 100%;
+  overflow-wrap: break-word;
   ul,
   ol {
     padding-inline-start: ${spacing.r16};

--- a/stories/tooltip.stories.tsx
+++ b/stories/tooltip.stories.tsx
@@ -168,3 +168,27 @@ export const WithoutOverlay = {
     );
   },
 };
+
+
+export const LongWordOverflow = {
+  render: () => {
+    return (
+      <Wrapper>
+        <div style={{ display: 'flex', gap: '4rem' }}>
+          <div>
+            <SubTitle>Long endpoint URL</SubTitle>
+            <Tooltip overlay="https://s3.us-east-1.amazonaws.com/my-very-long-bucket-name/path/to/some/deeply/nested/object-key.tar.gz">
+              <SubTitle>Hover here!</SubTitle>
+            </Tooltip>
+          </div>
+          <div>
+            <SubTitle>Normal text (still wraps at word boundaries)</SubTitle>
+            <Tooltip overlay="This is a longer tooltip message that should wrap naturally at word boundaries without breaking mid-word.">
+              <SubTitle>Hover here!</SubTitle>
+            </Tooltip>
+          </div>
+        </div>
+      </Wrapper>
+    );
+  },
+};


### PR DESCRIPTION
Add rule to wrap a word if it will overflow in the Tooltip:
Example of issue:
<img width="932" height="856" alt="image" src="https://github.com/user-attachments/assets/be762332-6859-47f4-be52-7ed6f7b6bc5e" />

Result:
<img width="781" height="323" alt="image" src="https://github.com/user-attachments/assets/252c85a5-4ab7-45c0-b26b-261a710842e2" />
