### PR TITLE
feat(icon): add LayerGroup entry to iconTable

### DIFF
--- a/src/lib/components/icon/iconTable.ts
+++ b/src/lib/components/icon/iconTable.ts
@@ -85,6 +85,7 @@ export const iconTable = {
   'Angle-right': 'fas faAngleRight',
   'Angle-double-right': 'fas faAnglesRight',
   Language: 'fas faLanguage',
+  LayerGroup: 'fas faLayerGroup',
   Theme: 'fas faPalette',
   Documentation: 'fas faClipboardList',
   Support: 'fas faComments',


### PR DESCRIPTION
## Summary

Adds `LayerGroup: 'fas faLayerGroup'` to `src/lib/components/icon/iconTable.ts` so the FontAwesome `layer-group` icon becomes a valid `IconName`. Since `IconName` is derived from `keyof typeof iconTable`, no separate type update is required. `faLayerGroup` is already shipped by `@fortawesome/free-solid-svg-icons` v7.1.0 and resolved dynamically by `Icon.component.tsx` using the same pattern as every other `fas` entry.

## Links

- JIRA: [CUI-26](https://scality.atlassian.net/browse/CUI-26)
- Tracking issue: scality/agent-task#154

## Step Adherence

- [x] Step 1: Add LayerGroup entry to iconTable

## Test Strategy Executed

- TypeScript compilation produces no errors related to the change (verified via `tsc --noEmit`; pre-existing unrelated module-not-found errors in the environment are not introduced by this change).
- No automated tests enumerate `iconTable` keys. Manual verification path: Storybook's icon story (`stories/icon.stories.tsx`) will render `LayerGroup` automatically once the entry is present.

## Notes

A simplification pass attempted to normalize quote styles for four pre-existing entries (`Sliders`, `MedicalFile`, `ArrowsUpDown`, `HeadSet`) that were unrelated to this change. Those modifications were intentionally **not committed** to keep the PR scope tight to CUI-26.


[CUI-26]: https://scality.atlassian.net/browse/CUI-26?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ