### PR TITLE
fix(stories): repair build-storybook (RadioGroup import in guideline stories)

### DIFF
--- a/stories/guideline/inputs-guideline.mdx
+++ b/stories/guideline/inputs-guideline.mdx
@@ -46,7 +46,7 @@ See [Components/Inputs/Toggle](?path=/docs/components-inputs-toggle--guideline) 
 
 Use Radio when the user must pick one option from a group of 2 to 4 choices. Radio enforces mutual exclusivity by design: selecting one option automatically deselects the others.
 
-<Canvas of={RadioStories.RadioGroup} sourceState="none" />
+<Canvas of={RadioStories.RadioGroupExample} sourceState="none" />
 
 See [Components/Inputs/Radio](?path=/docs/components-inputs-radio--guideline) for the full guideline.
 

--- a/stories/guideline/selection-controls-overview.stories.tsx
+++ b/stories/guideline/selection-controls-overview.stories.tsx
@@ -1,7 +1,7 @@
 import React, { useState } from 'react';
 import { Checkbox } from '../../src/lib/components/checkbox/Checkbox.component';
 import { Toggle } from '../../src/lib/components/toggle/Toggle.component';
-import { Radio } from '../../src/lib/components/radio/Radio.component';
+import { RadioGroup } from '../../src/lib/components/radio/RadioGroup.component';
 import { Select } from '../../src/lib/components/selectv2/Selectv2.component';
 
 export default {
@@ -39,14 +39,20 @@ export const Overview = {
         </div>
         <div>
           <div style={labelStyle}>Radio</div>
-          <div style={{ display: 'flex', flexDirection: 'column', gap: '0.5rem' }}>
-            <Radio name="overview-radio" value="governance" label="Governance" checked={radio === 'governance'} onChange={() => setRadio('governance')} />
-            <Radio name="overview-radio" value="compliance" label="Compliance" checked={radio === 'compliance'} onChange={() => setRadio('compliance')} />
-          </div>
+          <RadioGroup
+            name="overview-radio"
+            aria-label="Radio"
+            value={radio}
+            onChange={setRadio}
+            options={[
+              { value: 'governance', label: 'Governance' },
+              { value: 'compliance', label: 'Compliance' },
+            ]}
+          />
         </div>
         <div>
           <div style={labelStyle}>Select</div>
-          <Select placeholder="Select an option" value={select} onChange={(v) => setSelect(v as string)}>
+          <Select id="overview-select" placeholder="Select an option" value={select} onChange={(v) => setSelect(v as string)}>
             <Select.Option value="a">Option A</Select.Option>
             <Select.Option value="b">Option B</Select.Option>
             <Select.Option value="c">Option C</Select.Option>


### PR DESCRIPTION
## Problem
`build-storybook` is failing on `development/1.0` and therefore on **every open PR** (including #1119 *Add Stepper guideline*), with:

```
SB_BUILDER-WEBPACK5_0002 (WebpackInvocationError): Module not found:
Error: Can't resolve '../../src/lib/components/radio/Radio.component'
```

## Root cause
A logical merge conflict between two independently-green PRs:
- The design-system guideline stories import `radio/Radio.component` and reference the `RadioStories.RadioGroup` story export.
- **CUI-17** renamed `Radio` → `RadioGroup` (deleting `Radio.component.tsx`, renaming the story export to `RadioGroupExample`).

CUI-17 branched before the `storybook-build` check existed and was never rebased, so `build-storybook` never ran on its PR. Storybook compiles the whole story set, so the broken combination took down the build for all PRs once both landed.

## Fix
- Import `RadioGroup` from `radio/RadioGroup.component`
- Use `RadioGroup` with `options`/`value`/`onChange`
- Point `<Canvas>` at `RadioStories.RadioGroupExample`
- Add `id` to the overview `Select`

## Verification
`npm run build-storybook` completes successfully (exit 0) with this change.

Once merged, open PRs (#1119 etc.) should be rebased to pick up the fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)