### PR TITLE
improvement(charts): fix Barchart tooltip units and ticks

### DIFF
--- a/src/lib/components/charts/barchart/Barchart.test.tsx
+++ b/src/lib/components/charts/barchart/Barchart.test.tsx
@@ -512,5 +512,22 @@ describe('Barchart', () => {
       );
       expect(screen.getByText('05 Jul')).toBeInTheDocument();
     });
+    it('should render both lines of a multi-line category tick label', () => {
+      const { Wrapper } = getWrapper();
+      render(
+        <Wrapper>
+          <CustomTick
+            type={{ type: 'category' }}
+            x={100}
+            y={100}
+            payload={{ value: '00:00–03:00\n05 Jul' }}
+            visibleTicksCount={10}
+            width={100}
+          />
+        </Wrapper>,
+      );
+      expect(screen.getByText('00:00–03:00')).toBeInTheDocument();
+      expect(screen.getByText('05 Jul')).toBeInTheDocument();
+    });
   });
 });

--- a/src/lib/components/charts/barchart/Barchart.tsx
+++ b/src/lib/components/charts/barchart/Barchart.tsx
@@ -13,7 +13,7 @@ import { Stack } from '../../../spacing';
 import { chartColors, ChartColors, fontSize } from '../../../style/theme';
 import { useChartLegend } from '../legend/ChartLegendWrapper';
 import { BarchartTooltip } from './BarchartTooltip';
-import { formatTickValue, getTicks } from '../common/chartUtils';
+import { formatTickValue, getTicks, splitTickLines } from '../common/chartUtils';
 import { useChartData } from './Barchart.utils';
 import {
   ChartHeader,
@@ -21,6 +21,8 @@ import {
   ChartLoading,
   CustomTick,
   StyledResponsiveContainer,
+  TICK_BASE_HEIGHT,
+  TICK_LINE_HEIGHT,
 } from '../common/SharedComponents';
 import { TimeType, CategoryType, UnitRange } from '../types';
 
@@ -172,6 +174,7 @@ export const Barchart = <T extends BarchartBars>(props: BarchartProps<T>) => {
     roundReferenceValue,
     rechartsData,
     topDomain,
+    valueBase,
   } = useChartData(
     bars || [],
     type,
@@ -187,6 +190,20 @@ export const Barchart = <T extends BarchartBars>(props: BarchartProps<T>) => {
     (value: number) => formatTickValue(value, roundReferenceValue),
     [roundReferenceValue],
   );
+
+  // A category label may wrap to a second line (e.g. a date on a midnight
+  // crossover). Reserve matching x-axis height so the extra line is not clipped.
+  const maxTickLines = useMemo(() => {
+    if (type.type !== 'category') {
+      return 1;
+    }
+    return rechartsData.reduce((max, point) => {
+      const lineCount = splitTickLines(point.category ?? '').length;
+      return Math.max(max, lineCount);
+    }, 1);
+  }, [type.type, rechartsData]);
+
+  const xAxisHeight = TICK_BASE_HEIGHT + (maxTickLines - 1) * TICK_LINE_HEIGHT;
 
   const renderChartContent = () => {
     if (isError || (!bars && !isLoading)) {
@@ -254,6 +271,7 @@ export const Barchart = <T extends BarchartBars>(props: BarchartProps<T>) => {
 
           <XAxis
             dataKey="category"
+            height={xAxisHeight}
             tick={(props) => (
               <CustomTick
                 {...props}
@@ -277,6 +295,8 @@ export const Barchart = <T extends BarchartBars>(props: BarchartProps<T>) => {
                 hoveredValue={hoveredValue}
                 tooltip={tooltip}
                 unitLabel={unitLabel}
+                unitRange={unitRange}
+                valueBase={valueBase}
                 chartContainerRef={chartRef}
               />
             )}

--- a/src/lib/components/charts/barchart/Barchart.utils.ts
+++ b/src/lib/components/charts/barchart/Barchart.utils.ts
@@ -400,7 +400,7 @@ export const useChartData = <T extends BarchartBars>(
 
   const maxValue = getMaxBarValue(filteredData, stacked);
 
-  const { unitLabel, topValue, rechartsData, topDomain } =
+  const { unitLabel, topValue, rechartsData, topDomain, valueBase } =
     normalizeChartDataWithUnits(filteredData, maxValue, unitRange, 'category');
 
   return {
@@ -409,6 +409,7 @@ export const useChartData = <T extends BarchartBars>(
     roundReferenceValue: topValue,
     rechartsData,
     topDomain,
+    valueBase,
   };
 };
 

--- a/src/lib/components/charts/barchart/BarchartTooltip.tsx
+++ b/src/lib/components/charts/barchart/BarchartTooltip.tsx
@@ -8,8 +8,9 @@ import {
   TooltipHeader,
 } from '../common/ChartTooltip';
 import { BarchartBars, BarchartTooltipFn } from './Barchart';
-import { CategoryType, TimeType } from '../types';
+import { CategoryType, TimeType, UnitRange } from '../types';
 import { getCurrentPoint } from './Barchart.utils';
+import { formatTooltipValueWithUnit } from '../common/chartUtils';
 
 export const BarchartTooltip = <T extends BarchartBars>({
   type,
@@ -18,6 +19,8 @@ export const BarchartTooltip = <T extends BarchartBars>({
   hoveredValue,
   tooltip,
   unitLabel,
+  unitRange,
+  valueBase = 1,
   chartContainerRef,
 }: {
   type: TimeType | CategoryType;
@@ -26,6 +29,8 @@ export const BarchartTooltip = <T extends BarchartBars>({
   hoveredValue: string | undefined;
   tooltip?: BarchartTooltipFn<T>;
   unitLabel?: string;
+  unitRange?: UnitRange;
+  valueBase?: number;
   chartContainerRef: React.RefObject<HTMLDivElement>;
 }) => {
   const { active, coordinate } = tooltipProps;
@@ -62,12 +67,13 @@ export const BarchartTooltip = <T extends BarchartBars>({
             />
           );
 
-          const formattedValue = Number.isInteger(value.value)
-            ? `${value.value}`
-            : value.value.toFixed(2);
-          const valueWithUnit = unitLabel
-            ? `${formattedValue} ${unitLabel}`
-            : formattedValue;
+          const valueWithUnit = formatTooltipValueWithUnit(
+            value.value,
+            valueBase,
+            unitRange,
+            unitLabel,
+            false,
+          );
           return (
             <ChartTooltipItem
               key={value.label}

--- a/src/lib/components/charts/common/SharedComponents.tsx
+++ b/src/lib/components/charts/common/SharedComponents.tsx
@@ -7,7 +7,7 @@ import { Loader } from '../../loader/Loader.component';
 import { Text } from '../../text/Text.component';
 import { ConstrainedText } from '../../constrainedtext/Constrainedtext.component';
 import { FormattedDateTime } from '../../date/FormattedDateTime';
-import { formatXAxisDate, maxWidthTooltip } from './chartUtils';
+import { formatXAxisDate, maxWidthTooltip, splitTickLines } from './chartUtils';
 import { TimeType, CategoryType } from '../types';
 
 /**
@@ -23,29 +23,37 @@ export const StyledResponsiveContainer = styled(ResponsiveContainer)`
   }
 `;
 
+// Tick labels are top-anchored (not vertically centered) at the tick, then grow
+// downward. The first line therefore sits at the same place for every tick —
+// single- or multi-line — instead of its position depending on the box height.
+// All lines share one line-height so the first line of a multi-line label is
+// identical to a single-line label.
 const TickContainer = styled.div`
   width: 100%;
   height: 100%;
   display: flex;
-  align-items: center;
+  align-items: flex-start;
   justify-content: center;
+  & span {
+    line-height: 0.9;
+  }
 `;
 
-// Stacks a multi-line tick label (e.g. time + date on a midnight crossover)
-// tightly. The reduced line-height keeps the two lines visually grouped; each
-// line stays its own ConstrainedText so it truncates independently.
+// Stacks the lines of a multi-line tick label (e.g. time + date on a midnight
+// crossover); each line stays its own ConstrainedText so it truncates
+// independently. Line spacing and first-line alignment come from TickContainer.
 const MultilineTickContainer = styled.div`
   width: 100%;
   display: flex;
   flex-direction: column;
   align-items: center;
-  & span {
-    line-height: 1.1;
-  }
 `;
 
 // Extra height granted per wrapped line so a second line is not clipped.
-const TICK_LINE_HEIGHT = 12;
+export const TICK_LINE_HEIGHT = 12;
+
+// Height of a single-line x-axis tick band (matches the foreignObject base height).
+export const TICK_BASE_HEIGHT = 30;
 
 interface ChartLoadingOrErrorProps {
   height: number;
@@ -138,7 +146,9 @@ interface CustomTickProps {
   x: number | string;
   y: number | string;
   payload: {
-    value: number;
+    // A timestamp for time ticks, or the category label (possibly "\n"-split
+    // into multiple lines) for category ticks.
+    value: number | string;
   };
   visibleTicksCount?: number;
   width?: number | string;
@@ -194,7 +204,7 @@ export const CustomTick = ({
 
   // A category label may carry a second line (e.g. a date on a midnight
   // crossover) separated by "\n"; those lines are stacked tightly.
-  const lines = type.type === 'time' ? [] : String(payload.value).split('\n');
+  const lines = type.type === 'time' ? [] : splitTickLines(payload.value);
   const isMultiline = lines.length > 1;
 
   const content =
@@ -216,9 +226,12 @@ export const CustomTick = ({
   return (
     <foreignObject
       x={centerX}
-      y={numY - 10}
+      y={numY}
       width={tickWidth}
-      height={30 + (isMultiline ? (lines.length - 1) * TICK_LINE_HEIGHT : 0)}
+      // Box is anchored at the tick; the first line sits at its top and extra
+      // lines overflow downward (visible) into the space the XAxis reserves via
+      // TICK_LINE_HEIGHT.
+      height={TICK_BASE_HEIGHT}
       style={{
         overflow: 'visible',
         pointerEvents: 'none',

--- a/src/lib/components/charts/common/chartUtils.test.ts
+++ b/src/lib/components/charts/common/chartUtils.test.ts
@@ -490,4 +490,26 @@ describe('formatTooltipValueWithUnit', () => {
   it('returns "-" for non-finite values', () => {
     expect(formatTooltipValueWithUnit(NaN, 1000, unitRange, 'kop/s')).toBe('-');
   });
+
+  describe('with fixedDecimals = false (bare whole numbers)', () => {
+    it('drops the trailing ".00" for whole values on the re-derived unit', () => {
+      // Same input as the default case, which yields "5.00 op/s".
+      expect(
+        formatTooltipValueWithUnit(0.005, 1000, unitRange, 'kop/s', false),
+      ).toBe('5 op/s');
+    });
+
+    it('still keeps up to two decimals for fractional values', () => {
+      // 1.84 (stored) * 1000 = 1840 op/s → 1.84 kop/s
+      expect(
+        formatTooltipValueWithUnit(1.84, 1000, unitRange, 'kop/s', false),
+      ).toBe('1.84 kop/s');
+    });
+
+    it('drops the trailing ".00" in the no-unit-range fallback', () => {
+      expect(formatTooltipValueWithUnit(20, 1, undefined, 'kB', false)).toBe(
+        '20 kB',
+      );
+    });
+  });
 });

--- a/src/lib/components/charts/common/chartUtils.ts
+++ b/src/lib/components/charts/common/chartUtils.ts
@@ -9,6 +9,14 @@ import { formatISONumber } from '../../../utils';
 
 export const maxWidthTooltip = { maxWidth: '20rem' };
 
+/**
+ * Splits a tick label into its display lines. A category label may embed a
+ * second line (e.g. a date on a midnight crossover) using "\n" as the
+ * separator. Single source of truth for that convention.
+ */
+export const splitTickLines = (value: string | number): string[] =>
+  String(value).split('\n');
+
 /* -------------------------------------------------------------------------- */
 /*                               utils functions                              */
 /* -------------------------------------------------------------------------- */
@@ -231,18 +239,20 @@ export const normalizeChartDataWithUnits = <T extends Record<string, any>>(
  * @param valueBase - The factor the dataset was divided by during normalization
  * @param unitRange - Unit range used for the chart; when empty the value is shown as-is
  * @param fallbackUnitLabel - Unit label used when no unitRange is provided (e.g. "%")
+ * @param fixedDecimals - When true (default) always show 2 decimals; set false to keep whole values bare (e.g. counts)
  */
 export const formatTooltipValueWithUnit = (
   value: number,
   valueBase: number,
   unitRange: UnitRange | undefined,
   fallbackUnitLabel?: string,
+  fixedDecimals = true,
 ): string => {
   if (!Number.isFinite(value)) return '-';
 
   if (!unitRange || unitRange.length === 0) {
     const formatted = formatISONumber(value, {
-      fixedDecimals: true,
+      fixedDecimals,
       compact: true,
     });
     return `${formatted}${fallbackUnitLabel ? ` ${fallbackUnitLabel}` : ''}`;
@@ -254,7 +264,7 @@ export const formatTooltipValueWithUnit = (
     Math.abs(originalValue),
   );
   const formatted = formatISONumber(originalValue / tooltipValueBase, {
-    fixedDecimals: true,
+    fixedDecimals,
     compact: true,
   });
   return `${formatted}${unitLabel ? ` ${unitLabel}` : ''}`;

--- a/stories/BarChart/barchart.stories.tsx
+++ b/stories/BarChart/barchart.stories.tsx
@@ -991,6 +991,11 @@ export const Histogram: Story = {
  * that crosses midnight shows the date (`02 Jun`) on a second line. The caller
  * supplies these strings; the chart renders them as-is via `CustomTick`'s
  * multi-line support.
+ *
+ * The values span several orders of magnitude (like a response-code histogram),
+ * so `unitRange` scales the axis to `k` while the tooltip re-derives each unit
+ * per value — the `Success` bars read e.g. `4.5 k`, the small `Errors` series
+ * stays bare (`12`) in the same tooltip.
  */
 export const HistogramWithMultilineLabels: Story = {
   render: () => {
@@ -1005,25 +1010,35 @@ export const HistogramWithMultilineLabels: Story = {
       '05:00',
       '08:00',
     ];
-    const values = [12, 30, 45, 50, 42, 20, 15, 25];
+    const success = [1840, 3020, 4500, 5010, 4200, 2000, 1500, 2500];
+    const errors = [12, 30, 8, 45, 6, 9, 4, 15];
     const histogramData = [
       {
-        label: 'Requests',
-        data: labels.map(
-          (label, i) => [label, values[i]] as [string, number],
-        ),
+        label: 'Success',
+        data: labels.map((label, i) => [label, success[i]] as [string, number]),
+      },
+      {
+        label: 'Errors',
+        data: labels.map((label, i) => [label, errors[i]] as [string, number]),
       },
     ];
     return (
       <div style={{ width: '50%', padding: spacing.r16 }}>
         <ChartLegendWrapper
           colorSet={{
-            Requests: theme.statusHealthy,
+            Success: theme.statusHealthy,
+            Errors: theme.statusCritical,
           }}
         >
           <Barchart
             type={{ type: 'category', gap: 0 }}
             bars={histogramData}
+            stacked
+            unitRange={[
+              { threshold: 1, label: '' },
+              { threshold: 1000, label: 'k' },
+              { threshold: 1000000, label: 'M' },
+            ]}
             title="Requests over 24h"
           />
           <ChartLegend shape="rectangle" />


### PR DESCRIPTION
##Summary 

- Tooltip re-derives the unit per value (whole numbers stay bare) instead of applying the chart's single axis unit, so small bars no longer read "0.001 k"; adds a fixedDecimals opt-out to formatTooltipValueWithUnit.
- Top-anchor tick labels at the tick and reserve x-axis height for wrapped labels, so a multi-line label's first line aligns with single-line labels regardless of line count (no centering, no offset constant).
- Extract splitTickLines helper as the single source of the "\n" convention; widen CustomTick payload.value type to string | number.
- Add a multi-line tick test and enrich HistogramWithMultilineLabels with multi-magnitude data (values > 1000) to exercise the unit scaling.
