### PR TITLE
fix(tablev2): replace JSON.stringify with per-column String() matching in globalFilter

### DIFF
--- a/src/lib/components/tablev2/Tablev2.component.tsx
+++ b/src/lib/components/tablev2/Tablev2.component.tsx
@@ -195,11 +195,11 @@ function Table<
 
   const stringifyFilter = useMemo(() => {
     return (rows: Row<object>[], columnIds: string[], value) => {
+      const searchTerm = (value || '').toLowerCase();
       const filteredRows = rows.filter((row) => {
-        // we stringify the object to make sure we can match the value
-        return JSON.stringify(row.values)
-          .toLowerCase()
-          .includes((value || '').toLowerCase());
+        return columnIds.some((columnId) =>
+          String(row.values[columnId]).toLowerCase().includes(searchTerm),
+        );
       });
       return filteredRows;
     };

--- a/src/lib/components/tablev2/Tablev2.test.tsx
+++ b/src/lib/components/tablev2/Tablev2.test.tsx
@@ -128,4 +128,108 @@ describe('TableV2', () => {
 
     expect(rows.length).toBe(4);
   });
+
+  test('it should not produce false positive when searching for JSON brace character', async () => {
+    const { getAllByRole } = render(
+      <div>
+        <Table
+          columns={columns}
+          data={data}
+          defaultSortingKey={'firstName'}
+          globalFilter="{"
+        >
+          <Table.SingleSelectableContent
+            rowHeight="h40"
+            separationLineVariant="backgroundLevel3"
+          />
+        </Table>
+      </div>
+    );
+    await waitFor(() => screen.queryAllByRole('img', { hidden: true }));
+
+    const rows = getAllByRole('row');
+    // only the header row should remain, no data rows
+    expect(rows.length).toBe(1);
+  });
+
+  test('it should not produce false positive when searching for a column key name', async () => {
+    const { getAllByRole } = render(
+      <div>
+        <Table
+          columns={columns}
+          data={data}
+          defaultSortingKey={'firstName'}
+          globalFilter="firstName"
+        >
+          <Table.SingleSelectableContent
+            rowHeight="h40"
+            separationLineVariant="backgroundLevel3"
+          />
+        </Table>
+      </div>
+    );
+    await waitFor(() => screen.queryAllByRole('img', { hidden: true }));
+
+    const rows = getAllByRole('row');
+    // only the header row should remain, no data rows
+    expect(rows.length).toBe(1);
+  });
+
+  test('it should not produce false positive when searching for ISO date millisecond component', async () => {
+    const dateData = [
+      { name: 'Alpha', createdAt: new Date('2023-01-01T00:00:00.000Z') },
+      { name: 'Beta', createdAt: new Date('2023-06-15T12:30:45.123Z') },
+    ];
+    const dateColumns: TableProps['columns'] = [
+      { Header: 'Name', accessor: 'name' },
+      {
+        Header: 'Created At',
+        accessor: 'createdAt',
+        Cell: ({ value }: { value: Date }) => value.toLocaleDateString(),
+      },
+    ];
+
+    const { getAllByRole } = render(
+      <div>
+        <Table
+          columns={dateColumns}
+          data={dateData}
+          globalFilter=".000"
+        >
+          <Table.SingleSelectableContent
+            rowHeight="h40"
+            separationLineVariant="backgroundLevel3"
+          />
+        </Table>
+      </div>
+    );
+    await waitFor(() => screen.queryAllByRole('img', { hidden: true }));
+
+    const rows = getAllByRole('row');
+    // only the header row should remain, no data rows
+    expect(rows.length).toBe(1);
+  });
+
+  test('it should still match rows when search term appears in a column value', async () => {
+    const { getAllByRole } = render(
+      <div>
+        <Table
+          columns={columns}
+          data={data}
+          defaultSortingKey={'firstName'}
+          globalFilter="Yohann"
+        >
+          <Table.SingleSelectableContent
+            rowHeight="h40"
+            separationLineVariant="backgroundLevel3"
+          />
+        </Table>
+      </div>
+    );
+    await waitFor(() => screen.queryAllByRole('img', { hidden: true }));
+
+    const rows = getAllByRole('row');
+    expect(rows.length).toBe(2); // header + 1 matching data row
+    expect(rows[1]).toHaveTextContent(/Yohann/i);
+  });
 });


### PR DESCRIPTION
## Summary

Fixes false-positive matches in the TableV2 global filter caused by `JSON.stringify(row.values)` serializing the entire row object — including JSON structural characters (`{`, `}`), column ID keys (e.g. `firstName`), and full ISO-8601 date strings with milliseconds — as searchable text.

The fix replaces `JSON.stringify(row.values)` in `stringifyFilter` with a per-column iteration over `columnIds`, calling `String(row.values[columnId])` on each cell value and checking if any includes the search term (case-insensitive). This ensures only rendered column values are matched.

## Changes

- [x] **Step 1**: Fix `stringifyFilter` to use per-column `String()` matching — replaced `JSON.stringify(row.values)` with `columnIds.some()` loop using `String(row.values[columnId])`
- [x] **Step 2**: Add regression tests for false-positive search scenarios (4 new test cases covering JSON brace, column key name, ISO date milliseconds, and positive match confirmation)

## Test Results

All 7 tests pass:
- ✅ `it should display all the data`
- ✅ `it should sort by defaultSortingKey`
- ✅ `it should filterGlobally`
- ✅ `it should not produce false positive when searching for JSON brace character`
- ✅ `it should not produce false positive when searching for a column key name`
- ✅ `it should not produce false positive when searching for ISO date millisecond component`
- ✅ `it should still match rows when search term appears in a column value`

## Risks & Notes

The `columnIds` parameter passed by react-table v7's `useGlobalFilter` includes all columns where `disableGlobalFilter !== true`. This means columns explicitly excluded from global filtering will no longer be searchable — which is the correct behavior, unlike the previous `JSON.stringify` approach that searched everything indiscriminately.

## References

- **JIRA**: [RING-53752](https://scality.atlassian.net/browse/RING-53752)
- **Tracking Issue**: scality/agent-task#102

[RING-53752]: https://scality.atlassian.net/browse/RING-53752?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ