### PR TITLE
Added astronaut and microchip icons

### DIFF
--- a/src/lib/components/icon/iconTable.ts
+++ b/src/lib/components/icon/iconTable.ts
@@ -142,4 +142,6 @@ export const iconTable = {
   HeadSet: "fas faHeadset",
   HandSparkles: 'fas faHandSparkles',
   History: 'fas faClockRotateLeft',
+  Astronaut: 'fas faUserAstronaut',
+  Microchip: 'fas faMicrochip',
 };


### PR DESCRIPTION
## Summary
- Added `Astronaut` icon (`fas faUserAstronaut`) to the icon table
- Added `Microchip` icon (`fas faMicrochip`) to the icon table

## Test plan
- [ ] Verify both icons render correctly in the Storybook AllIcons story
- [ ] Verify icons can be used via `<Icon name="Astronaut" />` and `<Icon name="Microchip" />`

🤖 Generated with [Claude Code](https://claude.com/claude-code)