### PR TITLE
fix(ci): grant packages:read to deploy + publish-npm jobs

### DIFF
--- a/.github/workflows/github-pages.yml
+++ b/.github/workflows/github-pages.yml
@@ -8,6 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+      packages: read # to install @jbwatenbergscality/storybook-webmcp from GHPR
     steps:
       - uses: actions/checkout@v6
       - uses: actions/setup-node@v6

--- a/.github/workflows/post-release.yml
+++ b/.github/workflows/post-release.yml
@@ -57,6 +57,7 @@ jobs:
     permissions:
       id-token: write # Required for OIDC authentication
       contents: read
+      packages: read # to install @jbwatenbergscality/storybook-webmcp from GHPR
     environment: npmjs
     steps:
       - uses: actions/checkout@v6


### PR DESCRIPTION
## Summary

Follow-up to #1116. The first post-merge \`Deploy Storybook\` run failed with:

\`\`\`
403 Forbidden - GET https://npm.pkg.github.com/download/@jbwatenbergscality/storybook-webmcp/...
Permission installation not allowed to Read organization package
\`\`\`

[Failing run](https://github.com/scality/core-ui/actions/runs/26435637410/job/77817742497).

## Root cause

Both \`github-pages.yml\` and \`post-release.yml\` declare an explicit \`permissions:\` block. **When \`permissions:\` is set explicitly, undeclared scopes default to NO permission** — so \`secrets.GITHUB_TOKEN\` authenticates fine (no 401) but gets a 403 when GHPR checks whether it has \`packages:read\`.

\`storybook-build.yml\` and \`tests.yaml\` don't declare \`permissions:\` at all, so they inherit the runner default (which includes \`packages:read\`) and worked fine on #1116.

## Fix

One added line each:

- \`github-pages.yml\` → \`packages: read\` under \`deploy.permissions\`
- \`post-release.yml\` → \`packages: read\` under \`publish-npm.permissions\`

## Test plan

- [x] Local read of the modified files — both have the new permission entry
- [ ] Merge → next push to \`development/1.0\` triggers \`Deploy Storybook\` → should succeed (was the failing path)
- [ ] Next release → \`publish-npm\` job runs \`npm ci\` → should succeed (was about to fail with the same 403 on next release)

🤖 Generated with [Claude Code](https://claude.com/claude-code)