### PR TITLE
fix(tablev2): keep RenderRow stable 

### DIFF
--- a/src/lib/components/tablev2/MultiSelectableContent.tsx
+++ b/src/lib/components/tablev2/MultiSelectableContent.tsx
@@ -155,7 +155,6 @@ export const MultiSelectableContent = <
         const rows = data;
         const row = data[index];
         prepareRowRef.current(row);
-        const onSingleRowSelected = onSingleRowSelectedRef.current;
 
         const rowProps = {
           ...row.getRowProps({
@@ -166,19 +165,21 @@ export const MultiSelectableContent = <
              */
             style: { ...style },
           }),
-          onClick: onSingleRowSelected
-            ? () => {
-                onSingleRowSelected(row);
-                toggleAllRowsSelectedRef.current(false);
-                setActiveRowId(row.id);
-              }
-            : () =>
-                handleMultipleSelectedRowsRef.current(
-                  selectedRowIdsRef.current,
-                  rows,
-                  row,
-                  index,
-                ),
+          onClick: () => {
+            const onSingleRowSelected = onSingleRowSelectedRef.current;
+            if (onSingleRowSelected) {
+              onSingleRowSelected(row);
+              toggleAllRowsSelectedRef.current(false);
+              setActiveRowId(row.id);
+            } else {
+              handleMultipleSelectedRowsRef.current(
+                selectedRowIdsRef.current,
+                rows,
+                row,
+                index,
+              );
+            }
+          },
         };
 
         return (
@@ -204,19 +205,16 @@ export const MultiSelectableContent = <
                 return (
                   <div
                     {...cellProps}
-                    onClick={
-                      onSingleRowSelected
-                        ? (event) => {
-                            event.stopPropagation();
-                            handleMultipleSelectedRowsRef.current(
-                              selectedRowIdsRef.current,
-                              rows,
-                              row,
-                              index,
-                            );
-                          }
-                        : undefined
-                    }
+                    onClick={(event) => {
+                      if (!onSingleRowSelectedRef.current) return;
+                      event.stopPropagation();
+                      handleMultipleSelectedRowsRef.current(
+                        selectedRowIdsRef.current,
+                        rows,
+                        row,
+                        index,
+                      );
+                    }}
                   >
                     {cell.render('Cell')}
                   </div>

--- a/src/lib/components/tablev2/MultiSelectableContent.tsx
+++ b/src/lib/components/tablev2/MultiSelectableContent.tsx
@@ -1,6 +1,6 @@
-import { useEffect, useState, memo, CSSProperties } from 'react';
+import { useEffect, useState, memo, useMemo, useRef } from 'react';
 import { Row } from 'react-table';
-import { areEqual } from 'react-window';
+import { areEqual, ListChildComponentProps } from 'react-window';
 import { useTableContext } from './Tablev2.component';
 import {
   HeadRow,
@@ -14,7 +14,7 @@ import {
   TableLocalType,
   TableVariantType,
 } from './TableUtils';
-import { RenderRowType, TableRows, useTableScrollbar } from './TableCommon';
+import { TableRows, useTableScrollbar } from './TableCommon';
 import useSyncedScroll from './useSyncedScroll';
 import { Box } from '../box/Box';
 import { Loader } from '../loader/Loader.component';
@@ -124,79 +124,116 @@ export const MultiSelectableContent = <
 
   const { headerRef } = useSyncedScroll<DATA_ROW>();
 
-  const RenderRow = memo(({ index, style }: RenderRowType) => {
-    const row = rows[index];
-    prepareRow(row);
+  /**
+   * These values change identity on (almost) every render. We read them through refs so the row
+   * renderer below can keep a stable identity (see RenderRow).
+   */
+  const prepareRowRef = useRef(prepareRow);
+  prepareRowRef.current = prepareRow;
+  const selectedRowIdsRef = useRef(selectedRowIds);
+  selectedRowIdsRef.current = selectedRowIds;
+  const onSingleRowSelectedRef = useRef(onSingleRowSelected);
+  onSingleRowSelectedRef.current = onSingleRowSelected;
+  const toggleAllRowsSelectedRef = useRef(toggleAllRowsSelected);
+  toggleAllRowsSelectedRef.current = toggleAllRowsSelected;
+  const handleMultipleSelectedRowsRef = useRef(handleMultipleSelectedRows);
+  handleMultipleSelectedRowsRef.current = handleMultipleSelectedRows;
 
-    const rowProps = {
-      ...row.getRowProps({
-        /**
-         * Note:We need to pass the style property to the row component.
-         * Otherwise when we scroll down, the next rows are flashing
-         * because they are re-rendered in loop.
-         */
-        style: { ...style },
-      }),
-      onClick: onSingleRowSelected
-        ? () => {
-            onSingleRowSelected(row);
-            toggleAllRowsSelected(false);
-            setActiveRowId(row.id);
-          }
-        : () => handleMultipleSelectedRows(selectedRowIds, rows, row, index),
-    };
+  /**
+   * RenderRow MUST keep a stable identity across re-renders. It used to be redefined inline on
+   * every render, so react-window saw a new component type each time and remounted (not just
+   * re-rendered) every row — and therefore every cell — whenever the table re-rendered for any
+   * reason. That made async cell content reload and flash. We now read the row from react-window's
+   * `data` (itemData) prop and the volatile callbacks/state from refs, so the component is only
+   * recreated when something that affects the rendered output (activeRowId / separationLineVariant)
+   * actually changes. Checkbox selection still updates because react-table rebuilds `rows` (and
+   * therefore `data`) when `selectedRowIds` changes.
+   */
+  const RenderRow = useMemo(
+    () =>
+      memo(({ index, style, data }: ListChildComponentProps<Row<DATA_ROW>[]>) => {
+        const rows = data;
+        const row = data[index];
+        prepareRowRef.current(row);
+        const onSingleRowSelected = onSingleRowSelectedRef.current;
 
-    return (
-      <TableRowMultiSelectable
-        {...rowProps}
-        isSelected={row.isSelected || activeRowId === row.id}
-        separationLineVariant={separationLineVariant}
-        className="tr"
-      >
-        {row.cells.map((cell) => {
-          const cellProps = cell.getCellProps({
-            style: {
-              ...cell.column.cellStyle,
-              // Vertically center the text in cells.
-              display: 'flex',
-              flexDirection: 'column',
-              justifyContent: 'center',
-            },
-            role: 'gridcell',
-          });
+        const rowProps = {
+          ...row.getRowProps({
+            /**
+             * Note:We need to pass the style property to the row component.
+             * Otherwise when we scroll down, the next rows are flashing
+             * because they are re-rendered in loop.
+             */
+            style: { ...style },
+          }),
+          onClick: onSingleRowSelected
+            ? () => {
+                onSingleRowSelected(row);
+                toggleAllRowsSelectedRef.current(false);
+                setActiveRowId(row.id);
+              }
+            : () =>
+                handleMultipleSelectedRowsRef.current(
+                  selectedRowIdsRef.current,
+                  rows,
+                  row,
+                  index,
+                ),
+        };
 
-          if (cell.column.id === 'selection') {
-            return (
-              <div
-                {...cellProps}
-                onClick={
-                  onSingleRowSelected
-                    ? (event) => {
-                        event.stopPropagation();
-                        handleMultipleSelectedRows(
-                          selectedRowIds,
-                          rows,
-                          row,
-                          index,
-                        );
-                      }
-                    : undefined
-                }
-              >
-                {cell.render('Cell')}
-              </div>
-            );
-          }
+        return (
+          <TableRowMultiSelectable
+            {...rowProps}
+            isSelected={row.isSelected || activeRowId === row.id}
+            separationLineVariant={separationLineVariant}
+            className="tr"
+          >
+            {row.cells.map((cell) => {
+              const cellProps = cell.getCellProps({
+                style: {
+                  ...cell.column.cellStyle,
+                  // Vertically center the text in cells.
+                  display: 'flex',
+                  flexDirection: 'column',
+                  justifyContent: 'center',
+                },
+                role: 'gridcell',
+              });
 
-          return (
-            <div {...cellProps} className="td">
-              {cell.render('Cell')}
-            </div>
-          );
-        })}
-      </TableRowMultiSelectable>
-    );
-  }, areEqual);
+              if (cell.column.id === 'selection') {
+                return (
+                  <div
+                    {...cellProps}
+                    onClick={
+                      onSingleRowSelected
+                        ? (event) => {
+                            event.stopPropagation();
+                            handleMultipleSelectedRowsRef.current(
+                              selectedRowIdsRef.current,
+                              rows,
+                              row,
+                              index,
+                            );
+                          }
+                        : undefined
+                    }
+                  >
+                    {cell.render('Cell')}
+                  </div>
+                );
+              }
+
+              return (
+                <div {...cellProps} className="td">
+                  {cell.render('Cell')}
+                </div>
+              );
+            })}
+          </TableRowMultiSelectable>
+        );
+      }, areEqual),
+    [activeRowId, separationLineVariant],
+  );
 
   return (
     <>

--- a/src/lib/components/tablev2/SingleSelectableContent.tsx
+++ b/src/lib/components/tablev2/SingleSelectableContent.tsx
@@ -100,7 +100,6 @@ export function SingleSelectableContent<
       memo(({ index, style, data }: ListChildComponentProps<Row<DATA_ROW>[]>) => {
         const row = data[index];
         prepareRowRef.current(row);
-        const onRowSelected = onRowSelectedRef.current;
         let rowProps = row.getRowProps({
           /**
            * Note: We need to pass the style property to the row component.
@@ -114,10 +113,12 @@ export function SingleSelectableContent<
           ...rowProps,
           ...{
             onClick: () => {
+              const onRowSelected = onRowSelectedRef.current;
               if (onRowSelected) return onRowSelected(row);
             },
-            tabIndex: onRowSelected ? 0 : undefined,
+            tabIndex: onRowSelectedRef.current ? 0 : undefined,
             onKeyDown: (event) => {
+              const onRowSelected = onRowSelectedRef.current;
               if (
                 onRowSelected &&
                 (event.key === ' ' ||

--- a/src/lib/components/tablev2/SingleSelectableContent.tsx
+++ b/src/lib/components/tablev2/SingleSelectableContent.tsx
@@ -1,5 +1,5 @@
-import { memo, useEffect, useRef } from 'react';
-import { areEqual, FixedSizeList } from 'react-window';
+import { memo, useEffect, useMemo, useRef } from 'react';
+import { areEqual, FixedSizeList, ListChildComponentProps } from 'react-window';
 import { Row } from 'react-table';
 import { useTableContext } from './Tablev2.component';
 import {
@@ -14,7 +14,7 @@ import {
   TableLocalType,
   TableVariantType,
 } from './TableUtils';
-import { RenderRowType, TableRows, useTableScrollbar } from './TableCommon';
+import { TableRows, useTableScrollbar } from './TableCommon';
 import useSyncedScroll from './useSyncedScroll';
 import { Loader } from '../loader/Loader.component';
 import { Box } from '../box/Box';
@@ -77,69 +77,92 @@ export function SingleSelectableContent<
     return () => clearTimeout(timer);
   }, [autoScrollToSelected, selectedId, rows]);
 
-  const RenderRow = memo(({ index, style }: RenderRowType) => {
-    const row = rows[index];
-    prepareRow(row);
-    let rowProps = row.getRowProps({
-      /**
-       * Note: We need to pass the style property to the row component.
-       * Otherwise when we scroll down, the next rows are flashing
-       * because they are re-rendered in loop.
-       */
-      style: { ...style },
-    });
+  /**
+   * `prepareRow` and `onRowSelected` change identity on every render. We read them through refs
+   * so the row renderer below can keep a stable identity (see RenderRow).
+   */
+  const prepareRowRef = useRef(prepareRow);
+  prepareRowRef.current = prepareRow;
+  const onRowSelectedRef = useRef(onRowSelected);
+  onRowSelectedRef.current = onRowSelected;
 
-    rowProps = {
-      ...rowProps,
-      ...{
-        onClick: () => {
-          if (onRowSelected) return onRowSelected(row);
-        },
-        tabIndex: onRowSelected ? 0 : undefined,
-        onKeyDown: (event) => {
-          if (
-            onRowSelected &&
-            (event.key === ' ' ||
-              event.key === 'Enter' ||
-              event.key === 'Spacebar')
-          ) {
-            event.preventDefault();
-            onRowSelected(row);
-          }
-        },
-      },
-    };
+  /**
+   * RenderRow MUST keep a stable identity across re-renders. It used to be redefined inline on
+   * every render, so react-window saw a new component type each time and remounted (not just
+   * re-rendered) every row — and therefore every cell — whenever the table re-rendered for any
+   * reason. That made async cell content reload and flash. We now read the row from react-window's
+   * `data` (itemData) prop and the volatile callbacks from refs, so the component only needs to be
+   * recreated when something that affects the rendered output (selectedId / separationLineVariant)
+   * actually changes.
+   */
+  const RenderRow = useMemo(
+    () =>
+      memo(({ index, style, data }: ListChildComponentProps<Row<DATA_ROW>[]>) => {
+        const row = data[index];
+        prepareRowRef.current(row);
+        const onRowSelected = onRowSelectedRef.current;
+        let rowProps = row.getRowProps({
+          /**
+           * Note: We need to pass the style property to the row component.
+           * Otherwise when we scroll down, the next rows are flashing
+           * because they are re-rendered in loop.
+           */
+          style: { ...style },
+        });
 
-    return (
-      <TableRow
-        {...rowProps}
-        isSelected={selectedId === row.id}
-        aria-selected={selectedId === row.id ? 'true' : 'false'}
-        separationLineVariant={separationLineVariant}
-        selectedId={selectedId}
-        className="tr"
-      >
-        {row.cells.map((cell) => {
-          let cellProps = cell.getCellProps({
-            style: {
-              ...cell.column.cellStyle,
-              // Vertically center the text in cells.
-              display: 'flex',
-              flexDirection: 'column',
-              justifyContent: 'center',
+        rowProps = {
+          ...rowProps,
+          ...{
+            onClick: () => {
+              if (onRowSelected) return onRowSelected(row);
             },
-            role: 'gridcell',
-          });
+            tabIndex: onRowSelected ? 0 : undefined,
+            onKeyDown: (event) => {
+              if (
+                onRowSelected &&
+                (event.key === ' ' ||
+                  event.key === 'Enter' ||
+                  event.key === 'Spacebar')
+              ) {
+                event.preventDefault();
+                onRowSelected(row);
+              }
+            },
+          },
+        };
 
-          return (
-            <div {...cellProps} className="td">
-              {cell.render('Cell')}
-            </div>
-          );
-        })}
-      </TableRow>
-    );
-  }, areEqual);
+        return (
+          <TableRow
+            {...rowProps}
+            isSelected={selectedId === row.id}
+            aria-selected={selectedId === row.id ? 'true' : 'false'}
+            separationLineVariant={separationLineVariant}
+            selectedId={selectedId}
+            className="tr"
+          >
+            {row.cells.map((cell) => {
+              let cellProps = cell.getCellProps({
+                style: {
+                  ...cell.column.cellStyle,
+                  // Vertically center the text in cells.
+                  display: 'flex',
+                  flexDirection: 'column',
+                  justifyContent: 'center',
+                },
+                role: 'gridcell',
+              });
+
+              return (
+                <div {...cellProps} className="td">
+                  {cell.render('Cell')}
+                </div>
+              );
+            })}
+          </TableRow>
+        );
+      }, areEqual),
+    [selectedId, separationLineVariant],
+  );
 
   const { hasScrollbar, scrollBarWidth, handleScrollbarWidth } =
     useTableScrollbar();

--- a/src/lib/components/tablev2/TableCommon.tsx
+++ b/src/lib/components/tablev2/TableCommon.tsx
@@ -128,9 +128,7 @@ type TableRowsProps<
   locale?: TableLocalType;
   children?: (children: JSX.Element) => JSX.Element;
   customItemKey?: (index: number, data: DATA_ROW) => string;
-  RenderRow: React.MemoExoticComponent<
-    ({ index, style }: RenderRowType) => JSX.Element
-  >;
+  RenderRow: ComponentType<ListChildComponentProps<Row<DATA_ROW>[]>>;
   listRef?: Ref<FixedSizeList<Row<DATA_ROW>[]>>;
 };
 export function TableRows<

--- a/src/lib/components/tablev2/Tablev2.component.tsx
+++ b/src/lib/components/tablev2/Tablev2.component.tsx
@@ -53,6 +53,18 @@ export type CellProps<
 export type TableProps<
   DATA_ROW extends Record<string, unknown> = Record<string, unknown>,
 > = {
+  /**
+   * Column definitions for the table.
+   *
+   * IMPORTANT: memoize this (e.g. `useMemo`) and keep each column's `Cell`
+   * renderer stable across renders. react-table renders cells as
+   * `<column.Cell />`, so a new `Cell` function identity on every parent
+   * render is a new component type — React unmounts and remounts the whole
+   * cell subtree each render. For cells with async content or icons that
+   * causes flicker/refetch. Define columns outside the render or wrap them in
+   * `useMemo`, and hoist inline `Cell` components rather than redefining them
+   * inline. The same applies to `data`.
+   */
   columns: Array<Column<DATA_ROW>>;
   defaultSortingKey?: string;
   // We don't display the default sort key in the URL, so we need to specify here


### PR DESCRIPTION
## Problem

`TableV2` renders its rows virtualized via `react-window`. `RenderRow` was defined inline inside the component body, so it got a **new function identity on every render**. `react-window` caches rows by component type, so a fresh identity made it **unmount and remount every visible row — and therefore every cell — on any table re-render**, regardless of the cause (a parent state change, a context update, etc.), not just when the data changed.

Remounting (as opposed to re-rendering) is destructive: cell subtrees lose their internal state and re-run their mount effects. Cells whose content is loaded asynchronously on mount, or that animate/resolve on mount, re-trigger all of that work — producing visible flicker and redundant refetches every time the table re-rendered for any reason.

## What this PR does

- **Stabilize `RenderRow`.** Wrap it in `useMemo` so its identity only changes when something that affects the rendered row actually changes (`activeRowId`/`selectedId`, `separationLineVariant`). The row is read from `react-window`'s `itemData` (`data`) prop instead of closing over `rows`, and the volatile values (`prepareRow`, the selection callbacks, `selectedRowIds`) are read through refs. Unrelated re-renders now **re-render** rows (cheap, state-preserving) instead of remounting them.
- **Read selection callbacks at call time.** The row click/keydown handlers read `onSingleRowSelected` / `onRowSelected` from their refs at event time rather than from a render-time snapshot, removing a stale-closure edge case (the other volatile callbacks were already read this way).
- **Document the `columns` / `data` contract.** Added guidance on `TableProps.columns`: callers must memoize their columns and keep each `Cell` renderer stable across renders. `react-table` renders cells as `<column.Cell />`, so an unstable `Cell` identity is itself a new component type and remounts the cell subtree — independently of this fix.

## What's still missing (follow-up)

`RenderRow`'s `useMemo` deps include the selection state (`activeRowId` / `selectedId`). So while unrelated re-renders no longer remount rows, **changing the selection still recreates `RenderRow` and remounts all rows** — async/animated cells still flicker on row click/selection. This is intentional here: the selection is read by value so the row highlight stays correct.

Eliminating it requires keeping `RenderRow` fully stable and instead passing the selection through a memoized `itemData` object (e.g. `{ rows, selectedId }`), letting a custom `areEqual` **re-render** (not remount) only the affected rows. That ripples into `TableCommon` / `VirtualizedRows`, the `itemKey` / `customItemKey` selectors, and the single-select highlight path, so it is deferred to a separate PR to keep this one focused and low-risk.

## Verification

`npm run build-storybook` (exit 0), `tsc --noEmit` clean, ESLint clean, full Jest suite passing (446/446).

---
_Split out of the original combined branch — icon fallback rendering is in #1122, the Storybook guideline import fix was #1121 (merged)._

🤖 Generated with [Claude Code](https://claude.com/claude-code)
