### PR TITLE
fix(IconHelp): stable sizing and alignment, add stories and guideline

### DIFF
--- a/src/lib/components/iconhelper/IconHelper.tsx
+++ b/src/lib/components/iconhelper/IconHelper.tsx
@@ -1,6 +1,7 @@
 import { CSSProperties, ReactNode } from 'react';
 import styled from 'styled-components';
 import { Icon } from '../icon/Icon.component';
+import { fontSize } from '../../style/theme';
 import { Position, Tooltip } from '../tooltip/Tooltip.component';
 
 type IconHelpProps = {
@@ -19,14 +20,18 @@ type IconHelpProps = {
 
 const HelpButton = styled.button`
   display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: ${fontSize.base};
+  height: ${fontSize.base};
   background: none;
   border: none;
   padding: 0;
   margin: 0;
   color: inherit;
-  font: inherit;              /* Inherit font sizing */
-  vertical-align: text-bottom;     /* Align with text */
-  line-height: 1;
+  font-size: ${fontSize.base};
+  line-height: 0;
+  vertical-align: -0.125em;
   cursor: default;
   &:focus-visible {
     outline: 2px dashed ${(props) => props.theme.selectedActive};

--- a/stories/IconHelp/iconhelp.guideline.mdx
+++ b/stories/IconHelp/iconhelp.guideline.mdx
@@ -1,0 +1,53 @@
+import { Meta, Canvas } from '@storybook/addon-docs/blocks';
+import * as Stories from './iconhelp.stories';
+
+<Meta name="Guideline" of={Stories} />
+
+# IconHelp
+
+`IconHelp` is a small info icon that reveals a tooltip on hover or focus. Use it to provide secondary information without overloading the interface.
+
+<Canvas of={Stories.Simple} sourceState="none" />
+
+## When to use it
+
+Reach for `IconHelp` whenever a user might have to **guess** what a label, value or concept means. If the wording is not self-explanatory and there is no room — or no need — to spell it out in the layout, an `IconHelp` should be considered.
+
+Typical cases:
+
+- A label or a settings name that uses a domain term (`Object lock`, `Replication policy`, `RPO`).
+- A value whose meaning is not transparent (`Governance`, `Compliance`, `Standard` storage class).
+- A column header, badge, or status that benefits from a one-line definition.
+
+## When not to use it
+
+- **Don't use it as the only way to convey critical information.** A tooltip is hidden by default — anything required to complete a task must remain visible (helper text, error message, inline description).
+- **Don't stack multiple `IconHelp` next to each other.** If a section needs that much explanation, write a short paragraph or link to documentation instead.
+- **Don't replace good labels with an `IconHelp`.** Fix the label first; add help only when the term itself cannot be made clearer.
+- **Don't put long content inside the tooltip.** Keep it to one or two short sentences. For longer explanations, use a dedicated documentation page.
+
+## Explaining values in a key/value list
+
+In summary or detail pages, attach an `IconHelp` only to the values whose meaning is not obvious. Leave plain values (a name, an email, an ID) without one.
+
+<Canvas of={Stories.InKeyValueList} sourceState="none" />
+
+## In a form
+
+In forms, `FormGroup` already exposes a `labelHelpTooltip` prop that renders an `IconHelp` next to the field label — you don't need to add one manually. Use it to clarify:
+
+- **What the field represents** — e.g. _"The name other users will see on your profile."_
+- **The accepted format or validation rule** — e.g. _"Must be 3–32 characters, letters and digits only."_
+- **The impact of the value** — e.g. _"Enabling versioning keeps a copy of every overwrite or delete."_
+
+## Placement
+
+The tooltip defaults to `right`. Pick another placement only when `right` is clipped by the container or overlaps important content.
+
+<Canvas of={Stories.WithPlacement} sourceState="none" />
+
+## Accessibility
+
+- Always pass an `aria-label` that describes _what the tooltip explains_, not just `"Help"`. Example: `aria-label="More info about replication policy"`.
+- The icon renders as a real `<button>`, so it is reachable by keyboard (`Tab`) and the tooltip opens on focus.
+- The tooltip content is the visible text — keep it informative and complete on its own.

--- a/stories/IconHelp/iconhelp.guideline.mdx
+++ b/stories/IconHelp/iconhelp.guideline.mdx
@@ -5,13 +5,13 @@ import * as Stories from './iconhelp.stories';
 
 # IconHelp
 
-`IconHelp` is a small info icon that reveals a tooltip on hover or focus. Use it to provide secondary information without overloading the interface.
+`IconHelp` is an inline icon button that reveals a tooltip on hover or focus.
 
 <Canvas of={Stories.Simple} sourceState="none" />
 
 ## When to use it
 
-Reach for `IconHelp` whenever a user might have to **guess** what a label, value or concept means. If the wording is not self-explanatory and there is no room — or no need — to spell it out in the layout, an `IconHelp` should be considered.
+Use `IconHelp` to provide secondary information without overloading the interface. Reach for it whenever a user might have to **guess** what a label, value or concept means — if the wording is not self-explanatory and there is no room (or no need) to spell it out in the layout, `IconHelp` should be considered.
 
 Typical cases:
 
@@ -22,23 +22,31 @@ Typical cases:
 ## When not to use it
 
 - **Don't use it as the only way to convey critical information.** A tooltip is hidden by default — anything required to complete a task must remain visible (helper text, error message, inline description).
-- **Don't stack multiple `IconHelp` next to each other.** If a section needs that much explanation, write a short paragraph or link to documentation instead.
+- **Don't stack multiple `IconHelp` next to each other.** If a section needs that much explanation, surface it directly: add a description paragraph under the section heading, or place an `InfoMessage` above the content area. For longer explanations, link to the dedicated documentation page from that `InfoMessage` — never put long text in a tooltip.
 - **Don't replace good labels with an `IconHelp`.** Fix the label first; add help only when the term itself cannot be made clearer.
 - **Don't put long content inside the tooltip.** Keep it to one or two short sentences. For longer explanations, use a dedicated documentation page.
 
-## Explaining values in a key/value list
+## Explaining keys and values in a key/value list
 
-In summary or detail pages, attach an `IconHelp` only to the values whose meaning is not obvious. Leave plain values (a name, an email, an ID) without one.
+`IconHelp` can sit on either side of a key/value pair:
+
+- On the **key** when the label itself is the opaque term (`Object lock`, `RPO`, `Replication policy`).
+- On the **value** when the label is clear but the value is the unclear term (`Governance`, `Standard` as a storage class).
+
+Leave plain entries (a name, an email, an ID, a region code) without one.
 
 <Canvas of={Stories.InKeyValueList} sourceState="none" />
 
 ## In a form
 
-In forms, `FormGroup` already exposes a `labelHelpTooltip` prop that renders an `IconHelp` next to the field label — you don't need to add one manually. Use it to clarify:
+Use `IconHelp` (via `FormGroup`'s `labelHelpTooltip`) only for **conceptual context** — what a field represents and why it matters. Anything the user needs to complete the field correctly (format, validation rule, required input) belongs in **helper text**, surfaced via `FormGroup`'s `help` prop, because helper text is always visible.
+
+Good uses of `labelHelpTooltip`:
 
 - **What the field represents** — e.g. _"The name other users will see on your profile."_
-- **The accepted format or validation rule** — e.g. _"Must be 3–32 characters, letters and digits only."_
 - **The impact of the value** — e.g. _"Enabling versioning keeps a copy of every overwrite or delete."_
+
+Format and validation hints should never live in a tooltip.
 
 ## Placement
 

--- a/stories/IconHelp/iconhelp.stories.tsx
+++ b/stories/IconHelp/iconhelp.stories.tsx
@@ -1,0 +1,125 @@
+import React from 'react';
+import { IconHelp } from '../../src/lib/components/iconhelper/IconHelper';
+import { Text } from '../../src/lib/components/text/Text.component';
+import { Stack } from '../../src/lib/spacing';
+import { Wrapper } from '../common';
+
+export default {
+  title: 'Components/IconHelp',
+  component: IconHelp,
+  decorators: [(story: () => React.ReactNode) => <Wrapper>{story()}</Wrapper>],
+};
+
+export const Simple = {
+  name: 'Simple',
+  render: () => (
+    <Text>
+      Replication policy{' '}
+      <IconHelp
+        tooltipMessage="Defines how objects are replicated across locations."
+        aria-label="More info about replication policy"
+      />
+    </Text>
+  ),
+};
+
+export const WithPlacement = {
+  name: 'Tooltip placement',
+  render: () => (
+    <Stack direction="vertical" gap="r24">
+      <Text>
+        Placement <b>top</b>{' '}
+        <IconHelp
+          placement="top"
+          tooltipMessage="Appears above the icon."
+          aria-label="Top tooltip"
+        />
+      </Text>
+      <Text>
+        Placement <b>right</b> (default){' '}
+        <IconHelp
+          placement="right"
+          tooltipMessage="Appears to the right of the icon."
+          aria-label="Right tooltip"
+        />
+      </Text>
+      <Text>
+        Placement <b>bottom</b>{' '}
+        <IconHelp
+          placement="bottom"
+          tooltipMessage="Appears below the icon."
+          aria-label="Bottom tooltip"
+        />
+      </Text>
+      <Text>
+        Placement <b>left</b>{' '}
+        <IconHelp
+          placement="left"
+          tooltipMessage="Appears to the left of the icon."
+          aria-label="Left tooltip"
+        />
+      </Text>
+    </Stack>
+  ),
+};
+
+const KeyValueRow = ({
+  label,
+  value,
+  helpMessage,
+  helpAriaLabel,
+}: {
+  label: string;
+  value: React.ReactNode;
+  helpMessage?: React.ReactNode;
+  helpAriaLabel?: string;
+}) => (
+  <div
+    style={{
+      display: 'grid',
+      gridTemplateColumns: '200px 1fr',
+      alignItems: 'baseline',
+      gap: '16px',
+      padding: '6px 0',
+    }}
+  >
+    <Text color="textSecondary">{label}</Text>
+    <Text>
+      {value}
+      {helpMessage && (
+        <>
+          {' '}
+          <IconHelp
+            tooltipMessage={helpMessage}
+            aria-label={helpAriaLabel ?? `More info about ${label}`}
+          />
+        </>
+      )}
+    </Text>
+  </div>
+);
+
+export const InKeyValueList = {
+  name: 'Explaining values',
+  render: () => (
+    <div style={{ maxWidth: 560 }}>
+      <KeyValueRow label="Bucket name" value="prod-customer-assets" />
+      <KeyValueRow
+        label="Versioning"
+        value="Enabled"
+        helpMessage="Once enabled, every overwrite or delete keeps the previous version."
+      />
+      <KeyValueRow
+        label="Object lock"
+        value="Governance"
+        helpMessage="Governance mode allows privileged users to change retention; Compliance mode does not."
+      />
+      <KeyValueRow
+        label="Storage class"
+        value="Standard"
+        helpMessage="Affects durability, latency and pricing of stored objects."
+      />
+      <KeyValueRow label="Region" value="us-east-1" />
+    </div>
+  ),
+};

--- a/stories/IconHelp/iconhelp.stories.tsx
+++ b/stories/IconHelp/iconhelp.stories.tsx
@@ -13,13 +13,13 @@ export default {
 export const Simple = {
   name: 'Simple',
   render: () => (
-    <Text>
-      Replication policy{' '}
+    <Stack direction="horizontal" gap="r4">
+      <Text>Replication policy</Text>
       <IconHelp
         tooltipMessage="Defines how objects are replicated across locations."
         aria-label="More info about replication policy"
       />
-    </Text>
+    </Stack>
   ),
 };
 
@@ -27,49 +27,61 @@ export const WithPlacement = {
   name: 'Tooltip placement',
   render: () => (
     <Stack direction="vertical" gap="r24">
-      <Text>
-        Placement <b>top</b>{' '}
+      <Stack direction="horizontal" gap="r4">
+        <Text>
+          Placement <b>top</b>
+        </Text>
         <IconHelp
           placement="top"
           tooltipMessage="Appears above the icon."
           aria-label="Top tooltip"
         />
-      </Text>
-      <Text>
-        Placement <b>right</b> (default){' '}
+      </Stack>
+      <Stack direction="horizontal" gap="r4">
+        <Text>
+          Placement <b>right</b> (default)
+        </Text>
         <IconHelp
           placement="right"
           tooltipMessage="Appears to the right of the icon."
           aria-label="Right tooltip"
         />
-      </Text>
-      <Text>
-        Placement <b>bottom</b>{' '}
+      </Stack>
+      <Stack direction="horizontal" gap="r4">
+        <Text>
+          Placement <b>bottom</b>
+        </Text>
         <IconHelp
           placement="bottom"
           tooltipMessage="Appears below the icon."
           aria-label="Bottom tooltip"
         />
-      </Text>
-      <Text>
-        Placement <b>left</b>{' '}
+      </Stack>
+      <Stack direction="horizontal" gap="r4">
+        <Text>
+          Placement <b>left</b>
+        </Text>
         <IconHelp
           placement="left"
           tooltipMessage="Appears to the left of the icon."
           aria-label="Left tooltip"
         />
-      </Text>
+      </Stack>
     </Stack>
   ),
 };
 
 const KeyValueRow = ({
   label,
+  labelHelp,
+  labelAriaLabel,
   value,
   helpMessage,
   helpAriaLabel,
 }: {
   label: string;
+  labelHelp?: React.ReactNode;
+  labelAriaLabel?: string;
   value: React.ReactNode;
   helpMessage?: React.ReactNode;
   helpAriaLabel?: string;
@@ -77,42 +89,48 @@ const KeyValueRow = ({
   <div
     style={{
       display: 'grid',
-      gridTemplateColumns: '200px 1fr',
+      gridTemplateColumns: '220px 1fr',
       alignItems: 'baseline',
       gap: '16px',
       padding: '6px 0',
     }}
   >
-    <Text color="textSecondary">{label}</Text>
-    <Text>
-      {value}
-      {helpMessage && (
-        <>
-          {' '}
-          <IconHelp
-            tooltipMessage={helpMessage}
-            aria-label={helpAriaLabel ?? `More info about ${label}`}
-          />
-        </>
+    <Stack direction="horizontal" gap="r4">
+      <Text color="textSecondary">{label}</Text>
+      {labelHelp && (
+        <IconHelp
+          tooltipMessage={labelHelp}
+          aria-label={labelAriaLabel ?? `More info about ${label}`}
+        />
       )}
-    </Text>
+    </Stack>
+    <Stack direction="horizontal" gap="r4">
+      <Text>{value}</Text>
+      {helpMessage && (
+        <IconHelp
+          tooltipMessage={helpMessage}
+          aria-label={helpAriaLabel ?? `More info about ${label} value`}
+        />
+      )}
+    </Stack>
   </div>
 );
 
 export const InKeyValueList = {
-  name: 'Explaining values',
+  name: 'Explaining keys and values',
   render: () => (
-    <div style={{ maxWidth: 560 }}>
+    <div style={{ maxWidth: 620 }}>
       <KeyValueRow label="Bucket name" value="prod-customer-assets" />
       <KeyValueRow
-        label="Versioning"
-        value="Enabled"
-        helpMessage="Once enabled, every overwrite or delete keeps the previous version."
-      />
-      <KeyValueRow
         label="Object lock"
+        labelHelp="Object lock prevents objects from being deleted or overwritten for a fixed amount of time."
         value="Governance"
         helpMessage="Governance mode allows privileged users to change retention; Compliance mode does not."
+      />
+      <KeyValueRow
+        label="RPO"
+        labelHelp="Recovery Point Objective — the maximum acceptable amount of data loss measured in time."
+        value="15 minutes"
       />
       <KeyValueRow
         label="Storage class"


### PR DESCRIPTION
## Summary

- Fix `IconHelp` size and vertical-alignment drift introduced when the icon was reworked into a focusable `<button>` (was inheriting parent font, line-height and using `vertical-align: text-bottom`, making the glyph float and rescale per consumer).
- Pin the help button to a fixed `1rem × 1rem` hit area centered with `inline-flex`, so the icon stays the same recognizable "info" affordance everywhere and sits center inside the focus outline. Use FontAwesome's `-0.125em` baseline offset for stable inline alignment with surrounding text.
- Add focused usage stories under `Components/IconHelp` (`Simple`, `Tooltip placement`, `Explaining values`) and a `Guideline` mdx attached to the same group (same pattern as `InfoMessage`).

## Test plan

- [ ] Open Storybook → `Components/IconHelp` → check `Simple`, `Tooltip placement`, `Explaining values` render correctly.
- [ ] Check the `Guideline` tab on the same component renders the embedded canvases.
- [ ] Verify existing consumers (`Templates/Form`, `Components/TextBadge`, modal stories) still show the help icon aligned with adjacent text and not oversized in headings.
- [ ] Focus the icon with `Tab` — focus outline wraps the icon tightly with the icon centered.

🤖 Generated with [Claude Code](https://claude.com/claude-code)