### PR TITLE
Improvement/chart modern style

### DIFF
--- a/src/lib/components/charts/common/SharedComponents.tsx
+++ b/src/lib/components/charts/common/SharedComponents.tsx
@@ -76,29 +76,30 @@ interface ChartHeaderProps {
   secondaryTitle?: string;
   helpTooltip?: React.ReactNode;
   rightTitle?: React.ReactNode;
+  isLoading?: boolean;
 }
 
 /**
  * Shared chart header component
- * Used by Barchart and can be used by other charts
+ * Used by Barchart and LineTimeSerieChart
  */
 export const ChartHeader = ({
   title,
   secondaryTitle,
   helpTooltip,
   rightTitle,
+  isLoading,
 }: ChartHeaderProps) => {
   return (
     <Wrap>
       <Stack gap="r4">
-        <Text variant="ChartTitle">{title}</Text>
+        {title && <Text variant="ChartTitle">{title}</Text>}
         {helpTooltip && (
           <IconHelp
             tooltipMessage={helpTooltip}
             overlayStyle={maxWidthTooltip}
           />
         )}
-
         {secondaryTitle && (
           <Text
             color="textSecondary"
@@ -109,9 +110,10 @@ export const ChartHeader = ({
             {secondaryTitle}
           </Text>
         )}
+        {isLoading && <Loader />}
       </Stack>
 
-      {rightTitle && <Text>{rightTitle}</Text>}
+      {rightTitle}
     </Wrap>
   );
 };

--- a/src/lib/components/charts/legend/ChartLegend.tsx
+++ b/src/lib/components/charts/legend/ChartLegend.tsx
@@ -71,6 +71,7 @@ export const ChartLegend = ({
   const {
     listResources,
     getColor,
+    getLabel,
     isSelected,
     addSelectedResource,
     removeSelectedResource,
@@ -134,7 +135,7 @@ export const ChartLegend = ({
               shape={shape}
               chartColors={chartColors}
             />
-            <Text variant={legendSize}>{resource}</Text>
+            <Text variant={legendSize}>{getLabel(resource)}</Text>
           </LegendItem>
         );
       })}

--- a/src/lib/components/charts/legend/ChartLegend.tsx
+++ b/src/lib/components/charts/legend/ChartLegend.tsx
@@ -1,7 +1,7 @@
 import styled from 'styled-components';
 import { useChartLegend } from './ChartLegendWrapper';
 import { Text, TextVariant } from '../../text/Text.component';
-import { chartColors } from '../../../style/theme';
+import { chartColors, CoreUITheme } from '../../../style/theme';
 import { useCallback } from 'react';
 
 type ChartLegendProps = {
@@ -9,6 +9,7 @@ type ChartLegendProps = {
   disabled?: boolean;
   direction?: 'horizontal' | 'vertical';
   legendSize?: TextVariant;
+  legendColor?: keyof CoreUITheme;
 };
 
 const Legend = styled.div<{ direction: 'horizontal' | 'vertical' }>`
@@ -67,6 +68,7 @@ export const ChartLegend = ({
   disabled = false,
   direction = 'horizontal',
   legendSize = 'Basic',
+  legendColor,
 }: ChartLegendProps) => {
   const {
     listResources,
@@ -135,7 +137,7 @@ export const ChartLegend = ({
               shape={shape}
               chartColors={chartColors}
             />
-            <Text variant={legendSize}>{getLabel(resource)}</Text>
+            <Text variant={legendSize} color={legendColor}>{getLabel(resource)}</Text>
           </LegendItem>
         );
       })}

--- a/src/lib/components/charts/legend/ChartLegendWrapper.tsx
+++ b/src/lib/components/charts/legend/ChartLegendWrapper.tsx
@@ -29,10 +29,12 @@ export type ChartLegendState = {
   selectOnlyResource: (resource: string) => void;
   isSelected: (resource: string) => boolean;
   getColor: (resource: string) => string | undefined;
+  getLabel: (resource: string) => string;
   listResources: () => string[];
   isOnlyOneSelected: () => boolean;
   register: (chartId: string, seriesNames: string[]) => void;
 };
+
 
 const ChartLegendContext = createContext<ChartLegendState | null>(null);
 
@@ -42,12 +44,15 @@ export type ChartLegendWrapperProps = {
     | Record<string, ChartColors | string>
     | ((seriesNames: string[]) => Record<string, ChartColors | string>);
   sortOrder?: 'alphabetical' | 'status' | ((a: string, b: string) => number);
+  /** Optional display labels for legend items, keyed by resource name */
+  labelMap?: Record<string, string>;
 };
 
 export const ChartLegendWrapper = ({
   children,
   colorSet,
   sortOrder = 'alphabetical',
+  labelMap,
 }: ChartLegendWrapperProps) => {
   const [registeredColorSets, setRegisteredColorSets] = useState<
     Record<string, string[]>
@@ -134,6 +139,11 @@ export const ChartLegendWrapper = ({
     [internalColorSet],
   );
 
+  const getLabel = useCallback(
+    (resource: string) => labelMap?.[resource] ?? resource,
+    [labelMap],
+  );
+
   const listResources = useCallback(() => {
     const resources = Object.keys(internalColorSet);
 
@@ -159,6 +169,7 @@ export const ChartLegendWrapper = ({
       selectOnlyResource,
       isSelected,
       getColor,
+      getLabel,
       listResources,
       isOnlyOneSelected,
       register,
@@ -171,6 +182,7 @@ export const ChartLegendWrapper = ({
       selectOnlyResource,
       isSelected,
       getColor,
+      getLabel,
       listResources,
       isOnlyOneSelected,
       register,

--- a/src/lib/components/charts/linetimeseries/LineTimeSerieChart.tsx
+++ b/src/lib/components/charts/linetimeseries/LineTimeSerieChart.tsx
@@ -56,12 +56,12 @@ export function LineTimeSerieChart({
   yAxisTitle,
   helpText,
   rightTitle,
-  preset = 'default',
+  displayPreset = 'default',
   displayOptions,
   syncId,
   renderTooltip,
 }: LineChartProps) {
-  const presetOptions = CHART_PRESETS[preset];
+  const presetOptions = CHART_PRESETS[displayPreset];
   const resolvedNoBackground = displayOptions?.noBackground ?? presetOptions.noBackground;
   const resolvedShowHorizontalGridLines = displayOptions?.showHorizontalGridLines ?? presetOptions.showHorizontalGridLines;
   const resolvedNoHeader = displayOptions?.noHeader ?? presetOptions.noHeader;

--- a/src/lib/components/charts/linetimeseries/LineTimeSerieChart.tsx
+++ b/src/lib/components/charts/linetimeseries/LineTimeSerieChart.tsx
@@ -15,7 +15,7 @@ import { fontSize } from '../../../style/theme';
 import { ChartHeader, StyledResponsiveContainer } from '../common/SharedComponents';
 import { formatTickValue, getTicks } from '../common/chartUtils';
 import { formatXAxisLabel } from './LineTimeSerieChart.utils';
-import { LineChartProps } from './LineTimeSerieChart.types';
+import { LineChartProps, CHART_PRESETS } from './LineTimeSerieChart.types';
 import { LineTimeSerieChartTooltip } from './LineTimeSerieChartTooltip';
 import { useChartHover } from './useChartHover';
 import { useChartData } from './useChartData';
@@ -56,12 +56,17 @@ export function LineTimeSerieChart({
   yAxisTitle,
   helpText,
   rightTitle,
-  showHorizontalGridLines = false,
-  noBackground = false,
-  noHeader = false,
+  preset = 'default',
+  displayOptions,
   syncId,
   renderTooltip,
 }: LineChartProps) {
+  const presetOptions = CHART_PRESETS[preset];
+  const resolvedNoBackground = displayOptions?.noBackground ?? presetOptions.noBackground;
+  const resolvedShowHorizontalGridLines = displayOptions?.showHorizontalGridLines ?? presetOptions.showHorizontalGridLines;
+  const resolvedNoHeader = displayOptions?.noHeader ?? presetOptions.noHeader;
+  const resolvedNoYAxisLine = displayOptions?.noYAxisLine ?? presetOptions.noYAxisLine;
+
   const theme = useTheme();
   const chartRef = useRef(null);
 
@@ -100,7 +105,7 @@ export function LineTimeSerieChart({
 
   return (
     <LineTemporalChartWrapper>
-      {!noHeader && (
+      {!resolvedNoHeader && (
         <ChartHeader
           title={`${title}${unitLabel ? ` (${unitLabel})` : ''}`}
           helpTooltip={helpText}
@@ -136,10 +141,11 @@ export function LineTimeSerieChart({
 
           <CartesianGrid
             vertical={false}
-            horizontal={showHorizontalGridLines}
+            horizontal={resolvedShowHorizontalGridLines}
             stroke={theme.border}
             strokeOpacity={0.4}
-            fill={noBackground ? 'transparent' : theme.backgroundLevel4}
+            syncWithTicks={true}
+            fill={resolvedNoBackground ? 'transparent' : theme.backgroundLevel4}
           />
           <XAxis
             dataKey="timestamp"
@@ -171,7 +177,7 @@ export function LineTimeSerieChart({
                 : [0, topDomain]
             }
             allowDataOverflow={true}
-            axisLine={{ stroke: theme.border }}
+            axisLine={resolvedNoYAxisLine ? false : { stroke: theme.border }}
             tick={{
               fill: theme.textSecondary,
               fontSize: fontSize.smaller,

--- a/src/lib/components/charts/linetimeseries/LineTimeSerieChart.tsx
+++ b/src/lib/components/charts/linetimeseries/LineTimeSerieChart.tsx
@@ -1,8 +1,9 @@
 import React, { useCallback, useRef } from 'react';
 import {
+  Area,
   CartesianGrid,
+  ComposedChart,
   Line,
-  LineChart,
   ReferenceLine,
   Tooltip,
   TooltipContentProps,
@@ -10,13 +11,9 @@ import {
   YAxis,
 } from 'recharts';
 import styled, { useTheme } from 'styled-components';
-import { Stack } from '../../../spacing';
 import { fontSize } from '../../../style/theme';
-import { IconHelp } from '../../iconhelper/IconHelper';
-import { Loader } from '../../loader/Loader.component';
-import { ChartTitleText } from '../../text/Text.component';
-import { StyledResponsiveContainer } from '../common/SharedComponents';
-import { formatTickValue, getTicks, maxWidthTooltip } from '../common/chartUtils';
+import { ChartHeader, StyledResponsiveContainer } from '../common/SharedComponents';
+import { formatTickValue, getTicks } from '../common/chartUtils';
 import { formatXAxisLabel } from './LineTimeSerieChart.utils';
 import { LineChartProps } from './LineTimeSerieChart.types';
 import { LineTimeSerieChartTooltip } from './LineTimeSerieChartTooltip';
@@ -58,6 +55,9 @@ export function LineTimeSerieChart({
   yAxisType = 'default',
   yAxisTitle,
   helpText,
+  rightTitle,
+  showHorizontalGridLines = false,
+  noHeader = false,
   syncId,
   renderTooltip,
 }: LineChartProps) {
@@ -99,20 +99,18 @@ export function LineTimeSerieChart({
 
   return (
     <LineTemporalChartWrapper>
-      <Stack gap="r4">
-        <ChartTitleText>
-          {title} {unitLabel && `(${unitLabel})`}
-        </ChartTitleText>
-        {helpText && (
-          <IconHelp tooltipMessage={helpText} overlayStyle={maxWidthTooltip} />
-        )}
-        {isLoading && <Loader />}
-      </Stack>
+      {!noHeader && (
+        <ChartHeader
+          title={`${title}${unitLabel ? ` (${unitLabel})` : ''}`}
+          helpTooltip={helpText}
+          isLoading={isLoading}
+          rightTitle={rightTitle}
+        />
+      )}
 
       <StyledResponsiveContainer width="100%" height={height}>
-        <LineChart
+        <ComposedChart
           ref={chartRef}
-
           data={rechartsData}
           margin={{ top: 0, right: 0, bottom: 0, left: 0 }}
           aria-label={`Time series chart for ${title}`}
@@ -121,14 +119,26 @@ export function LineTimeSerieChart({
           onMouseEnter={handleMouseEnter}
           onMouseLeave={handleMouseLeave}
         >
+          {/* Gradient definitions for series with withGradient */}
+          <defs>
+            {linesToRender.filter((l) => l.withGradient).map((line) => (
+              <linearGradient
+                key={`${title}-${line.key}`}
+                id={`gradient-${chartId}-${line.key}`}
+                x1="0" y1="0" x2="0" y2="1"
+              >
+                <stop offset="5%" stopColor={line.stroke} stopOpacity={0.18} />
+                <stop offset="95%" stopColor={line.stroke} stopOpacity={0} />
+              </linearGradient>
+            ))}
+          </defs>
+
           <CartesianGrid
-            vertical={true}
-            horizontal={true}
-            verticalPoints={[0]}
-            horizontalPoints={[0]}
+            vertical={false}
+            horizontal={showHorizontalGridLines}
             stroke={theme.border}
+            strokeOpacity={0.4}
             fill={theme.backgroundLevel4}
-            strokeWidth={1}
           />
           <XAxis
             dataKey="timestamp"
@@ -183,24 +193,38 @@ export function LineTimeSerieChart({
               />
             )}
           />
-          {/* Add horizontal line at y=0 for symmetrical charts */}
+          {/* Horizontal reference line at y=0 for symmetrical charts */}
           {yAxisType === 'symmetrical' && (
             <ReferenceLine y={0} stroke={theme.border} />
           )}
 
-          {/* Chart lines */}
-          {linesToRender.map((line) => (
-            <Line
-              key={`${title}-${line.key}`}
-              type="monotone"
-              dataKey={line.dataKey}
-              stroke={line.stroke}
-              dot={false}
-              isAnimationActive={false}
-              strokeDasharray={line.strokeDasharray}
-            />
-          ))}
-        </LineChart>
+          {/* Chart lines — Area for gradient series, Line otherwise */}
+          {linesToRender.map((line) =>
+            line.withGradient ? (
+              <Area
+                key={`${title}-${line.key}`}
+                type="monotone"
+                dataKey={line.dataKey}
+                stroke={line.stroke}
+                strokeWidth={1.5}
+                fill={`url(#gradient-${chartId}-${line.key})`}
+                fillOpacity={1}
+                dot={false}
+                isAnimationActive={false}
+              />
+            ) : (
+              <Line
+                key={`${title}-${line.key}`}
+                type="monotone"
+                dataKey={line.dataKey}
+                stroke={line.stroke}
+                dot={false}
+                isAnimationActive={false}
+                strokeDasharray={line.strokeDasharray}
+              />
+            )
+          )}
+        </ComposedChart>
       </StyledResponsiveContainer>
     </LineTemporalChartWrapper >
   );

--- a/src/lib/components/charts/linetimeseries/LineTimeSerieChart.tsx
+++ b/src/lib/components/charts/linetimeseries/LineTimeSerieChart.tsx
@@ -57,6 +57,7 @@ export function LineTimeSerieChart({
   helpText,
   rightTitle,
   showHorizontalGridLines = false,
+  noBackground = false,
   noHeader = false,
   syncId,
   renderTooltip,
@@ -138,7 +139,7 @@ export function LineTimeSerieChart({
             horizontal={showHorizontalGridLines}
             stroke={theme.border}
             strokeOpacity={0.4}
-            fill={theme.backgroundLevel4}
+            fill={noBackground ? 'transparent' : theme.backgroundLevel4}
           />
           <XAxis
             dataKey="timestamp"

--- a/src/lib/components/charts/linetimeseries/LineTimeSerieChart.types.ts
+++ b/src/lib/components/charts/linetimeseries/LineTimeSerieChart.types.ts
@@ -74,12 +74,12 @@ export type LineChartProps = (
    *
    * @example
    * // Use the modern preset as-is
-   * <LineTimeSerieChart preset="modern" ... />
+   * <LineTimeSerieChart displayPreset="modern" ... />
    *
    * // Use modern but keep the header
-   * <LineTimeSerieChart preset="modern" displayOptions={{ noHeader: false }} ... />
+   * <LineTimeSerieChart displayPreset="modern" displayOptions={{ noHeader: false }} ... />
    */
-  preset?: 'default' | 'modern';
+  displayPreset?: 'default' | 'modern';
   /**
    * Fine-grained overrides applied on top of the active `preset`.
    * Only the properties you specify are overridden; the rest come from the preset.

--- a/src/lib/components/charts/linetimeseries/LineTimeSerieChart.types.ts
+++ b/src/lib/components/charts/linetimeseries/LineTimeSerieChart.types.ts
@@ -65,6 +65,8 @@ export type LineChartProps = (
   rightTitle?: React.ReactNode;
   /** Whether to display horizontal grid lines */
   showHorizontalGridLines?: boolean;
+  /** Remove the chart area background fill */
+  noBackground?: boolean;
   /** Hide the chart header (title, help, loading indicator, rightTitle) */
   noHeader?: boolean;
   /** Custom tooltip renderer */

--- a/src/lib/components/charts/linetimeseries/LineTimeSerieChart.types.ts
+++ b/src/lib/components/charts/linetimeseries/LineTimeSerieChart.types.ts
@@ -84,7 +84,7 @@ type DisplayOptions = Required<NonNullable<LineChartProps['displayOptions']>>;
 
 export const CHART_PRESETS: Record<'default' | 'modern', DisplayOptions> = {
   default: { noBackground: false, showHorizontalGridLines: false, noHeader: false, noYAxisLine: false },
-  modern:  { noBackground: true,  showHorizontalGridLines: true,  noHeader: false, noYAxisLine: true  },
+  modern:  { noBackground: true,  showHorizontalGridLines: true,  noHeader: true,  noYAxisLine: true  },
 };
 
 export type LineTimeSerieChartTooltipProps = {

--- a/src/lib/components/charts/linetimeseries/LineTimeSerieChart.types.ts
+++ b/src/lib/components/charts/linetimeseries/LineTimeSerieChart.types.ts
@@ -11,6 +11,8 @@ export type Serie = {
   metricPrefix?: string;
   /** Whether the line should be dashed */
   isLineDashed?: boolean;
+  /** Whether to render a gradient fill under the line */
+  withGradient?: boolean;
 };
 
 export type NonSymmetricalChartSerie = {
@@ -59,6 +61,12 @@ export type LineChartProps = (
   yAxisTitle?: string;
   /** Help text displayed as a tooltip icon */
   helpText?: string;
+  /** Optional content rendered on the right side of the chart header */
+  rightTitle?: React.ReactNode;
+  /** Whether to display horizontal grid lines */
+  showHorizontalGridLines?: boolean;
+  /** Hide the chart header (title, help, loading indicator, rightTitle) */
+  noHeader?: boolean;
   /** Custom tooltip renderer */
   renderTooltip?: (
     tooltipProps: TooltipContentProps<number, string>,

--- a/src/lib/components/charts/linetimeseries/LineTimeSerieChart.types.ts
+++ b/src/lib/components/charts/linetimeseries/LineTimeSerieChart.types.ts
@@ -63,9 +63,36 @@ export type LineChartProps = (
   helpText?: string;
   /** Optional content rendered on the right side of the chart header */
   rightTitle?: React.ReactNode;
-  /** Named display preset; displayOptions overrides individual values */
+  /**
+   * Named display preset that sets a group of visual defaults at once.
+   *
+   * - `'default'` — opaque background, no grid lines, header visible, Y-axis line visible.
+   * - `'modern'`  — transparent background, horizontal grid lines, no header, no Y-axis line.
+   *
+   * Individual values can be overridden with `displayOptions`.
+   * Defaults to `'default'` when omitted.
+   *
+   * @example
+   * // Use the modern preset as-is
+   * <LineTimeSerieChart preset="modern" ... />
+   *
+   * // Use modern but keep the header
+   * <LineTimeSerieChart preset="modern" displayOptions={{ noHeader: false }} ... />
+   */
   preset?: 'default' | 'modern';
-  /** Display options — overrides the preset values */
+  /**
+   * Fine-grained overrides applied on top of the active `preset`.
+   * Only the properties you specify are overridden; the rest come from the preset.
+   *
+   * - `noBackground`            — removes the chart background (transparent).
+   * - `showHorizontalGridLines` — draws horizontal grid lines across the plot area.
+   * - `noHeader`                — hides the title/help-text/right-title header row.
+   * - `noYAxisLine`             — hides the vertical Y-axis line.
+   *
+   * @example
+   * // Add grid lines to the default preset
+   * <LineTimeSerieChart displayOptions={{ showHorizontalGridLines: true }} ... />
+   */
   displayOptions?: {
     noBackground?: boolean;
     showHorizontalGridLines?: boolean;

--- a/src/lib/components/charts/linetimeseries/LineTimeSerieChart.types.ts
+++ b/src/lib/components/charts/linetimeseries/LineTimeSerieChart.types.ts
@@ -63,18 +63,28 @@ export type LineChartProps = (
   helpText?: string;
   /** Optional content rendered on the right side of the chart header */
   rightTitle?: React.ReactNode;
-  /** Whether to display horizontal grid lines */
-  showHorizontalGridLines?: boolean;
-  /** Remove the chart area background fill */
-  noBackground?: boolean;
-  /** Hide the chart header (title, help, loading indicator, rightTitle) */
-  noHeader?: boolean;
+  /** Named display preset; displayOptions overrides individual values */
+  preset?: 'default' | 'modern';
+  /** Display options — overrides the preset values */
+  displayOptions?: {
+    noBackground?: boolean;
+    showHorizontalGridLines?: boolean;
+    noHeader?: boolean;
+    noYAxisLine?: boolean;
+  };
   /** Custom tooltip renderer */
   renderTooltip?: (
     tooltipProps: TooltipContentProps<number, string>,
     unitLabel?: string,
     duration?: number,
   ) => React.ReactNode;
+};
+
+type DisplayOptions = Required<NonNullable<LineChartProps['displayOptions']>>;
+
+export const CHART_PRESETS: Record<'default' | 'modern', DisplayOptions> = {
+  default: { noBackground: false, showHorizontalGridLines: false, noHeader: false, noYAxisLine: false },
+  modern:  { noBackground: true,  showHorizontalGridLines: true,  noHeader: false, noYAxisLine: true  },
 };
 
 export type LineTimeSerieChartTooltipProps = {

--- a/src/lib/components/charts/linetimeseries/useChartData.ts
+++ b/src/lib/components/charts/linetimeseries/useChartData.ts
@@ -20,6 +20,7 @@ export type LineToRender = {
   dataKey: string;
   stroke: string;
   strokeDasharray?: string;
+  withGradient?: boolean;
 };
 
 type ChartDataOutput = {
@@ -288,6 +289,7 @@ export function useChartData({
           dataKey: label,
           stroke: getColor(serie.resource) || '',
           strokeDasharray: serie.isLineDashed ? '4 4' : undefined,
+          withGradient: serie.withGradient,
         };
       });
   }, [series, getColor, selectedResources, isSeriesEmpty]);

--- a/stories/linetimeseriechart.stories.tsx
+++ b/stories/linetimeseriechart.stories.tsx
@@ -1208,7 +1208,7 @@ export const ModernPreset: Story = {
     yAxisType: 'percentage',
     interval: SAMPLE_FREQUENCY_LAST_TWENTY_FOUR_HOURS,
     duration: SAMPLE_DURATION_LAST_TWENTY_FOUR_HOURS,
-    preset: 'modern',
+    displayPreset: 'modern',
   },
 };
 

--- a/stories/linetimeseriechart.stories.tsx
+++ b/stories/linetimeseriechart.stories.tsx
@@ -810,7 +810,7 @@ export const WithGridLines: Story = {
     yAxisType: 'percentage',
     interval: SAMPLE_FREQUENCY_LAST_TWENTY_FOUR_HOURS,
     duration: SAMPLE_DURATION_LAST_TWENTY_FOUR_HOURS,
-    showHorizontalGridLines: true,
+    displayOptions: { showHorizontalGridLines: true },
   },
 };
 
@@ -866,7 +866,7 @@ export const WithGridLinesAndGradient: Story = {
         yAxisType="default"
         interval={SAMPLE_FREQUENCY_LAST_TWENTY_FOUR_HOURS}
         duration={SAMPLE_DURATION_LAST_TWENTY_FOUR_HOURS}
-        showHorizontalGridLines
+        displayOptions={{ showHorizontalGridLines: true }}
       />
       <ChartLegend shape="line" />
     </ChartLegendWrapper>
@@ -1192,6 +1192,26 @@ const generateBigValuesData2 = (): [number, string][] => {
 
 const bigValuesData = generateBigValuesData();
 const bigValuesData2 = generateBigValuesData2();
+export const ModernPreset: Story = {
+  args: {
+    series: [
+      {
+        data: prometheusData as [number, string | number | null][],
+        resource: 'ip-10-160-122-207.eu-north-1.compute.internal',
+        getTooltipLabel: (_prefix, resource) => `${resource}`,
+        withGradient: true,
+      },
+    ],
+    title: 'CPU Usage',
+    height: 200,
+    startingTimeStamp: prometheusData[0][0] as number,
+    yAxisType: 'percentage',
+    interval: SAMPLE_FREQUENCY_LAST_TWENTY_FOUR_HOURS,
+    duration: SAMPLE_DURATION_LAST_TWENTY_FOUR_HOURS,
+    preset: 'modern',
+  },
+};
+
 export const BigValuesExample: Story = {
   render: () => {
     return (

--- a/stories/linetimeseriechart.stories.tsx
+++ b/stories/linetimeseriechart.stories.tsx
@@ -793,6 +793,86 @@ export const CustomTooltipExample: Story = {
   },
 };
 
+// ─── showHorizontalGridLines ────────────────────────────────────────────────────────────
+
+export const WithGridLines: Story = {
+  args: {
+    series: [
+      {
+        data: prometheusData as [number, string | number | null][],
+        resource: 'ip-10-160-122-207.eu-north-1.compute.internal',
+        getTooltipLabel: (_prefix, resource) => `${resource}`,
+      },
+    ],
+    title: 'CPU Usage',
+    height: 200,
+    startingTimeStamp: prometheusData[0][0] as number,
+    yAxisType: 'percentage',
+    interval: SAMPLE_FREQUENCY_LAST_TWENTY_FOUR_HOURS,
+    duration: SAMPLE_DURATION_LAST_TWENTY_FOUR_HOURS,
+    showHorizontalGridLines: true,
+  },
+};
+
+// ─── withGradient ─────────────────────────────────────────────────────────────
+
+export const WithGradient: Story = {
+  args: {
+    series: [
+      {
+        data: prometheusData as [number, string | number | null][],
+        resource: 'ip-10-160-122-207.eu-north-1.compute.internal',
+        getTooltipLabel: (_prefix, resource) => `${resource}`,
+        withGradient: true,
+      },
+    ],
+    title: 'CPU Usage',
+    height: 200,
+    startingTimeStamp: prometheusData[0][0] as number,
+    yAxisType: 'percentage',
+    interval: SAMPLE_FREQUENCY_LAST_TWENTY_FOUR_HOURS,
+    duration: SAMPLE_DURATION_LAST_TWENTY_FOUR_HOURS,
+  },
+};
+
+// ─── Combined: grid lines + gradient (two series, design-style) ───────────────
+
+export const WithGridLinesAndGradient: Story = {
+  render: () => (
+    <ChartLegendWrapper
+      colorSet={{
+        'net-capacity': lineTimeSeriesColorRange[0],
+        'total-capacity': lineTimeSeriesColorRange[2],
+      }}
+    >
+      <LineTimeSerieChart
+        series={[
+          {
+            data: prometheusData as [number, string | number | null][],
+            resource: 'net-capacity',
+            getTooltipLabel: () => 'Net capacity',
+            withGradient: true,
+          },
+          {
+            data: prometheusData2 as [number, string | number | null][],
+            resource: 'total-capacity',
+            getTooltipLabel: () => 'Total capacity',
+            isLineDashed: true,
+          },
+        ]}
+        title="Net Capacity"
+        height={200}
+        startingTimeStamp={prometheusData[0][0] as number}
+        yAxisType="default"
+        interval={SAMPLE_FREQUENCY_LAST_TWENTY_FOUR_HOURS}
+        duration={SAMPLE_DURATION_LAST_TWENTY_FOUR_HOURS}
+        showHorizontalGridLines
+      />
+      <ChartLegend shape="line" />
+    </ChartLegendWrapper>
+  ),
+};
+
 // Dynamic colorSet example components
 const DynamicChart1 = (props) => {
   const chartId = useChartId();


### PR DESCRIPTION
## Context

New overview page design has a 'modern' look and feel that demand change in our chart style

## Summary

### Add new props to LineTimesSeriesChart 

`displayOptions` and `preset` to allow the customization of the chart
`displayOptions` allow flexibility  and p`reset` is a way to easily and with a single prop enable the look wanted

### Add labelMap

Chart have a getTooltip to change the display name of the serie but this was not used by chart Legend

### Add color prop for legend

Allow the change of legend color text as it is possible with size


## Result

### Default style
<img width="1464" height="328" alt="image" src="https://github.com/user-attachments/assets/f11d14f4-c7ae-4487-8782-5e7f8f1629c1" />

### Modern style

<img width="1464" height="369" alt="image" src="https://github.com/user-attachments/assets/13fafc33-c3ef-4c80-b32a-e717943c5a1e" />

