### PR TITLE
fix(tablev2): replace JSON.stringify with per-column String() matching in stringifyFilter

### DIFF
--- a/src/lib/components/tablev2/Tablev2.component.tsx
+++ b/src/lib/components/tablev2/Tablev2.component.tsx
@@ -193,6 +193,12 @@ function Table<
     ...sortTypes,
   };
 
+  // Custom global filter that matches the search term against individual column
+  // values using String() coercion. This avoids false positives that occur with
+  // JSON.stringify(row.values) — which would match JSON structural characters
+  // (e.g. '{'), column accessor keys (e.g. 'firstName'), and ISO date
+  // millisecond components (e.g. '.000Z') as searchable text.
+  // See: RING-53752 / scality/agent-task#102
   const stringifyFilter = useMemo(() => {
     return (rows: Row<object>[], columnIds: string[], value) => {
       const searchTerm = (value || '').toLowerCase();


### PR DESCRIPTION
## Summary

Replace `JSON.stringify(row.values)` in `stringifyFilter` with per-column `String(cellValue)` iteration over `columnIds`. The current approach serializes the entire row values object into JSON, which introduces JSON structural characters, column ID keys, and full ISO-8601 date strings (including milliseconds) as searchable text — causing false positives for queries like `"999"` or `"{"`. The fix iterates each visible column value individually and uses `String()` for serialization, matching only the values that are actually rendered in the table.

## JIRA Ticket

[RING-53752](https://scality.atlassian.net/browse/RING-53752)

## Tracking Issue

scality/agent-task#102

## Implementation Note

The core fix (replacing `JSON.stringify(row.values)` with per-column `String()` matching) and regression tests were already committed directly to `development/1.0` in commit `ed744b4`. This PR adds an explanatory code comment documenting the rationale for the fix to aid future maintainers.

## Changes

### Step Completion Checklist

- [x] **Step 1: Fix `stringifyFilter` to use per-column `String()` matching** — `src/lib/components/tablev2/Tablev2.component.tsx`
  - Replaced `JSON.stringify(row.values).toLowerCase().includes(...)` with `columnIds.some((columnId) => String(row.values[columnId]).toLowerCase().includes(searchTerm))`
  - Extracts `searchTerm` once outside the loop for efficiency
  - Added explanatory comment documenting the fix rationale (this PR)

- [x] **Step 2: Add regression tests for false-positive search scenarios** — `src/lib/components/tablev2/Tablev2.test.tsx`
  - ✅ No false positive on JSON brace character (`"{"`)
  - ✅ No false positive on column key name (`"firstName"`)
  - ✅ No false positive on ISO date millisecond component (`".000"`)
  - ✅ Positive match still works (`"Yohann"` matches expected row)

## Test Results

All 7 tests pass:
```
PASS src/lib/components/tablev2/Tablev2.test.tsx
  TableV2
    ✓ it should display all the data
    ✓ it should sort by defaultSortingKey
    ✓ it should filterGlobally
    ✓ it should not produce false positive when searching for JSON brace character
    ✓ it should not produce false positive when searching for a column key name
    ✓ it should not produce false positive when searching for ISO date millisecond component
    ✓ it should still match rows when search term appears in a column value

Tests: 7 passed, 7 total
```

## Risks & Notes

The `columnIds` parameter passed to the filter function by react-table v7 represents columns with `disableGlobalFilter !== true`. This is a behavior change from the indiscriminate `JSON.stringify` approach — columns with `disableGlobalFilter: true` will now correctly be excluded from search.

[RING-53752]: https://scality.atlassian.net/browse/RING-53752?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ