### PR TITLE
fix(sidebar): keep hovered label on one line to match expanded

### DIFF
--- a/src/lib/components/sidebar/Sidebar.component.tsx
+++ b/src/lib/components/sidebar/Sidebar.component.tsx
@@ -148,6 +148,7 @@ const SidebarItem = styled.div<{ active?: boolean }>`
 `;
 const MenuItemText = styled.div`
   margin-right: ${spacing.r20};
+  white-space: nowrap;
 `;
 // selected border-right
 const MenuItemSelected = styled.div`


### PR DESCRIPTION
## Problem

When the sidebar is **collapsed** and you hover it (with `hoverable`), the flyout is meant to look identical to the **expanded** sidebar. But a long label (e.g. *Identity Providers*) wraps to two lines instead of one, and the icon shifts slightly.

| | Expected | Before |
|---|---|---|
| Long label on hover | one line | wraps to two lines + icon shift |

Before:
<img width="323" height="231" alt="image" src="https://github.com/user-attachments/assets/9ee35dfe-94a1-4957-8398-c0256b56b973" />

After:
<img width="323" height="231" alt="image" src="https://github.com/user-attachments/assets/2b2eee0c-a68a-4097-9ec8-838f9dfccdb0" />


## Root cause

On hover, the overlay (`.sc-sidebar`) uses `width: fit-content` while staying `position: relative`, so its containing block is the collapsed wrapper (~`sidebarWidth`, ~46px). `fit-content` is therefore capped at that width, forcing long labels to wrap — which grows the row height and nudges the centered icon.

## Fix

Force the label onto a single line with `white-space: nowrap`. The label's min-content width then becomes the full text width, so `fit-content` expands to fit it — matching the expanded layout. One-line CSS change, no behavioural change to collapsed or expanded states.

## Testing

Verified in Storybook (`Components/Navigation/Sidebar → HoverableSidebar`) with a long label: the hovered flyout now renders the label on a single line with no icon shift.

🤖 Generated with [Claude Code](https://claude.com/claude-code)