### PR TITLE
fix(ci): write GHPR token to workspace .npmrc so publish-npm npm ci can auth

### DIFF
--- a/.github/workflows/post-release.yml
+++ b/.github/workflows/post-release.yml
@@ -66,11 +66,16 @@ jobs:
         with:
           node-version: "24"
           registry-url: "https://registry.npmjs.org"
-      # GHPR auth for @jbwatenbergscality/storybook-webmcp. Written directly to
-      # ~/.npmrc instead of via NODE_AUTH_TOKEN to avoid leaking the GitHub
-      # token to registry.npmjs.org through setup-node's npmjs auth line
-      # (//registry.npmjs.org/:_authToken=${NODE_AUTH_TOKEN}).
-      - run: echo "//npm.pkg.github.com/:_authToken=${{ secrets.GITHUB_TOKEN }}" >> ~/.npmrc
+      # GHPR auth for @jbwatenbergscality/storybook-webmcp. Appended to the
+      # workspace .npmrc (project scope), NOT ~/.npmrc: the repo's own .npmrc
+      # already sets `//npm.pkg.github.com/:_authToken=${NODE_AUTH_TOKEN}`, and
+      # project config outranks ~/.npmrc, so writing to ~/.npmrc gets clobbered
+      # by an empty token (NODE_AUTH_TOKEN is unset here) -> 401 on npm ci.
+      # Appending to the project .npmrc wins (last line wins within a file).
+      # Scoping the token to npm.pkg.github.com only (rather than setting
+      # NODE_AUTH_TOKEN) keeps the GitHub token from leaking to npmjs through
+      # setup-node's `//registry.npmjs.org/:_authToken=${NODE_AUTH_TOKEN}` line.
+      - run: echo "//npm.pkg.github.com/:_authToken=${{ secrets.GITHUB_TOKEN }}" >> .npmrc
       - run: npm ci
       - run: npm run build
       - run: npm publish


### PR DESCRIPTION
## Problem

The `release` → `post-release.yml` **publish-npm** job fails at `npm ci` with:

```
npm error code E401
npm error 401 Unauthorized - GET https://npm.pkg.github.com/download/@jbwatenbergscality/storybook-webmcp/0.1.1/...
  unauthenticated: User cannot be authenticated with the token provided.
```

(e.g. run [27004973362](https://github.com/scality/core-ui/actions/runs/27004973362/job/79694214349))

## Root cause

It is **not** a permissions problem — the package is public and the org `GITHUB_TOKEN` can read it (proven by `tests.yaml`, which fetches it fine). It's an **npm config precedence collision**:

- The repo's checked-out `.npmrc` contains `//npm.pkg.github.com/:_authToken=${NODE_AUTH_TOKEN}` (**project** scope).
- `publish-npm` did not set `NODE_AUTH_TOKEN`; it echoed the token to **`~/.npmrc`** (user scope) instead.
- **Project config outranks `~/.npmrc`**, so with `NODE_AUTH_TOKEN` unset that line expands to an **empty token** and clobbers the good one → 401.

`packages: read` (added in #1117) is necessary but not sufficient — the clobber remained, so the next release would still 401.

## Fix

Append the GHPR token to the **workspace `.npmrc`** (project scope, last line wins) instead of `~/.npmrc`, so `npm ci` resolves a real token.

The token stays scoped to `npm.pkg.github.com` only (we don't set `NODE_AUTH_TOKEN`), preserving the hardening from `7ae36735` — the GitHub token is still not sent to `registry.npmjs.org` during `npm publish`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)