### PR TITLE
feat(ButtonGroup): add segmented ButtonGroup to next entry

### DIFF
--- a/src/lib/components/buttongroup/ButtonGroup.component.test.tsx
+++ b/src/lib/components/buttongroup/ButtonGroup.component.test.tsx
@@ -1,0 +1,89 @@
+import '@testing-library/jest-dom';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import React from 'react';
+import { getWrapper } from '../../testUtils';
+import { Button } from '../buttonv2/Buttonv2.component';
+import { ButtonGroup } from './ButtonGroup.component';
+
+describe('ButtonGroup', () => {
+  const { Wrapper } = getWrapper();
+
+  it('renders its child buttons inside a group', () => {
+    render(
+      <ButtonGroup>
+        <Button value="name" label="Name" />
+        <Button value="version" label="Version" />
+      </ButtonGroup>,
+      { wrapper: Wrapper },
+    );
+
+    expect(screen.getByRole('group')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Name' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Version' })).toBeInTheDocument();
+  });
+
+  it('marks the selected child as pressed when selection is enabled', () => {
+    render(
+      <ButtonGroup value="version" onChange={jest.fn()}>
+        <Button value="name" label="Name" />
+        <Button value="version" label="Version" />
+      </ButtonGroup>,
+      { wrapper: Wrapper },
+    );
+
+    expect(screen.getByRole('button', { name: 'Name' })).toHaveAttribute(
+      'aria-pressed',
+      'false',
+    );
+    expect(screen.getByRole('button', { name: 'Version' })).toHaveAttribute(
+      'aria-pressed',
+      'true',
+    );
+  });
+
+  it('calls onChange with the clicked child value', async () => {
+    const onChange = jest.fn();
+    render(
+      <ButtonGroup value="name" onChange={onChange}>
+        <Button value="name" label="Name" />
+        <Button value="version" label="Version" />
+      </ButtonGroup>,
+      { wrapper: Wrapper },
+    );
+
+    await userEvent.click(screen.getByRole('button', { name: 'Version' }));
+
+    expect(onChange).toHaveBeenCalledTimes(1);
+    expect(onChange).toHaveBeenCalledWith('version');
+  });
+
+  it('preserves a child onClick handler while still notifying the group', async () => {
+    const onChange = jest.fn();
+    const childOnClick = jest.fn();
+    render(
+      <ButtonGroup value={null} onChange={onChange}>
+        <Button value="name" label="Name" onClick={childOnClick} />
+      </ButtonGroup>,
+      { wrapper: Wrapper },
+    );
+
+    await userEvent.click(screen.getByRole('button', { name: 'Name' }));
+
+    expect(childOnClick).toHaveBeenCalledTimes(1);
+    expect(onChange).toHaveBeenCalledWith('name');
+  });
+
+  it('does not inject selection props without onChange', () => {
+    render(
+      <ButtonGroup>
+        <Button value="name" label="Name" />
+      </ButtonGroup>,
+      { wrapper: Wrapper },
+    );
+
+    expect(screen.getByRole('button', { name: 'Name' })).not.toHaveAttribute(
+      'aria-pressed',
+    );
+  });
+});

--- a/src/lib/components/buttongroup/ButtonGroup.component.test.tsx
+++ b/src/lib/components/buttongroup/ButtonGroup.component.test.tsx
@@ -74,6 +74,23 @@ describe('ButtonGroup', () => {
     expect(onChange).toHaveBeenCalledWith('name');
   });
 
+  it('does not mark a valueless child as a toggle button in selectable mode', () => {
+    render(
+      <ButtonGroup value="name" onChange={jest.fn()}>
+        <Button value="name" label="Name" />
+        <Button label="Static" />
+      </ButtonGroup>,
+      { wrapper: Wrapper },
+    );
+
+    expect(screen.getByRole('button', { name: 'Name' })).toHaveAttribute(
+      'aria-pressed',
+    );
+    expect(screen.getByRole('button', { name: 'Static' })).not.toHaveAttribute(
+      'aria-pressed',
+    );
+  });
+
   it('does not inject selection props without onChange', () => {
     render(
       <ButtonGroup>

--- a/src/lib/components/buttongroup/ButtonGroup.component.tsx
+++ b/src/lib/components/buttongroup/ButtonGroup.component.tsx
@@ -1,0 +1,142 @@
+import {
+  Children,
+  cloneElement,
+  isValidElement,
+  type HTMLAttributes,
+  type MouseEvent,
+  type ReactElement,
+  type ReactNode,
+} from 'react';
+import styled, { css } from 'styled-components';
+import { spacing } from '../../spacing';
+
+type Orientation = 'horizontal' | 'vertical';
+
+export type ButtonGroupProps = Omit<
+  HTMLAttributes<HTMLDivElement>,
+  'onChange'
+> & {
+  /** Lay the buttons out in a row (default) or a column. */
+  orientation?: Orientation;
+  /**
+   * Value of the selected button. Providing `value` together with `onChange`
+   * turns the group into a single-select segmented control: every child must
+   * carry a `value`, and the child whose `value` matches is rendered selected.
+   * Pass `null` to render no selection.
+   */
+  value?: string | null;
+  /** Called with the clicked child's `value` when selection is enabled. */
+  onChange?: (value: string) => void;
+  /** The buttons to group — typically `Button` from `@scality/core-ui/next`. */
+  children: ReactNode;
+};
+
+const ButtonGroupContainer = styled.div<{ orientation: Orientation }>`
+  display: inline-flex;
+  flex-direction: ${(props) =>
+    props.orientation === 'vertical' ? 'column' : 'row'};
+  align-items: stretch;
+  border: ${spacing.r1} solid ${(props) => props.theme.border};
+  border-radius: ${spacing.r4};
+  overflow: hidden;
+
+  /* Each child button is wrapped (by Button's Tooltip) in extra elements.
+     Let those wrappers and the button itself fill their cell so a vertical
+     group reads as equal-width rows; horizontal cells keep their natural
+     width since the group never stretches them on the main axis. */
+  & > * {
+    display: flex;
+  }
+  & > * > * {
+    flex: 1;
+    display: flex;
+  }
+
+  /* Strip each child button of its own framing so the group reads as one
+     segmented control rather than a row of separate buttons. */
+  .sc-button {
+    flex: 1;
+    border: none;
+    border-radius: 0;
+    background: transparent;
+    box-shadow: none;
+    color: ${(props) => props.theme.textSecondary};
+  }
+
+  /* A single hairline separator between adjacent buttons. */
+  ${(props) =>
+    props.orientation === 'vertical'
+      ? css`
+          & > *:not(:last-child) .sc-button {
+            border-bottom: ${spacing.r1} solid ${props.theme.border};
+          }
+        `
+      : css`
+          & > *:not(:last-child) .sc-button {
+            border-right: ${spacing.r1} solid ${props.theme.border};
+          }
+        `}
+
+  /* Doubled class selector keeps these states above Button's own variant
+     rules without resorting to !important. */
+  && .sc-button:hover:enabled {
+    background: ${(props) => props.theme.backgroundLevel1};
+    color: ${(props) => props.theme.textPrimary};
+  }
+
+  && .sc-button[aria-pressed='true'] {
+    background: ${(props) => props.theme.backgroundLevel1};
+    color: ${(props) => props.theme.textPrimary};
+    box-shadow: inset 0 0 0 ${spacing.r1} ${(props) => props.theme.selectedActive};
+  }
+`;
+
+type SelectableChildProps = {
+  value?: string;
+  onClick?: (event: MouseEvent<HTMLButtonElement>) => void;
+};
+
+function ButtonGroup({
+  orientation = 'horizontal',
+  value,
+  onChange,
+  children,
+  ...rest
+}: ButtonGroupProps) {
+  const selectable = typeof onChange === 'function';
+
+  const items = selectable
+    ? Children.map(children, (child) => {
+        if (!isValidElement(child)) {
+          return child;
+        }
+
+        const element = child as ReactElement<SelectableChildProps>;
+        const childValue = element.props.value;
+        const selected = childValue != null && childValue === value;
+
+        return cloneElement(element, {
+          'aria-pressed': selected,
+          onClick: (event: MouseEvent<HTMLButtonElement>) => {
+            element.props.onClick?.(event);
+            if (childValue != null) {
+              onChange(childValue);
+            }
+          },
+        } as Partial<SelectableChildProps> & { 'aria-pressed': boolean });
+      })
+    : children;
+
+  return (
+    <ButtonGroupContainer
+      className="sc-button-group"
+      role="group"
+      orientation={orientation}
+      {...rest}
+    >
+      {items}
+    </ButtonGroupContainer>
+  );
+}
+
+export { ButtonGroup };

--- a/src/lib/components/buttongroup/ButtonGroup.component.tsx
+++ b/src/lib/components/buttongroup/ButtonGroup.component.tsx
@@ -116,14 +116,16 @@ function ButtonGroup({
         const selected = childValue != null && childValue === value;
 
         return cloneElement(element, {
-          'aria-pressed': selected,
+          // Only a child with a `value` is a real toggle button; without one,
+          // clicking is a no-op, so it must not advertise a pressed state.
+          ...(childValue != null && { 'aria-pressed': selected }),
           onClick: (event: MouseEvent<HTMLButtonElement>) => {
             element.props.onClick?.(event);
             if (childValue != null) {
               onChange(childValue);
             }
           },
-        } as Partial<SelectableChildProps> & { 'aria-pressed': boolean });
+        } as Partial<SelectableChildProps> & { 'aria-pressed'?: boolean });
       })
     : children;
 

--- a/src/lib/next.ts
+++ b/src/lib/next.ts
@@ -2,6 +2,8 @@ import '@fortawesome/fontawesome-free/css/all.css';
 import './index.css';
 export { Button } from './components/buttonv2/Buttonv2.component';
 export { CopyButton } from './components/buttonv2/CopyButton.component';
+export { ButtonGroup } from './components/buttongroup/ButtonGroup.component';
+export type { ButtonGroupProps } from './components/buttongroup/ButtonGroup.component';
 export { Tabs, Tab } from './components/tabsv2/Tabsv2.component';
 export { Table } from './components/tablev2/Tablev2.component';
 

--- a/stories/buttongroup.stories.tsx
+++ b/stories/buttongroup.stories.tsx
@@ -1,0 +1,142 @@
+import { action } from 'storybook/actions';
+import React, { useState } from 'react';
+import { Icon, Stack } from '../src/lib';
+import { Button, ButtonGroup } from '../src/lib/next';
+import { Wrapper, Title } from './common';
+
+export default {
+  title: 'Components/ButtonGroup',
+  component: ButtonGroup,
+};
+
+const SORT_OPTIONS = [
+  { value: 'name', label: 'Name' },
+  { value: 'managedData', label: 'Managed data' },
+  { value: 'version', label: 'Version' },
+] as const;
+
+const GROUP_OPTIONS = [
+  { value: 'label', label: 'Label' },
+  { value: 'health', label: 'Health' },
+  { value: 'version', label: 'Version' },
+] as const;
+
+/**
+ * Single-select segmented control — provide `value` + `onChange` and give each
+ * child `Button` a `value`. This is the "Sort by" use case from maestro: the
+ * selected criterion is highlighted, and re-selecting it toggles the direction.
+ */
+export const SortBy = () => {
+  const [sortBy, setSortBy] = useState<string>('name');
+  const [direction, setDirection] = useState<'asc' | 'desc'>('asc');
+
+  const handleChange = (value: string) => {
+    if (value === sortBy) {
+      setDirection((current) => (current === 'asc' ? 'desc' : 'asc'));
+    } else {
+      setSortBy(value);
+      setDirection('asc');
+    }
+  };
+
+  return (
+    <Wrapper>
+      <Title>Sort by</Title>
+      <ButtonGroup value={sortBy} onChange={handleChange} aria-label="Sort by">
+        {SORT_OPTIONS.map((option) => (
+          <Button
+            key={option.value}
+            value={option.value}
+            label={option.label}
+            icon={
+              sortBy === option.value ? (
+                <Icon name={direction === 'asc' ? 'Arrow-up' : 'Arrow-down'} />
+              ) : undefined
+            }
+          />
+        ))}
+      </ButtonGroup>
+    </Wrapper>
+  );
+};
+
+/**
+ * `null` value renders no selection — re-selecting the active option clears it,
+ * matching maestro's optional "Group by".
+ */
+export const GroupByClearable = () => {
+  const [groupBy, setGroupBy] = useState<string | null>(null);
+
+  const handleChange = (value: string) => {
+    setGroupBy((current) => (current === value ? null : value));
+  };
+
+  return (
+    <Wrapper>
+      <Title>Group by (clearable)</Title>
+      <ButtonGroup value={groupBy} onChange={handleChange} aria-label="Group by">
+        {GROUP_OPTIONS.map((option) => (
+          <Button key={option.value} value={option.value} label={option.label} />
+        ))}
+      </ButtonGroup>
+    </Wrapper>
+  );
+};
+
+/** Vertical orientation. */
+export const Vertical = () => {
+  const [value, setValue] = useState<string>('list');
+
+  return (
+    <Wrapper>
+      <Title>Vertical</Title>
+      <ButtonGroup
+        orientation="vertical"
+        value={value}
+        onChange={setValue}
+        aria-label="View"
+      >
+        <Button value="list" label="List" icon={<Icon name="LayerGroup" />} />
+        <Button value="network" label="Network" icon={<Icon name="Network" />} />
+        <Button value="map" label="Map" icon={<Icon name="Map-marker" />} />
+      </ButtonGroup>
+    </Wrapper>
+  );
+};
+
+/**
+ * Without `value`/`onChange` the group is a plain visual cluster of buttons;
+ * each child keeps its own `onClick`.
+ */
+export const PlainGroup = () => {
+  return (
+    <Wrapper>
+      <Title>Plain group (no selection)</Title>
+      <ButtonGroup aria-label="Pagination">
+        <Button label="Previous" onClick={action('previous')} />
+        <Button label="1" onClick={action('page-1')} />
+        <Button label="2" onClick={action('page-2')} />
+        <Button label="Next" onClick={action('next')} />
+      </ButtonGroup>
+    </Wrapper>
+  );
+};
+
+export const Playground = () => {
+  const [value, setValue] = useState<string>('name');
+  return (
+    <Wrapper>
+      <Stack direction="vertical" gap="r16">
+        <ButtonGroup value={value} onChange={setValue}>
+          {SORT_OPTIONS.map((option) => (
+            <Button
+              key={option.value}
+              value={option.value}
+              label={option.label}
+            />
+          ))}
+        </ButtonGroup>
+      </Stack>
+    </Wrapper>
+  );
+};


### PR DESCRIPTION
## Summary

Adds a **`ButtonGroup`** component, exported from `@scality/core-ui/next`, that restyles its child `Button`s into a single segmented control.

This generalises the local `SegmentedControl`/`SegmentedGroup` introduced in [artesca-maestro#650](https://github.com/scality/artesca-maestro/pull/650) (the deployments-list "Sort by" / "Group by" controls) into a reusable core-ui component, so maestro can drop its bespoke `styled.div`/`styled.button` and consume this instead.

The API is inspired by MUI's `ButtonGroup`/`ToggleButtonGroup` but kept intentionally minimal and adapted to our use case.

## API

| Prop | Purpose |
|------|---------|
| `value` + `onChange` | Optional single-select toggle. Each child carries a `value`; the matching child is highlighted (`aria-pressed`). Pass `null` for no selection. |
| `orientation` | `'horizontal'` (default) or `'vertical'`. |
| children | core-ui `Button`s. Without `value`/`onChange` the group is a plain visual cluster, each child keeping its own `onClick`. |

```tsx
import { Button, ButtonGroup } from '@scality/core-ui/next';

<ButtonGroup value={sortBy} onChange={handleSortChange} aria-label="Sort by">
  <Button value="name" label="Name" />
  <Button value="version" label="Version" />
</ButtonGroup>
```

## Behaviour

- Joins child buttons into one bordered group, collapsing their individual radii/borders into shared hairline separators.
- Selected segment is highlighted using the existing theme tokens (`backgroundLevel1`, `textPrimary`, `selectedActive`) — same look as the original maestro control.
- `null` value renders no selection (supports maestro's clearable "Group by").
- Vertical groups render equal-width rows; horizontal cells keep their natural width.

## Stories

`Components/ButtonGroup`: SortBy, GroupByClearable, Vertical, PlainGroup, Playground.

<img width="596" height="216" alt="image" src="https://github.com/user-attachments/assets/a15ab187-a391-4804-a5d9-fd99f3d7a97a" />
<img width="512" height="230" alt="image" src="https://github.com/user-attachments/assets/651178ba-ba53-4da8-91a5-63327b7b15b2" />
<img width="372" height="352" alt="image" src="https://github.com/user-attachments/assets/a96ebaca-b8c3-41ba-a5d6-2798912e1683" />

## Tests

5 unit tests (rendering, `aria-pressed` selection, `onChange` payload, child `onClick` preservation, no selection props without `onChange`). `eslint` and `tsc --noEmit` clean.


