### PR TITLE
bugfix(navbar): keep user dropdown on one line and reveal navbar border

### DIFF
--- a/src/lib/components/navbar/Navbar.component.tsx
+++ b/src/lib/components/navbar/Navbar.component.tsx
@@ -135,12 +135,19 @@ const NavbarMenuItem = styled.div`
   align-items: center;
   .sc-dropdown {
     .trigger {
-      background-color: ${getThemePropSelector('navbarBackground')};
       &:hover {
         background-color: ${getThemePropSelector('highlight')};
       }
-      height: auto;
+      height: ${navbarHeight};
+      white-space: nowrap;
       font-size: ${fontSize.base};
+      .sc-trigger-text {
+        display: block;
+        max-width: 12rem;
+        white-space: nowrap;
+        overflow: hidden;
+        text-overflow: ellipsis;
+      }
     }
     .menu-item {
       max-height: unset;

--- a/stories/navbar.stories.tsx
+++ b/stories/navbar.stories.tsx
@@ -177,6 +177,27 @@ export const NavbarWithOnlyLinkTabs = {
   },
 };
 
+export const NavbarWithLongUserName = {
+  args: {
+    rightActions: [
+      {
+        type: 'dropdown',
+        text: 'averylongusername.that-would-previously-wrap@example.com',
+        icon: <i className="fas fa-user" />,
+        items: [{ label: 'Log out', onClick: action('Logout clicked') }],
+      },
+    ],
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'A long username stays on a single line, truncated with an ellipsis, and the trigger keeps the navbar height instead of wrapping to two lines. The trigger has no background fill so the navbar bottom border stays visible.',
+      },
+    },
+  },
+};
+
 export const NavbarDropdownShowcase = {
   args: {
     rightActions: [


### PR DESCRIPTION
## Problem

A long username in the navbar's right-action dropdown wrapped to two lines and grew **taller than the navbar**, breaking vertical alignment. The trigger's solid `navbarBackground` fill also covered the navbar's bottom border.


## Fix

In `NavbarMenuItem .sc-dropdown .trigger` (`Navbar.component.tsx`):
- Pin the trigger to `navbarHeight` and add `white-space: nowrap` so it never wraps.
- Truncate the label (`.sc-trigger-text`): `display: block; max-width: 12rem; overflow: hidden; text-overflow: ellipsis`.
- Remove the `background-color: navbarBackground` fill so the navbar's bottom border stays visible.

Scope matches the original bug — it applies to `Dropdown`-type right actions (the username case), whose trigger text carries `.sc-trigger-text`.

## Verification

- `NavbarWithLongUserName` Storybook story added for visual review.
- Full Jest suite: 36 suites / 454 tests pass.
- `tsc --noEmit` clean; ESLint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
