### PR TITLE
feat(storybook): add storybook-webmcp addon for AI agents

### DIFF
--- a/.github/workflows/github-pages.yml
+++ b/.github/workflows/github-pages.yml
@@ -14,6 +14,10 @@ jobs:
         with:
           node-version: 24
       - run: npm ci
+        env:
+          # storybook-webmcp is hosted on GitHub Packages (npm.pkg.github.com).
+          # Even public GHPR packages require an auth token.
+          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Configure git credentials
         run: git config --global url."https://x-access-token:${{ github.token }}@github.com/".insteadOf "https://github.com/"
       - run: npm run storybook:deploy

--- a/.github/workflows/post-release.yml
+++ b/.github/workflows/post-release.yml
@@ -65,10 +65,11 @@ jobs:
         with:
           node-version: "24"
           registry-url: "https://registry.npmjs.org"
+      # GHPR auth for @jbwatenbergscality/storybook-webmcp. Written directly to
+      # ~/.npmrc instead of via NODE_AUTH_TOKEN to avoid leaking the GitHub
+      # token to registry.npmjs.org through setup-node's npmjs auth line
+      # (//registry.npmjs.org/:_authToken=${NODE_AUTH_TOKEN}).
+      - run: echo "//npm.pkg.github.com/:_authToken=${{ secrets.GITHUB_TOKEN }}" >> ~/.npmrc
       - run: npm ci
-        env:
-          # storybook-webmcp is hosted on GitHub Packages (npm.pkg.github.com).
-          # Even public GHPR packages require an auth token.
-          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - run: npm run build
       - run: npm publish

--- a/.github/workflows/post-release.yml
+++ b/.github/workflows/post-release.yml
@@ -66,5 +66,9 @@ jobs:
           node-version: "24"
           registry-url: "https://registry.npmjs.org"
       - run: npm ci
+        env:
+          # storybook-webmcp is hosted on GitHub Packages (npm.pkg.github.com).
+          # Even public GHPR packages require an auth token.
+          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - run: npm run build
       - run: npm publish

--- a/.github/workflows/storybook-build.yml
+++ b/.github/workflows/storybook-build.yml
@@ -24,6 +24,10 @@ jobs:
         with:
           node-version: 24
       - run: npm ci
+        env:
+          # storybook-webmcp is hosted on GitHub Packages (npm.pkg.github.com).
+          # Even public GHPR packages require an auth token.
+          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - run: npm run build-storybook
         env:
           STORYBOOK_DISABLE_TELEMETRY: 1

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -28,5 +28,9 @@ jobs:
         with:
           node-version: 24
       - run: npm ci
+        env:
+          # storybook-webmcp is hosted on GitHub Packages (npm.pkg.github.com).
+          # Even public GHPR packages require an auth token.
+          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - run: npm run test
       - run: npm run lint

--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,8 @@
 legacy-peer-deps=true
+
+# storybook-webmcp lives on GitHub Packages. Even for public packages,
+# the GHPR npm registry requires a token with read:packages scope.
+# Local dev: export NODE_AUTH_TOKEN=$(gh auth token)
+# CI: pass NODE_AUTH_TOKEN via secrets (e.g. ${{ secrets.GITHUB_TOKEN }}).
+@jbwatenbergscality:registry=https://npm.pkg.github.com
+//npm.pkg.github.com/:_authToken=${NODE_AUTH_TOKEN}

--- a/.storybook/main.ts
+++ b/.storybook/main.ts
@@ -17,6 +17,7 @@ const config: StorybookConfig = {
         },
       },
     },
+    '@jbwatenbergscality/storybook-webmcp',
   ],
   framework: {
     name: '@storybook/react-webpack5',

--- a/package-lock.json
+++ b/package-lock.json
@@ -50,6 +50,7 @@
         "@babel/preset-react": "^7.16.7",
         "@babel/preset-typescript": "^7.16.7",
         "@chromatic-com/storybook": "^5.1.2",
+        "@jbwatenbergscality/storybook-webmcp": "^0.1.1",
         "@storybook/addon-docs": "10.3.5",
         "@storybook/addon-webpack5-compiler-swc": "^4.0.3",
         "@storybook/react-webpack5": "10.3.5",
@@ -2225,6 +2226,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@cfworker/json-schema": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/@cfworker/json-schema/-/json-schema-4.1.1.tgz",
+      "integrity": "sha512-gAmrUZSGtKc3AiBL71iNWxDsyUC5uMaKKGdvzYsBoTW/xi42JQHl7eKV2OYzCUqvc+D2RCcf7EXY2iCyFIk6og==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@chromatic-com/storybook": {
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/@chromatic-com/storybook/-/storybook-5.1.2.tgz",
@@ -3553,6 +3561,21 @@
         "node": ">=8"
       }
     },
+    "node_modules/@jbwatenbergscality/storybook-webmcp": {
+      "version": "0.1.1",
+      "resolved": "https://npm.pkg.github.com/download/@jbwatenbergscality/storybook-webmcp/0.1.1/7ea99ee19b416c6cbd9fee8ebbe42e472218ee79",
+      "integrity": "sha512-5Eu9jJU/5ZpoovBxZetKoL4ePjnoiYG7YtVjmbh0PTQckn+pCCTlcEF1BBos+OdX2ygyAHdFXA7ja3Rtx03o4Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@mcp-b/global": "^2.2.0",
+        "zod": "^3.25",
+        "zod-to-json-schema": "^3.25.0"
+      },
+      "peerDependencies": {
+        "storybook": "^10.2.0"
+      }
+    },
     "node_modules/@jest/console": {
       "version": "30.2.0",
       "resolved": "https://registry.npmjs.org/@jest/console/-/console-30.2.0.tgz",
@@ -4284,6 +4307,81 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/@marijn/find-cluster-break/-/find-cluster-break-1.0.2.tgz",
       "integrity": "sha512-l0h88YhZFyKdXIFNfSWpyjStDjGHwZ/U7iobcK1cQQD8sejsONdQtTVU+1wVN1PBw40PiiHB1vA5S7VTfQiP9g==",
+      "license": "MIT"
+    },
+    "node_modules/@mcp-b/global": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/@mcp-b/global/-/global-2.3.2.tgz",
+      "integrity": "sha512-44+Rxn2cuwJKUwVBi/xwpQ/+yEuKrmrrOJH/vysyr7JbE74Pr2Pfqb8YZCWwpk6wB4jwBHIfrFWigNfeMMaYAQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@mcp-b/transports": "2.3.2",
+        "@mcp-b/webmcp-polyfill": "2.3.2",
+        "@mcp-b/webmcp-ts-sdk": "2.3.2",
+        "@mcp-b/webmcp-types": "2.3.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@mcp-b/transports": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/@mcp-b/transports/-/transports-2.3.2.tgz",
+      "integrity": "sha512-aRKaF1TjwSBXEXYUpWfz3JKOiagYMHH4D7gpesaU1aGAs69cjTVX4lDwFZ9qIO+4a/1CijLcBnOsKmsPzFWQjA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@mcp-b/webmcp-ts-sdk": "2.3.2",
+        "zod": "3.25.76"
+      }
+    },
+    "node_modules/@mcp-b/webmcp-polyfill": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/@mcp-b/webmcp-polyfill/-/webmcp-polyfill-2.3.2.tgz",
+      "integrity": "sha512-kvGmGypnsASUUGLI/NJ2E1eNLhtRkOq+dxaXxv01EKli9C78hb7x1KpIfknSCxpfIufJGE8wzjjIf279pQT/gQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@cfworker/json-schema": "^4.1.1",
+        "@mcp-b/webmcp-types": "2.3.2",
+        "@standard-schema/spec": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@mcp-b/webmcp-ts-sdk": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/@mcp-b/webmcp-ts-sdk/-/webmcp-ts-sdk-2.3.2.tgz",
+      "integrity": "sha512-mRZMXSM7bNkNsnGws884DpcatwZCYoAFIaV39Bb/YsBjLKhGYA8/9z4GmftIPnKFZm+BljYi9h+AUMgEc/Cz4Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@mcp-b/webmcp-polyfill": "2.3.2",
+        "@mcp-b/webmcp-types": "2.3.2"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "zod": "^3.25 || ^4.0",
+        "zod-to-json-schema": "^3.25.0"
+      },
+      "peerDependenciesMeta": {
+        "zod": {
+          "optional": true
+        },
+        "zod-to-json-schema": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@mcp-b/webmcp-types": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/@mcp-b/webmcp-types/-/webmcp-types-2.3.2.tgz",
+      "integrity": "sha512-167nu2e5qIh8BcKvFp4dUzaeyO1+S+eMWGUaohjkwnqgc2Gq49Fv+i/Lei19019s1iCfQJ3yjtrzDK0nApivKg==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@mdx-js/react": {
@@ -21273,6 +21371,26 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/zod": {
+      "version": "3.25.76",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/zod-to-json-schema": {
+      "version": "3.25.2",
+      "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.25.2.tgz",
+      "integrity": "sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==",
+      "dev": true,
+      "license": "ISC",
+      "peerDependencies": {
+        "zod": "^3.25.28 || ^4"
       }
     },
     "node_modules/zwitch": {

--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
     "@babel/preset-react": "^7.16.7",
     "@babel/preset-typescript": "^7.16.7",
     "@chromatic-com/storybook": "^5.1.2",
+    "@jbwatenbergscality/storybook-webmcp": "^0.1.1",
     "@storybook/addon-docs": "10.3.5",
     "@storybook/addon-webpack5-compiler-swc": "^4.0.3",
     "@storybook/react-webpack5": "10.3.5",


### PR DESCRIPTION
## Summary

Adds [`@jbwatenbergscality/storybook-webmcp`](https://github.com/JBWatenbergScality/storybook-webmcp) to this Storybook. After this change, the deployed [`https://scality.github.io/core-ui/`](https://scality.github.io/core-ui/) doubles as a **serverless MCP source** for AI agents — no backend needed.

It's an alternative to Storybook's official [`@storybook/mcp` self-hosted server](https://storybook.js.org/docs/ai/mcp/sharing#self-hosting-with-storybookmcp), implemented in-browser via the W3C `navigator.modelContext` API (WebMCP).

## Changes

- `.storybook/main.ts` — added `'@jbwatenbergscality/storybook-webmcp'` to `addons`. The addon auto-enables `features.componentsManifest: true` and `experimental_manifests: {}` via its preset, so no manual manifest config is needed.
- `package.json` — added `"@jbwatenbergscality/storybook-webmcp": "^0.1.1"` to `devDependencies`.
- `.npmrc` — mapped the `@jbwatenbergscality` scope to GitHub Packages, plus an env-var auth-token line. GHPR requires a token (with `read:packages`) even for public packages.

## What ships in `storybook-static/` after this

```
storybook-static/
  manifests/
    components.json   ← NEW: 61 components, including reactDocgenTypescript props
    components.html   ← NEW: human-readable manifest debugger
    docs.json         ← NEW: unattached MDX docs
  sb-addons/2/manager-bundle.js  ← contains the WebMCP bootstrap
  ... (existing Storybook output)
```

## Three tools registered

| Tool | What it returns |
|---|---|
| `storybook.list-all-documentation` | Index of all 61 components + unattached docs |
| `storybook.get-documentation` | Full docs (props from `react-docgen-typescript`, first 3 stories, story index) for one component |
| `storybook.get-documentation-for-story` | Single story by `storyId` or `componentId` + `storyName` |

## How to consume (for reviewers)

1. Install [`chrome-devtools-mcp`](https://github.com/ChromeDevTools/chrome-devtools-mcp) ≥ the version with `--category-experimental-webmcp` (currently experimental).
2. In your MCP client config (e.g. `~/.claude.json` / `.mcp.json`):

   ```json
   {
     "mcpServers": {
       "chrome-devtools": {
         "command": "npx",
         "args": ["chrome-devtools-mcp@latest", "--category-experimental-webmcp"]
       }
     }
   }
   ```

3. Launch Chrome 149+ with `--enable-features=WebMCPTesting,DevToolsWebMCPSupport`.
4. Open `https://scality.github.io/core-ui/` (after merge + deploy) in that Chrome instance.
5. In Claude Code: `list_webmcp_tools` should show three `storybook.*` tools; `execute_webmcp_tool` invokes them.

## CI considerations

The build needs `NODE_AUTH_TOKEN` to resolve the GHPR-hosted addon. Locally:

```sh
export NODE_AUTH_TOKEN=$(gh auth token)
npm install
```

For CI (GitHub Actions running on this repo), `${{ secrets.GITHUB_TOKEN }}` works out of the box — it has `read:packages` for the org's accessible packages. **Action item:** if any CI workflow runs `npm install` without that env, it needs to be added. I haven't audited the workflows yet; flagging for whoever's familiar with the build setup.

## Test plan

- [x] Local: `NODE_AUTH_TOKEN=$(gh auth token) npm install` succeeds
- [x] Local: `npm run build-storybook` produces `storybook-static/manifests/components.json` with 61 components and populated props
- [ ] CI: confirm whatever workflow runs `build-storybook` passes (depends on `NODE_AUTH_TOKEN` being set)
- [ ] After merge + `storybook:deploy`: confirm `https://scality.github.io/core-ui/manifests/components.json` returns 200
- [ ] End-to-end: open the deployed URL in instrumented Chrome, call `list_webmcp_tools` from Claude Code, confirm three storybook tools appear

## Known limitations (v1)

- Only `react-docgen-typescript` and vanilla `react-docgen` are supported. `react-component-meta` (experimental) is not yet handled — would return empty props for those components.
- Consumer transport is `chrome-devtools-mcp` only. MCP-B local relay and Chrome extension paths are explicitly out of scope.
- The Storybook manifest schema is officially "preview, not stable" — when Storybook bumps it, the addon will need an update. The addon has a runtime `SchemaVersionError` guard that fails loudly rather than silently miscarrying.

## Draft because

- Want maintainers to weigh in on the GHPR auth choice before merge (alternative: publish to npmjs.com instead — fully public, no token).
- CI implications (NODE_AUTH_TOKEN propagation) haven't been confirmed end-to-end on this repo's workflows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)