### PR TITLE
improvement(CUI-14): enforce checkbox label placement pattern

### DIFF
--- a/src/lib/components/checkbox/Checkbox.component.tsx
+++ b/src/lib/components/checkbox/Checkbox.component.tsx
@@ -19,6 +19,11 @@ const CheckboxInput = styled.input`
 	transform: scale(1.5);`;
 
 export type Props = {
+  /**
+   * Label displayed next to the checkbox.
+   * Use only for standalone checkboxes (not inside a FormGroup).
+   * When inside a FormGroup, set the label on FormGroup's `label` prop instead.
+   */
   label?: string;
   value?: string;
   checked?: boolean;


### PR DESCRIPTION
## Summary

- Add JSDoc to the `label` prop of `Checkbox` clarifying it should only be used for standalone checkboxes (not inside a `FormGroup`)

Jira: https://scality.atlassian.net/browse/CUI-14
