### PR TITLE
improvement(guidelines): document table, modal, spacing, and typography patterns

### DIFF
--- a/stories/format.mdx
+++ b/stories/format.mdx
@@ -44,3 +44,9 @@ import { Meta } from '@storybook/addon-docs/blocks';
     Avoid using formats with **letters** for Date in Tables.
 *   For having consistent length and alignment, and to prevent mistakes, all the formats are with **leading zeros** (2020-07-20 09:00 instead of 2020-7-20 9:00).
 *   These formats are applicable for the English language.
+
+## Key-value display
+
+In a key-value layout, values must be left-aligned. Do not right-align values regardless of key length.
+
+This applies anywhere key-value pairs appear: modal bodies, detail panels, drawers, tooltips.

--- a/stories/modal.guideline.mdx
+++ b/stories/modal.guideline.mdx
@@ -50,6 +50,14 @@ Use `alertdialog` when accidentally dismissing the modal would be dangerous or m
 - `subTitle` occupies the header slot when no close button is present. Use it for contextual information (e.g. a step indicator or a required-fields disclaimer).
 - `subTitle` occupies the same slot as the close button. When `subTitle` is used, `close` must be omitted and navigation must be handled in the footer.
 
+## Read-only modals
+
+Use a read-only modal to surface the details of a specific resource without allowing edits.
+
+- Title: "View [Resource]" or "View [Resource] details". Examples: "View Disk details", "View Certificate", "View Access key".
+- Use `role="dialog"` with a close button.
+- Footer: a single "Close" button (`variant="primary"`).
+
 ## Body content
 
 - When the action targets a specific resource, name it explicitly in the body: **"my-node-name** will be permanently deleted, this action is irreversible." This prevents the user from acting on the wrong resource.

--- a/stories/spacing.mdx
+++ b/stories/spacing.mdx
@@ -1,4 +1,5 @@
-import { Meta } from '@storybook/addon-docs/blocks';
+import { Meta, Canvas } from '@storybook/addon-docs/blocks';
+import * as SpacingStories from './spacing.stories';
 
 <Meta title="Style/Spacing" />
 
@@ -48,3 +49,9 @@ A `Box` generic component with all css flex box customisation possible.
 A `Stack` component placing children side by side with a uniform configurable gap in between.
 `Stack` children can optionaly be separated by dividers. A `Stack` can be verticaly or horizontaly aligned.
 A `Wrap` component filling parent width with non configurable uniform gap between children.
+
+## Icon and label
+
+When placing an icon next to a text label (for example in a status cell or an inline metadata row), use `Stack` with `gap="r8"`.
+
+<Canvas of={SpacingStories.IconAndLabel} />

--- a/stories/spacing.stories.tsx
+++ b/stories/spacing.stories.tsx
@@ -6,6 +6,7 @@ import {
   LargerText,
   SecondaryText,
   SmallerSecondaryText,
+  Text,
 } from '../src/lib/components/text/Text.component';
 import { TextBadge } from '../src/lib/components/textbadge/TextBadge.component';
 import { spacing, Stack, Wrap } from '../src/lib/spacing';
@@ -13,6 +14,31 @@ import { spacing, Stack, Wrap } from '../src/lib/spacing';
 export default {
   title: 'Components/Styling/Spacing Utils',
   component: Stack,
+};
+
+export const IconAndLabel = {
+  name: 'Icon and label (r8)',
+  parameters: { docs: { canvas: { sourceState: 'none' } } },
+  render: () => (
+    <Stack direction="vertical" gap="r16" style={{ padding: '1.5rem' }}>
+      <Stack gap="r8">
+        <Icon name="Check-circle" color="statusHealthy" />
+        <Text color="textPrimary">Healthy</Text>
+      </Stack>
+      <Stack gap="r8">
+        <Icon name="Exclamation-circle" color="statusWarning" />
+        <Text color="textPrimary">Warning</Text>
+      </Stack>
+      <Stack gap="r8">
+        <Icon name="Times-circle" color="statusCritical" />
+        <Text color="textPrimary">Critical</Text>
+      </Stack>
+      <Stack gap="r8">
+        <Icon name="Info-circle" color="infoPrimary" />
+        <Text color="textPrimary">Information</Text>
+      </Stack>
+    </Stack>
+  ),
 };
 
 export const Playground = {

--- a/stories/tablev2.guideline.mdx
+++ b/stories/tablev2.guideline.mdx
@@ -28,4 +28,5 @@ Use this button to open a read-only detail view for the row.
 - Use `variant="outline"`, `size="inline"`.
 - Label: `"View details"`.
 - Icon: `Eye`.
+
 <Canvas of={TableStories.TableWithViewAction} layout="fullscreen" />

--- a/stories/tablev2.guideline.mdx
+++ b/stories/tablev2.guideline.mdx
@@ -23,5 +23,9 @@ Tables may include an action column on the far right for row-level actions.
 ### View action
 
 Use this button to open a read-only detail view for the row.
+Use this button to open a read-only detail view for the row.
 
+- Use `variant="outline"`, `size="inline"`.
+- Label: `"View details"`.
+- Icon: `Eye`.
 <Canvas of={TableStories.TableWithViewAction} layout="fullscreen" />

--- a/stories/tablev2.guideline.mdx
+++ b/stories/tablev2.guideline.mdx
@@ -1,0 +1,27 @@
+import { Meta, Canvas } from '@storybook/addon-docs/blocks';
+import * as TableStories from './tablev2.stories';
+
+<Meta of={TableStories} name="Guideline" />
+
+<style>{`
+  .sbdocs-content h2 { margin-top: 5rem; }
+  .sbdocs-content h3 { margin-top: 3rem; }
+`}</style>
+
+# Table
+
+A table displays structured data in rows and columns, allowing users to scan, sort, and act on multiple items.
+
+## Action column
+
+Tables may include an action column on the far right for row-level actions.
+
+- `Header` must be an empty string. Never "Actions", "Details", or any other label.
+- Buttons are right-aligned within the cell.
+- Prefer `size="inline"` buttons.
+
+### View action
+
+Use this button to open a read-only detail view for the row.
+
+<Canvas of={TableStories.TableWithViewAction} layout="fullscreen" />

--- a/stories/tablev2.guideline.mdx
+++ b/stories/tablev2.guideline.mdx
@@ -23,7 +23,6 @@ Tables may include an action column on the far right for row-level actions.
 ### View action
 
 Use this button to open a read-only detail view for the row.
-Use this button to open a read-only detail view for the row.
 
 - Use `variant="outline"`, `size="inline"`.
 - Label: `"View details"`.

--- a/stories/tablev2.stories.tsx
+++ b/stories/tablev2.stories.tsx
@@ -739,6 +739,10 @@ export const TableWithViewAction = {
           isOpen={selectedEntry !== null}
           close={() => setSelectedEntry(null)}
           title={`View Entry details`}
+          role="dialog"
+          isOpen={selectedEntry !== null}
+          close={() => setSelectedEntry(null)}
+          title={`View Entry details`}
           footer={
             <Stack gap="r8" style={{ justifyContent: 'flex-end' }}>
               <Button

--- a/stories/tablev2.stories.tsx
+++ b/stories/tablev2.stories.tsx
@@ -14,6 +14,9 @@ import {
 import { CellProps, Row } from 'react-table';
 import { Box, Button } from '../src/lib/next';
 import styled from 'styled-components';
+import { Icon } from '../src/lib/components/icon/Icon.component';
+import { Modal } from '../src/lib/components/modal/Modal.component';
+import { Stack } from '../src/lib/spacing';
 
 const Flex = styled(Box)`
   display: flex;
@@ -673,6 +676,97 @@ export const TableWithSyncButton = {
           />
         </Table>
       </Box>
+    );
+  },
+};
+
+export const TableWithViewAction = {
+  render: () => {
+    const [selectedEntry, setSelectedEntry] = useState<Entry | null>(null);
+
+    const columnsWithAction: Column<Entry>[] = [
+      {
+        Header: 'First Name',
+        accessor: 'firstName',
+        cellStyle: { width: 'unset', flex: 2, textAlign: 'left' },
+      },
+      {
+        Header: 'Last Name',
+        accessor: 'lastName',
+        cellStyle: { width: 'unset', flex: 2, textAlign: 'left' },
+      },
+      {
+        Header: 'Health',
+        accessor: 'health',
+        cellStyle: { width: 'unset', flex: 1, textAlign: 'left' },
+      },
+      {
+        Header: '',
+        id: 'actions',
+        cellStyle: {
+          width: 'unset',
+          flex: 1,
+          display: 'flex',
+          justifyContent: 'flex-end',
+        },
+        Cell: ({ row }: CellProps<Entry>) => (
+          <Button
+            size="inline"
+            variant="outline"
+            label="View details"
+            icon={<Icon name="Eye" />}
+            onClick={() => setSelectedEntry(row.original)}
+          />
+        ),
+      },
+    ];
+
+    return (
+      <>
+        <Box width="700px" height="260px">
+          <Table
+            columns={columnsWithAction}
+            data={data}
+            defaultSortingKey={'firstName'}
+          >
+            <Table.SingleSelectableContent
+              rowHeight="h40"
+              separationLineVariant="backgroundLevel3"
+            />
+          </Table>
+        </Box>
+        <Modal
+          isOpen={selectedEntry !== null}
+          close={() => setSelectedEntry(null)}
+          title={`View Entry details`}
+          footer={
+            <Stack gap="r8" style={{ justifyContent: 'flex-end' }}>
+              <Button
+                variant="primary"
+                label="Close"
+                onClick={() => setSelectedEntry(null)}
+              />
+            </Stack>
+          }
+        >
+          {selectedEntry && (
+            <Stack direction="vertical" gap="r8">
+              <div>
+                <strong>First name</strong>: {selectedEntry.firstName}
+              </div>
+              <div>
+                <strong>Last name</strong>: {selectedEntry.lastName}
+              </div>
+              <div>
+                <strong>Age</strong>: {selectedEntry.age ?? '—'}
+              </div>
+              <div>
+                <strong>Health</strong>: {selectedEntry.health}
+              </div>
+            </Stack>
+          )}
+        </Modal>
+      </>
     );
   },
 };

--- a/stories/typography.mdx
+++ b/stories/typography.mdx
@@ -53,3 +53,11 @@ All UI text must use **sentence case**: capitalize only the first word and prope
 Exception: when displaying a list of resources (buckets, nodes, accounts…), each item may be capitalized as a proper noun if it represents a named entity.
 
 This rule is enforced by the `technical-sentence-case` ESLint rule.
+
+## Text overflow
+
+Two strategies are available when text overflows its container.
+
+**Wrap**: the text continues on the next line. When it does, the break must occur at a delimiter, a dot or a dash. Do not break mid-segment.
+
+**Ellipsis**: the text is clipped with a `…` and the full value is shown in a tooltip on hover. Use `ConstrainedText` for this behavior. Two placements are possible: trailing (`longvalue…`) or middle (`longv…lue`), preserving the end of the string. The middle variant is useful for filenames or paths where the extension or last segment carries meaning.


### PR DESCRIPTION
## Context

Several visual and UX issues were raised in ARTESCA-17604 on the disk list view. A recurring root cause: the developer implemented the feature without mock-ups and without explicit design system rules to follow. This PR documents those missing rules so future features have clear references.

## Changes

### New: Table guideline (`stories/tablev2.guideline.mdx`)
- Action column: empty header, right-aligned buttons
- View action: `variant="outline"`, `size="inline"`, `label="View details"`, `icon={Eye}`
- Includes an interactive Canvas story demonstrating the full pattern (table + read-only modal)

### Updated: Modal guideline (`stories/modal.guideline.mdx`)
- New section: Read-only modals — title convention (`View [Resource] details`), `role="dialog"`, single primary Close button

### Updated: Spacing (`stories/spacing.mdx` + `stories/spacing.stories.tsx`)
- New section: Icon and label — use `Stack` with `gap="r8"`
- Visual Canvas story showing the pattern across status variants

### Updated: Typography (`stories/typography.mdx`)
- New section: Text overflow — two strategies (wrap at delimiter, ellipsis trailing or middle)

### Updated: Format (`stories/format.mdx`)
- New section: Key-value display — values must be left-aligned