### PR TITLE
Add Tag icon (fa-tag) to icon table

### DIFF
--- a/src/lib/components/icon/iconTable.ts
+++ b/src/lib/components/icon/iconTable.ts
@@ -145,4 +145,5 @@ export const iconTable = {
   History: 'fas faClockRotateLeft',
   Astronaut: 'fas faUserAstronaut',
   Microchip: 'fas faMicrochip',
+  Tag: 'fas faTag',
 };


### PR DESCRIPTION
## Summary

Adds a `Tag` icon to the core-ui icon table, mapped to FontAwesome's solid `faTag` glyph. This makes a tag/label icon available via `<Icon name="Tag" />`.

## Why

It's needed to render the "add label" affordance on deployment cards in Artesca Maestro, which currently inlines a custom SVG because core-ui had no tag icon.

## Changes

- `src/lib/components/icon/iconTable.ts`: add `Tag: 'fas faTag'`

🤖 Generated with [Claude Code](https://claude.com/claude-code)