### PR TITLE
fix(icon): stabilize fallback rendering (mount flash, layout shift, spinner)

### DIFF
--- a/src/lib/components/icon/Icon.component.tsx
+++ b/src/lib/components/icon/Icon.component.tsx
@@ -77,9 +77,10 @@ type Props = {
 };
 
 const DelayedFallback = ({
+  size,
   children,
   ...rest
-}: PropsWithChildren<HTMLProps<HTMLElement>>) => {
+}: PropsWithChildren<Omit<HTMLProps<HTMLElement>, 'size'> & { size?: SizeProp }>) => {
   const [show, setShow] = useState(false);
   useEffect(() => {
     let timeout = setTimeout(() => setShow(true), 300);
@@ -88,7 +89,20 @@ const DelayedFallback = ({
     };
   }, []);
 
-  return <i {...rest}>{show && children}</i>;
+  // Reserve the icon's box so a cold-loading icon doesn't paint zero-width and shift
+  // neighbouring content. svg-inline--fa gives height:1em and the icon baseline, and
+  // fa-${size} scales font-size so 1em tracks the requested size. Width has no intrinsic
+  // SVG to derive from, so set a 1em square — matches the glyph height exactly and
+  // approximates its (variable) width without altering how loaded icons render.
+  return (
+    <i
+      {...rest}
+      className={`svg-inline--fa${size ? ` fa-${size}` : ''}`}
+      style={{ width: '1em' }}
+    >
+      {show && children}
+    </i>
+  );
 };
 
 export const IconWrapper = styled.div<{ size: SizeProp }>`
@@ -185,7 +199,7 @@ function NonWrappedIcon({
 
   if (!icon && !customIcons[name]) {
     return (
-      <DelayedFallback {...accessibilityProps}>
+      <DelayedFallback size={size} {...accessibilityProps}>
         <Loader size="base" />
       </DelayedFallback>
     );

--- a/src/lib/components/icon/Icon.component.tsx
+++ b/src/lib/components/icon/Icon.component.tsx
@@ -76,6 +76,10 @@ type Props = {
   title?: string;
 };
 
+// Mirrors the <Loader> default spinner color (see Loader.component.tsx) so the
+// fallback looks identical to a real Loader while the icon resolves.
+const LOADER_SPINNER_COLOR = '#A14FBF';
+
 // The spinner shown while a cold icon loads. Sized in em so it scales with the
 // fa-${size} font-size of the fallback box, matching the glyph it stands in for —
 // unlike <Loader>, whose container forces a fixed px svg and resets font-size.
@@ -84,7 +88,7 @@ const FallbackSpinner = styled.span`
   svg {
     width: 1em;
     height: 1em;
-    fill: #a14fbf;
+    fill: ${LOADER_SPINNER_COLOR};
   }
 `;
 
@@ -195,6 +199,10 @@ function NonWrappedIcon({
       setIcon(iconCache[cacheKey]);
       return;
     }
+
+    // The name changed to an icon we haven't loaded yet: drop the previous glyph so the
+    // reserved fallback shows instead of a stale icon while the dynamic import resolves.
+    setIcon(undefined);
 
     // Handle FontAwesome icons with dynamic import
     import(

--- a/src/lib/components/icon/Icon.component.tsx
+++ b/src/lib/components/icon/Icon.component.tsx
@@ -84,7 +84,7 @@ const FallbackSpinner = styled.span`
   svg {
     width: 1em;
     height: 1em;
-    fill: currentColor;
+    fill: #a14fbf;
   }
 `;
 

--- a/src/lib/components/icon/Icon.component.tsx
+++ b/src/lib/components/icon/Icon.component.tsx
@@ -137,21 +137,32 @@ function NonWrappedIcon({
   const iconInfo = iconTable[name] || customIcons[name];
   if (!iconInfo) throw new Error(`${name}: is not a valid icon.`);
 
-  // Loaded fortawesome icon if not a custom icon
-  const [icon, setIcon] = useState();
+  const [fontAwesomeType, iconClass] = customIcons[name]
+    ? []
+    : (() => {
+        const [type, cls] = iconInfo.split(' ');
+        return [
+          type === 'far' ? 'free-regular-svg-icons' : 'free-solid-svg-icons',
+          cls,
+        ];
+      })();
+  const cacheKey = iconClass ? `${fontAwesomeType}/${iconClass}` : undefined;
+
+  // Seed from the module-level cache synchronously so an already-loaded icon paints on the
+  // first render. Reading the cache only inside the effect (which runs after paint) makes a
+  // freshly-mounted icon — e.g. a virtualized table row scrolling into view — render the empty
+  // zero-width fallback for a frame, shifting neighbouring content before the real glyph appears.
+  const [icon, setIcon] = useState(() =>
+    cacheKey ? iconCache[cacheKey] : undefined,
+  );
 
   useEffect(() => {
-    if (customIcons[name]) {
+    if (!cacheKey || !iconClass) {
       return;
     }
-
-    const [iconType, iconClass] = iconInfo.split(' ');
-    const fontAwesomeType =
-      iconType === 'far' ? 'free-regular-svg-icons' : 'free-solid-svg-icons';
-    const cacheKey = `${fontAwesomeType}/${iconClass}`;
     if (iconCache[cacheKey]) {
       setIcon(iconCache[cacheKey]);
-      return () => setIcon(undefined);
+      return;
     }
 
     // Handle FontAwesome icons with dynamic import
@@ -164,8 +175,7 @@ function NonWrappedIcon({
       }).catch((err) => {
         console.warn(`Icon ${iconClass} could not be loaded:`, err.message);
       });
-    return () => setIcon(undefined);
-  }, [name, iconInfo]);
+  }, [cacheKey, fontAwesomeType, iconClass]);
 
   // Icons are decorative by default (aria-hidden: true)
   // If ariaLabel is provided, the icon is meaningful (aria-hidden: false)

--- a/src/lib/components/icon/Icon.component.tsx
+++ b/src/lib/components/icon/Icon.component.tsx
@@ -9,7 +9,7 @@ import {
 } from 'react';
 import styled, { css } from 'styled-components';
 import type { CoreUITheme } from '../../style/theme';
-import { Loader } from '../loader/Loader.component';
+import { LoaderIcon } from '../../icons/scality-loading';
 import { Bucket, Buckets, RemoteGroup, RemoteUser } from './CustomsIcons';
 import { iconTable } from './iconTable';
 
@@ -76,6 +76,18 @@ type Props = {
   title?: string;
 };
 
+// The spinner shown while a cold icon loads. Sized in em so it scales with the
+// fa-${size} font-size of the fallback box, matching the glyph it stands in for —
+// unlike <Loader>, whose container forces a fixed px svg and resets font-size.
+const FallbackSpinner = styled.span`
+  display: inline-flex;
+  svg {
+    width: 1em;
+    height: 1em;
+    fill: currentColor;
+  }
+`;
+
 const DelayedFallback = ({
   size,
   children,
@@ -100,7 +112,12 @@ const DelayedFallback = ({
       className={`svg-inline--fa${size ? ` fa-${size}` : ''}`}
       style={{ width: '1em' }}
     >
-      {show && children}
+      {show &&
+        (children ?? (
+          <FallbackSpinner>
+            <LoaderIcon />
+          </FallbackSpinner>
+        ))}
     </i>
   );
 };
@@ -199,9 +216,7 @@ function NonWrappedIcon({
 
   if (!icon && !customIcons[name]) {
     return (
-      <DelayedFallback size={size} {...accessibilityProps}>
-        <Loader size="base" />
-      </DelayedFallback>
+      <DelayedFallback size={size} {...accessibilityProps} />
     );
   }
 


### PR DESCRIPTION
Split out of #1120, which mixed unrelated table, icon, and Storybook changes. This PR contains **only the Icon component fixes**.

## Changes
- Seed the cached icon synchronously so an already-loaded icon paints on the first render instead of flashing the empty fallback
- Reserve the icon box in the delayed fallback to avoid layout shift while a cold icon loads
- Scale the fallback spinner with `size` (sized in `em`) instead of a fixed px value
- Keep the fallback spinner the Loader default color, via a named `LOADER_SPINNER_COLOR` constant rather than an inline hex
- Clear a stale glyph when `name` changes to an uncached icon, so the reserved fallback shows during the dynamic import instead of the previous icon

## Files
- `src/lib/components/icon/Icon.component.tsx`

## Verification
`npm run build-storybook` (exit 0), ESLint clean, full Jest suite passing (446/446).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
