### PR TITLE
bugfix(charts): re-derive tooltip unit per value

### DIFF
--- a/src/lib/components/charts/common/chartUtils.test.ts
+++ b/src/lib/components/charts/common/chartUtils.test.ts
@@ -6,6 +6,7 @@ import {
   formatXAxisDate,
   normalizeChartDataWithUnits,
   getTooltipDateFormat,
+  formatTooltipValueWithUnit,
 } from './chartUtils';
 import { NAN_STRING } from '../../constants';
 import { UnitRange } from '../types';
@@ -413,5 +414,80 @@ describe('normalizeChartDataWithUnits', () => {
       expect(result.topValue).toBe(100);
       expect(result.rechartsData).toEqual(data);
     });
+  });
+
+  describe('valueBase', () => {
+    it('should expose the value base used for normalization', () => {
+      const data = [{ category: 'A', value: 2000 }];
+      const unitRange: UnitRange = [
+        { threshold: 1, label: 'op/s' },
+        { threshold: 1000, label: 'kop/s' },
+      ];
+
+      const result = normalizeChartDataWithUnits(
+        data,
+        2000,
+        unitRange,
+        'category',
+      );
+
+      expect(result.unitLabel).toBe('kop/s');
+      expect(result.valueBase).toBe(1000);
+    });
+
+    it('should default valueBase to 1 when no unit range is provided', () => {
+      const result = normalizeChartDataWithUnits(
+        [{ category: 'A', value: 100 }],
+        100,
+        undefined,
+        'category',
+      );
+
+      expect(result.valueBase).toBe(1);
+    });
+  });
+});
+
+describe('formatTooltipValueWithUnit', () => {
+  const unitRange: UnitRange = [
+    { threshold: 1, label: 'op/s' },
+    { threshold: 1000, label: 'kop/s' },
+    { threshold: 1000000, label: 'Mop/s' },
+  ];
+
+  it('re-derives a smaller unit for values that are small relative to the axis unit', () => {
+    // Axis is in kop/s (valueBase 1000). A point of 5 op/s is stored as 0.005.
+    // Without re-scaling it would read "0.01 kop/s"; instead it should read "5 op/s".
+    expect(formatTooltipValueWithUnit(0.005, 1000, unitRange, 'kop/s')).toBe(
+      '5.00 op/s',
+    );
+  });
+
+  it('keeps the axis unit for values that match its magnitude', () => {
+    // 2 (stored) * 1000 = 2000 op/s → 2 kop/s
+    expect(formatTooltipValueWithUnit(2, 1000, unitRange, 'kop/s')).toBe(
+      '2.00 kop/s',
+    );
+  });
+
+  it('re-derives a larger unit for values that exceed the axis unit', () => {
+    // 5000 (stored) * 1000 = 5,000,000 op/s → 5 Mop/s
+    expect(formatTooltipValueWithUnit(5000, 1000, unitRange, 'kop/s')).toBe(
+      '5.00 Mop/s',
+    );
+  });
+
+  it('handles negative values (symmetrical charts) using the magnitude', () => {
+    expect(formatTooltipValueWithUnit(-0.005, 1000, unitRange, 'kop/s')).toBe(
+      '-5.00 op/s',
+    );
+  });
+
+  it('falls back to the provided unit label when no unit range is given', () => {
+    expect(formatTooltipValueWithUnit(42.5, 1, undefined, '%')).toBe('42.50 %');
+  });
+
+  it('returns "-" for non-finite values', () => {
+    expect(formatTooltipValueWithUnit(NaN, 1000, unitRange, 'kop/s')).toBe('-');
   });
 });

--- a/src/lib/components/charts/common/chartUtils.ts
+++ b/src/lib/components/charts/common/chartUtils.ts
@@ -182,6 +182,7 @@ export const normalizeChartDataWithUnits = <T extends Record<string, any>>(
   topValue: number;
   rechartsData: T[];
   topDomain: number;
+  valueBase: number;
 } => {
   // If no unit range provided, just calculate top value without unit conversion
   if (!unitRange || unitRange.length === 0) {
@@ -191,6 +192,7 @@ export const normalizeChartDataWithUnits = <T extends Record<string, any>>(
       topValue,
       rechartsData: data,
       topDomain: maxValue * 1.1,
+      valueBase: 1,
     };
   }
 
@@ -212,7 +214,50 @@ export const normalizeChartDataWithUnits = <T extends Record<string, any>>(
     return normalizedDataPoint as T;
   });
 
-  return { unitLabel, topValue, rechartsData, topDomain };
+  return { unitLabel, topValue, rechartsData, topDomain, valueBase };
+};
+
+/**
+ * Formats a single value for tooltip display, re-deriving the unit from the
+ * value's own magnitude when a unitRange is provided.
+ *
+ * Chart data is normalized once against the dataset maximum so the Y-axis can
+ * use a single unit. A value that is small relative to that maximum would
+ * otherwise render with many decimals under the axis unit (e.g. "0.005 kop/s").
+ * Re-applying the unitRange per value keeps the tooltip readable (e.g. "5 op/s")
+ * independently of the axis unit.
+ *
+ * @param value - The normalized value as stored in the Recharts dataset
+ * @param valueBase - The factor the dataset was divided by during normalization
+ * @param unitRange - Unit range used for the chart; when empty the value is shown as-is
+ * @param fallbackUnitLabel - Unit label used when no unitRange is provided (e.g. "%")
+ */
+export const formatTooltipValueWithUnit = (
+  value: number,
+  valueBase: number,
+  unitRange: UnitRange | undefined,
+  fallbackUnitLabel?: string,
+): string => {
+  if (!Number.isFinite(value)) return '-';
+
+  if (!unitRange || unitRange.length === 0) {
+    const formatted = formatISONumber(value, {
+      fixedDecimals: true,
+      compact: true,
+    });
+    return `${formatted}${fallbackUnitLabel ? ` ${fallbackUnitLabel}` : ''}`;
+  }
+
+  const originalValue = value * valueBase;
+  const { valueBase: tooltipValueBase, unitLabel } = getUnitLabel(
+    unitRange,
+    Math.abs(originalValue),
+  );
+  const formatted = formatISONumber(originalValue / tooltipValueBase, {
+    fixedDecimals: true,
+    compact: true,
+  });
+  return `${formatted}${unitLabel ? ` ${unitLabel}` : ''}`;
 };
 
 /**

--- a/src/lib/components/charts/index.ts
+++ b/src/lib/components/charts/index.ts
@@ -47,6 +47,7 @@ export {
   formatXAxisDate,
   getTooltipDateFormat,
   normalizeChartDataWithUnits,
+  formatTooltipValueWithUnit,
 } from './common/chartUtils';
 
 // Context Providers (for backward compatibility)

--- a/src/lib/components/charts/linetimeseries/LineTimeSerieChart.tsx
+++ b/src/lib/components/charts/linetimeseries/LineTimeSerieChart.tsx
@@ -80,6 +80,7 @@ export function LineTimeSerieChart({
     topDomain,
     topValue,
     unitLabel,
+    valueBase,
     xAxisTicks,
     linesToRender,
     belowSeriesLabels,
@@ -192,6 +193,8 @@ export function LineTimeSerieChart({
             content={(props: TooltipContentProps<number, string>) => (
               <LineTimeSerieChartTooltip
                 unitLabel={unitLabel}
+                valueBase={valueBase}
+                unitRange={unitRange}
                 duration={duration}
                 renderTooltip={renderTooltip}
                 isSymmetrical={yAxisType === 'symmetrical'}

--- a/src/lib/components/charts/linetimeseries/LineTimeSerieChart.types.ts
+++ b/src/lib/components/charts/linetimeseries/LineTimeSerieChart.types.ts
@@ -119,6 +119,11 @@ export const CHART_PRESETS: Record<'default' | 'modern', DisplayOptions> = {
 export type LineTimeSerieChartTooltipProps = {
   tooltipProps: TooltipContentProps<number, string>;
   unitLabel?: string;
+  valueBase?: number;
+  unitRange?: {
+    threshold: number;
+    label: string;
+  }[];
   duration: number;
   renderTooltip?: (
     tooltipProps: TooltipContentProps<number, string>,

--- a/src/lib/components/charts/linetimeseries/LineTimeSerieChartTooltip.tsx
+++ b/src/lib/components/charts/linetimeseries/LineTimeSerieChartTooltip.tsx
@@ -10,26 +10,7 @@ import {
 } from '../common/ChartTooltip';
 import { LineTimeSerieChartTooltipProps } from './LineTimeSerieChart.types';
 import { getCurrentlyHoveredChartId } from './useChartHover';
-import { formatISONumber } from '../../../utils';
-
-/**
- * Formats a numeric value for tooltip display
- * - Non-finite values (NaN, null, undefined) → "-"
- * - Zero → "0" with unit
- * - Large values (>= 1000) → compact notation (1k, 1M)
- * - Normal values (1-999) → up to 2 decimal places
- * - Small values (0.01-0.99) → 2 decimal places
- * - Very small values (< 0.01) → scientific notation (e.g., 4.7e-5)
- */
-export const formatTooltipValue = (
-  value: number,
-  unitLabel?: string,
-): string => {
-  if (!Number.isFinite(value)) return '-';
-
-  const formatted = formatISONumber(value, { fixedDecimals: true, compact: true });
-  return `${formatted}${unitLabel ? ` ${unitLabel}` : ''}`;
-};
+import { formatTooltipValueWithUnit } from '../common/chartUtils';
 
 /**
  * Custom tooltip component for LineTimeSerieChart
@@ -39,6 +20,8 @@ export const LineTimeSerieChartTooltip: React.FC<
   LineTimeSerieChartTooltipProps
 > = ({
   unitLabel,
+  valueBase = 1,
+  unitRange,
   duration,
   tooltipProps,
   renderTooltip,
@@ -104,7 +87,12 @@ export const LineTimeSerieChartTooltip: React.FC<
                 />
               );
 
-              const formattedValue = formatTooltipValue(entry.value, unitLabel);
+              const formattedValue = formatTooltipValueWithUnit(
+                entry.value,
+                valueBase,
+                unitRange,
+                unitLabel,
+              );
 
               return (
                 <React.Fragment key={index}>

--- a/src/lib/components/charts/linetimeseries/useChartData.ts
+++ b/src/lib/components/charts/linetimeseries/useChartData.ts
@@ -32,6 +32,8 @@ type ChartDataOutput = {
   topValue: number;
   /** Unit label (e.g., "KiB/s", "%") */
   unitLabel: string | undefined;
+  /** Factor the dataset was divided by during normalization (for tooltip re-scaling) */
+  valueBase: number;
   /** X-axis tick positions */
   xAxisTicks: number[];
   /** Line configurations ready for rendering */
@@ -207,7 +209,7 @@ export function useChartData({
    * - Applies unit range thresholds (e.g., B/s → KiB/s → MiB/s)
    * - Calculates Y-axis domain
    */
-  const { topValue, unitLabel, rechartsData, topDomain } = useMemo(() => {
+  const { topValue, unitLabel, rechartsData, topDomain, valueBase } = useMemo(() => {
     const values = chartData.flatMap((dataPoint) =>
       Object.entries(dataPoint)
         .filter(([key]) => key !== 'timestamp')
@@ -231,6 +233,7 @@ export function useChartData({
         unitLabel: yAxisType === 'percentage' ? '%' : undefined,
         rechartsData: chartData,
         topDomain: 1,
+        valueBase: 1,
       };
     }
 
@@ -258,6 +261,7 @@ export function useChartData({
       unitLabel: result.unitLabel ?? (yAxisType === 'percentage' ? '%' : undefined),
       rechartsData: result.rechartsData,
       topDomain: finalTopDomain,
+      valueBase: result.valueBase,
     };
   }, [chartData, yAxisType, unitRange]);
 
@@ -317,6 +321,7 @@ export function useChartData({
     topDomain,
     topValue,
     unitLabel,
+    valueBase,
     xAxisTicks,
     linesToRender,
     belowSeriesLabels,

--- a/stories/linetimeseriechart.stories.tsx
+++ b/stories/linetimeseriechart.stories.tsx
@@ -1212,6 +1212,144 @@ export const ModernPreset: Story = {
   },
 };
 
+// ─── ARTESCA-17366: tooltip unit independent from axis unit ───────────────────
+// Operations per second. The dataset maximum is in the thousands, so the axis
+// (and chart title) settle on "kop/s". A handful of points are only a few op/s.
+// Before the fix those points rendered as "0.00 kop/s" in the tooltip (the axis
+// unit forced on every value). Now the tooltip re-derives the unit per value, so
+// a 3 op/s point reads "3.00 op/s" while the axis stays in kop/s.
+const UNIT_RANGE_OPS = [
+  { threshold: 1, label: 'op/s' },
+  { threshold: 1000, label: 'kop/s' },
+  { threshold: 1000000, label: 'Mop/s' },
+];
+
+const mixedMagnitudeOpsData: [number, string][] = [
+  [1740405600, '4200'],
+  [1740406320, '3850'],
+  [1740407760, '4100'],
+  [1740408480, '3'], // tiny spike-down → "3.00 op/s", not "0.00 kop/s"
+  [1740409200, '4500'],
+  [1740409920, '3920'],
+  [1740410640, '7'], // tiny → "7.00 op/s"
+  [1740411360, '4310'],
+  [1740412080, '3780'],
+  [1740412800, '4640'],
+  [1740413520, '5120'],
+  [1740414240, '120'], // small → "120.00 op/s"
+  [1740415680, '4170'],
+  [1740416400, '3550'],
+  [1740417120, '4790'],
+  [1740417840, '3210'],
+  [1740418560, '4410'],
+  [1740419280, '0.5'], // sub-unit → "0.50 op/s"
+  [1740420000, '3950'],
+  [1740420720, '4680'],
+  [1740421440, '3504'],
+  [1740422160, '4660'],
+  [1740422880, '4357'],
+  [1740423600, '3680'],
+];
+
+export const TooltipUnitRangeExample: Story = {
+  render: () => {
+    return (
+      <ChartLegendWrapper colorSet={{ 'operations': lineTimeSeriesColorRange[0] }}>
+        <LineTimeSerieChart
+          series={[
+            {
+              data: mixedMagnitudeOpsData,
+              resource: 'operations',
+              metricPrefix: 'rate',
+              getTooltipLabel: (_prefix, resource) => `${resource}`,
+            },
+          ]}
+          title="Operation"
+          height={200}
+          startingTimeStamp={mixedMagnitudeOpsData[0][0]}
+          unitRange={UNIT_RANGE_OPS}
+          isLoading={false}
+          yAxisType={'default'}
+          interval={SAMPLE_FREQUENCY_LAST_TWENTY_FOUR_HOURS}
+          duration={SAMPLE_DURATION_LAST_TWENTY_FOUR_HOURS}
+          helpText="Axis is in kop/s; hover the low points (3, 7, 120, 0.5) — the tooltip re-applies the unit range so they read in op/s instead of 0.00 kop/s."
+        />
+        <ChartLegend shape="line" direction="vertical" />
+      </ChartLegendWrapper>
+    );
+  },
+};
+
+// Three series sharing the same timestamps but living in different magnitudes:
+// - "deletes" peaks in the millions  → axis settles on Mop/s
+// - "reads"  is in the thousands     → tooltip re-derives kop/s
+// - "writes" is a handful of op/s    → tooltip re-derives op/s
+// Hovering any point shows all three values, each with its own proper unit,
+// instead of the small ones collapsing to "0.00 Mop/s".
+const opsTimestamps = mixedMagnitudeOpsData.map(([t]) => t);
+
+const readsData: [number, string][] = opsTimestamps.map((t, i) => [
+  t,
+  (3500 + ((i * 137) % 1800)).toString(),
+]);
+
+const writesData: [number, string][] = opsTimestamps.map((t, i) => [
+  t,
+  (2 + ((i * 7) % 40)).toString(),
+]);
+
+const deletesData: [number, string][] = opsTimestamps.map((t, i) => [
+  t,
+  (1_200_000 + ((i * 91_000) % 900_000)).toString(),
+]);
+
+export const TooltipUnitRangeMultiSeriesExample: Story = {
+  render: () => {
+    return (
+      <ChartLegendWrapper
+        colorSet={{
+          reads: lineTimeSeriesColorRange[0],
+          writes: lineTimeSeriesColorRange[1],
+          deletes: lineTimeSeriesColorRange[2],
+        }}
+      >
+        <LineTimeSerieChart
+          series={[
+            {
+              data: deletesData,
+              resource: 'deletes',
+              metricPrefix: 'rate',
+              getTooltipLabel: (_prefix, resource) => `${resource}`,
+            },
+            {
+              data: readsData,
+              resource: 'reads',
+              metricPrefix: 'rate',
+              getTooltipLabel: (_prefix, resource) => `${resource}`,
+            },
+            {
+              data: writesData,
+              resource: 'writes',
+              metricPrefix: 'rate',
+              getTooltipLabel: (_prefix, resource) => `${resource}`,
+            },
+          ]}
+          title="Operation"
+          height={200}
+          startingTimeStamp={opsTimestamps[0]}
+          unitRange={UNIT_RANGE_OPS}
+          isLoading={false}
+          yAxisType={'default'}
+          interval={SAMPLE_FREQUENCY_LAST_TWENTY_FOUR_HOURS}
+          duration={SAMPLE_DURATION_LAST_TWENTY_FOUR_HOURS}
+          helpText="Axis is in Mop/s (largest series). Hover any point: deletes read in Mop/s, reads in kop/s and writes in op/s — each value gets its own unit, independent of the axis."
+        />
+        <ChartLegend shape="line" direction="vertical" />
+      </ChartLegendWrapper>
+    );
+  },
+};
+
 export const BigValuesExample: Story = {
   render: () => {
     return (


### PR DESCRIPTION
## Problem

Chart data is normalized once against the dataset maximum so the Y-axis can display a single unit (e.g. `kop/s`). The tooltip reused that **same axis unit for every point**, so a value that is small relative to the maximum was shown with the wrong magnitude — e.g. a `5 op/s` point rendered as `0.00 kop/s`, which is both misleading and lossy.

## Fix

The `LineTimeSerieChart` tooltip now re-applies the unit range **per value**, independently of the axis unit:

- each value is denormalized (multiplied back by the `valueBase` used for the axis),
- the appropriate unit is re-derived for that value's own magnitude via the existing `getUnitLabel`,
- it falls back to the axis label when no `unitRange` is configured (e.g. percentage charts).

So with an axis in `kop/s`, a small `5 op/s` point now reads `5.00 op/s`, and a large point can read `5.00 Mop/s` — each value in its proper unit while the axis stays fixed.

The shared logic lives in a new `formatTooltipValueWithUnit` helper in `chartUtils` (exported for advanced usage), and `normalizeChartDataWithUnits` now also returns the `valueBase` so the tooltip can denormalize.

## Design note: approach chosen

Two approaches were considered for getting a per-value unit in the tooltip:

- **Method A — denormalize in the tooltip (chosen):** one normalized dataset for the axis; the tooltip multiplies the plotted value back by `valueBase`, then re-derives the unit.
- **Method B — carry the raw value through:** keep the raw values reachable from the tooltip (either store raw alongside normalized in `rechartsData`, or pass the original `series` and look the value up by timestamp + label), so the tooltip skips the multiply.

**Method A was chosen.** The tooltip's input is already the normalized value (Recharts hands back what it plotted), so a direct "raw value → tooltip" path isn't available without re-introducing the raw data somewhere. Method A keeps a single source of truth (one normalized dataset) and adds only a localized, commented inverse-multiply, whereas Method B would duplicate state (raw + normalized) or re-derive the label correlation that `useChartData` already owns — for no perf gain at tooltip-render frequency.

## Tests

- 8 new unit tests in `chartUtils.test.ts` (smaller/larger/matching unit re-derivation, negative values for symmetrical charts, no-range fallback, non-finite handling, `valueBase` exposure).
- Full charts suite: 186/186 passing. Typecheck and lint clean.

## Storybook

Two new stories under **Charts/LineTimeSerieChart**:

- `TooltipUnitRangeExample` — single series, axis in `kop/s`, with low points that read in `op/s`.
- `TooltipUnitRangeMultiSeriesExample` — three series spanning `op/s` / `kop/s` / `Mop/s`, so a single tooltip shows multiple values each in its own unit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
