### PR TITLE
Add space for label

### DIFF
--- a/src/lib/components/charts/globalhealthbar/GlobalHealthBar.utils.test.ts
+++ b/src/lib/components/charts/globalhealthbar/GlobalHealthBar.utils.test.ts
@@ -207,6 +207,25 @@ describe('Health Bar Utils', () => {
         expect(visible).toBe(true);
       });
 
+      it('should apply week span thinning when space per tick is between 80 and 120px', () => {
+        // 7-day labels use long format (~100px wide); 700/7=100px passes the old 80px
+        // threshold but not the 120px threshold required for the long format
+        const chartWidth = 700;
+        const totalTicks = 7;
+        const span = TIME_CONSTANTS.ONE_WEEK;
+        const endTimestamp = Date.now();
+
+        expect(
+          calculateLabelVisibility(chartWidth, totalTicks, span, 0, endTimestamp),
+        ).toBe(true);
+        expect(
+          calculateLabelVisibility(chartWidth, totalTicks, span, 1, endTimestamp),
+        ).toBe(false);
+        expect(
+          calculateLabelVisibility(chartWidth, totalTicks, span, 2, endTimestamp),
+        ).toBe(true);
+      });
+
       it('should apply week span rules when space is limited', () => {
         const chartWidth = 200;
         const totalTicks = 7;

--- a/src/lib/components/charts/globalhealthbar/GlobalHealthBar.utils.ts
+++ b/src/lib/components/charts/globalhealthbar/GlobalHealthBar.utils.ts
@@ -28,6 +28,7 @@ export const TIME_CONSTANTS = {
 
 export const LABEL_CONFIG = {
   MIN_SPACE_PER_TICK: 80,
+  MIN_SPACE_PER_TICK_LONG_FORMAT: 120,
   MODULO_CONFIG: {
     [TIME_CONSTANTS.ONE_WEEK]: 2,
     [TIME_CONSTANTS.ONE_DAY]: 3,
@@ -130,8 +131,11 @@ export const calculateLabelVisibility = (
   index: number,
   endTimestamp: number,
 ): boolean => {
-  const hasEnoughSpace =
-    chartWidth / totalTicks > LABEL_CONFIG.MIN_SPACE_PER_TICK;
+  const minSpacePerTick =
+    span === TIME_CONSTANTS.ONE_WEEK
+      ? LABEL_CONFIG.MIN_SPACE_PER_TICK_LONG_FORMAT
+      : LABEL_CONFIG.MIN_SPACE_PER_TICK;
+  const hasEnoughSpace = chartWidth / totalTicks > minSpacePerTick;
 
   // If enough space, show all labels
   if (hasEnoughSpace) return true;


### PR DESCRIPTION
On Health bar with time span of 7 days, if the bar has a size around 600-700px the label are difficult to read (reach the max size for label without having enough for next one. 
Add a new width for the long label so label reach threshold sooner and avoid overlap
