### PR TITLE
Fix typography docs page crashing with React error #130

### DIFF
--- a/stories/typography.mdx
+++ b/stories/typography.mdx
@@ -1,4 +1,4 @@
-import { Meta } from "@storybook/addon-docs";
+import { Meta } from '@storybook/addon-docs/blocks';
 
 <Meta title="Style/Typography" />
 


### PR DESCRIPTION
## Problem

The Typography docs page (`Style/Typography`) was crashing with a minified React error #130 (element type is invalid — expected a string or class/function but got `undefined`).

The root cause: `typography.mdx` was importing `Meta` from `@storybook/addon-docs` (the package root), which does not re-export `Meta` in Storybook 10. The component resolved as `undefined` at runtime, causing the render to fail.

## Fix

Change the import to the correct subpath:

```diff
- import { Meta } from "@storybook/addon-docs";
+ import { Meta } from '@storybook/addon-docs/blocks';
```

This is consistent with every other MDX file in the `stories/` directory, which already use `@storybook/addon-docs/blocks`.

## Verification

Confirmed locally: the Typography page renders correctly after the fix.