### PR TITLE
improvement(responsive): add dropAt column drop to Tablev2

### DIFF
--- a/src/lib/components/tablev2/TableCommon.tsx
+++ b/src/lib/components/tablev2/TableCommon.tsx
@@ -1,4 +1,11 @@
-import { ComponentType, Ref, useCallback, useState, forwardRef } from 'react';
+import {
+  ComponentType,
+  Ref,
+  useCallback,
+  useMemo,
+  useState,
+  forwardRef,
+} from 'react';
 import { Row } from 'react-table';
 import AutoSizer from 'react-virtualized-auto-sizer';
 import {
@@ -40,6 +47,16 @@ type VirtualizedRowsType<
   onBottom?: (rowLength: number) => void;
   onBottomOffset?: number;
   listRef?: Ref<FixedSizeList<Row<DATA_ROW>[]>>;
+  /**
+   * Signature of the currently visible columns. Each row is rendered through
+   * `memo(RenderRow, areEqual)`, and react-window's `areEqual` skips the render
+   * when `itemData` is referentially unchanged. react-table keeps the `rows`
+   * array identity stable when only column visibility changes (responsive
+   * `dropAt`), so without this the header would update while the virtualized
+   * body kept its stale cells. Changing this key gives `itemData` a fresh
+   * identity, forcing the visible rows to re-render without remounting the list.
+   */
+  columnsKey?: string;
 };
 
 export const VirtualizedRows = <
@@ -53,43 +70,52 @@ export const VirtualizedRows = <
   RenderRow,
   listRef,
   itemKey,
-}: VirtualizedRowsType<DATA_ROW>) => (
-  <AutoSizer disableWidth>
-    {({ height }) => {
-      return (
-        <List
-          height={height - 1}
-          itemCount={rows.length} // how many items we are going to render
-          itemSize={convertRemToPixels(tableRowHeight[rowHeight])} // height of each row in pixel
-          width={'100%'}
-          itemKey={itemKey}
-          itemData={rows}
-          ref={listRef}
-          outerElementType={SmoothScrollDiv}
-          onItemsRendered={({
-            visibleStartIndex,
-            visibleStopIndex,
-            overscanStopIndex,
-          }) => {
-            setHasScrollbar(
-              visibleStopIndex - visibleStartIndex < overscanStopIndex,
-            );
+  columnsKey,
+}: VirtualizedRowsType<DATA_ROW>) => {
+  // Fresh array identity whenever the rows or the visible-column set changes, so
+  // react-window's `areEqual` lets the body re-render in step with the header.
+  // `columnsKey` is deliberately a dependency though it is not read here — it is
+  // the signal that the visible-column set changed.
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  const itemData = useMemo(() => rows.slice(), [rows, columnsKey]);
+  return (
+    <AutoSizer disableWidth>
+      {({ height }) => {
+        return (
+          <List
+            height={height - 1}
+            itemCount={rows.length} // how many items we are going to render
+            itemSize={convertRemToPixels(tableRowHeight[rowHeight])} // height of each row in pixel
+            width={'100%'}
+            itemKey={itemKey}
+            itemData={itemData}
+            ref={listRef}
+            outerElementType={SmoothScrollDiv}
+            onItemsRendered={({
+              visibleStartIndex,
+              visibleStopIndex,
+              overscanStopIndex,
+            }) => {
+              setHasScrollbar(
+                visibleStopIndex - visibleStartIndex < overscanStopIndex,
+              );
 
-            if (
-              onBottom &&
-              onBottomOffset != null &&
-              overscanStopIndex >= rows.length - 1 - onBottomOffset
-            ) {
-              onBottom(rows.length);
-            }
-          }}
-        >
-          {RenderRow}
-        </List>
-      );
-    }}
-  </AutoSizer>
-);
+              if (
+                onBottom &&
+                onBottomOffset != null &&
+                overscanStopIndex >= rows.length - 1 - onBottomOffset
+              ) {
+                onBottom(rows.length);
+              }
+            }}
+          >
+            {RenderRow}
+          </List>
+        );
+      }}
+    </AutoSizer>
+  );
+};
 
 export const useTableScrollbar = () => {
   const { hasScrollbar, setHasScrollbar } = useTableContext();
@@ -141,9 +167,23 @@ export function TableRows<
   listRef: externalListRef,
 }: TableRowsProps<DATA_ROW>) {
   const { setHasScrollbar } = useTableScrollbar();
-  const { rows, status, entityName, rowHeight, onBottom, onBottomOffset } =
-    useTableContext<DATA_ROW>();
+  const {
+    rows,
+    status,
+    entityName,
+    rowHeight,
+    onBottom,
+    onBottomOffset,
+    headerGroups,
+  } = useTableContext<DATA_ROW>();
   const { bodyRef } = useSyncedScroll<DATA_ROW>();
+
+  // headerGroups only contains visible columns, so this string changes whenever
+  // a responsive column drops or reappears — used to re-sync the virtualized
+  // body with the header (see VirtualizedRows.columnsKey).
+  const columnsKey = headerGroups
+    .map((group) => group.headers.map((header) => header.id).join(','))
+    .join('|');
   const listRef: Ref<FixedSizeList<Row<DATA_ROW>[]>> =
     externalListRef || bodyRef;
 
@@ -178,6 +218,7 @@ export function TableRows<
             onBottom={onBottom}
             onBottomOffset={onBottomOffset}
             RenderRow={RenderRow}
+            columnsKey={columnsKey}
           />,
         );
       } else {
@@ -200,6 +241,7 @@ export function TableRows<
           itemKey={itemKey}
           rowHeight={rowHeight}
           RenderRow={RenderRow}
+          columnsKey={columnsKey}
         />
       );
     } else {

--- a/src/lib/components/tablev2/Tablev2.component.tsx
+++ b/src/lib/components/tablev2/Tablev2.component.tsx
@@ -294,7 +294,9 @@ function Table<
             ]
           : [],
         selectedRowIds: formattedInitiallySelectedRows,
-        hiddenColumns: ['selection', DROPPED_COLUMNS_COLUMN_ID],
+        hiddenColumns: revealDroppedColumns
+          ? ['selection', DROPPED_COLUMNS_COLUMN_ID]
+          : ['selection'],
       },
       disableMultiSort: true,
       autoResetSortBy: false,
@@ -302,6 +304,9 @@ function Table<
       //@ts-ignore TODO investigate why this type is not matching
       globalFilter: stringifyFilter,
       autoResetHiddenColumns: false,
+      // Threaded onto the react-table instance so `useDroppedColumns` only
+      // injects its synthetic column when the feature is opted into.
+      revealDroppedColumns,
       updateTableData,
     },
     useBlockLayout,
@@ -332,6 +337,11 @@ function Table<
     new Set(),
   );
 
+  // Last `revealDroppedColumns` value the effect reconciled against, so a
+  // runtime toggle re-runs the reveal-column logic even when the dropped set is
+  // unchanged.
+  const previousRevealRef = useRef(revealDroppedColumns);
+
   useEffect(() => {
     if (!hasResponsiveColumns) {
       return;
@@ -350,10 +360,14 @@ function Table<
         .map((column) => column.id),
     );
     const previouslyDropped = responsivelyDroppedRef.current;
-    const unchanged =
-      shouldDrop.size === previouslyDropped.size &&
-      [...shouldDrop].every((id) => previouslyDropped.has(id));
-    if (unchanged) {
+    const dropSetChanged =
+      shouldDrop.size !== previouslyDropped.size ||
+      [...shouldDrop].some((id) => !previouslyDropped.has(id));
+    // Reconcile when the dropped set changed OR the reveal feature was toggled;
+    // the latter must still update the reveal column's visibility even though
+    // the same columns stay dropped.
+    const revealChanged = previousRevealRef.current !== revealDroppedColumns;
+    if (!dropSetChanged && !revealChanged) {
       return;
     }
     setHiddenColumns((previousHidden) => {
@@ -363,20 +377,21 @@ function Table<
       shouldDrop.forEach((id) => {
         if (!next.includes(id)) next.push(id);
       });
-      // Reveal the trailing "show dropped columns" column only while at least
-      // one responsive column is hidden and the feature is opted into.
+      // Show the trailing "reveal" column only while at least one responsive
+      // column is hidden and the feature is opted into; otherwise hide it.
       const shouldReveal = revealDroppedColumns && shouldDrop.size > 0;
-      const isRevealHidden = next.includes(DROPPED_COLUMNS_COLUMN_ID);
-      if (shouldReveal && isRevealHidden) {
-        return next.filter((id) => id !== DROPPED_COLUMNS_COLUMN_ID);
-      }
-      if (!shouldReveal && !isRevealHidden) {
-        return [...next, DROPPED_COLUMNS_COLUMN_ID];
-      }
-      return next;
+      const withoutReveal = next.filter(
+        (id) => id !== DROPPED_COLUMNS_COLUMN_ID,
+      );
+      return shouldReveal
+        ? withoutReveal
+        : [...withoutReveal, DROPPED_COLUMNS_COLUMN_ID];
     });
-    setDroppedColumnIds(shouldDrop);
-    responsivelyDroppedRef.current = shouldDrop;
+    previousRevealRef.current = revealDroppedColumns;
+    if (dropSetChanged) {
+      setDroppedColumnIds(shouldDrop);
+      responsivelyDroppedRef.current = shouldDrop;
+    }
   }, [
     hasResponsiveColumns,
     allColumns,

--- a/src/lib/components/tablev2/Tablev2.component.tsx
+++ b/src/lib/components/tablev2/Tablev2.component.tsx
@@ -1,6 +1,13 @@
 /// <reference path="react-table-config.ts" />
 
-import { createContext, useContext, useEffect, useMemo, useState } from 'react';
+import {
+  createContext,
+  useContext,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from 'react';
 import {
   Column as TableColumn,
   CellProps as TableCellProps,
@@ -32,8 +39,13 @@ import { SingleSelectableContent } from './SingleSelectableContent';
 import { TableWrapper, TooltipContent } from './Tablestyle';
 import { compareHealth, TableHeightKeyType } from './TableUtils';
 import { useCheckbox } from './useCheckbox';
+import {
+  useDroppedColumns,
+  DROPPED_COLUMNS_COLUMN_ID,
+} from './useDroppedColumns';
 import { Icon } from '../icon/Icon.component';
 import { TableSync } from './TableSync';
+import { useContainerWidth } from '../responsive/useContainerWidth';
 
 type UpdateTableData<
   DATA_ROW extends Record<string, unknown> = Record<string, unknown>,
@@ -86,6 +98,13 @@ export type TableProps<
     fr?: { singular: string; plural: string };
   };
   initiallySelectedRowsIds?: Set<string | number>;
+  /**
+   * When `true`, a trailing column is shown while one or more `dropAt` columns
+   * are responsively hidden. Its per-row trigger opens a popover listing the
+   * dropped columns' `Header: value` pairs, so the data stays reachable on
+   * narrow viewports. Opt-in; defaults to `false` (no behaviour change).
+   */
+  revealDroppedColumns?: boolean;
   //To call it from the Cell renderer to update the original data
 } & UpdateTableData<DATA_ROW>;
 
@@ -122,6 +141,8 @@ type TableContextType<
   setSyncScrollListener: (listener: (event: Event) => void) => void;
   setHasScrollbar: React.Dispatch<React.SetStateAction<boolean>>;
   hasScrollbar?: boolean;
+  /** Ids of the columns currently hidden by the responsive `dropAt` effect. */
+  droppedColumnIds: Set<string>;
 };
 const TableContext = createContext<TableContextType | null>(null);
 
@@ -197,6 +218,7 @@ function Table<
   updateTableData,
   status,
   entityName,
+  revealDroppedColumns = false,
 }: TableProps<DATA_ROW>) {
   sortTypes = {
     health: (row1, row2) => {
@@ -242,6 +264,7 @@ function Table<
     headerGroups,
     rows,
     prepareRow,
+    allColumns,
     selectedFlatRows,
     getTableBodyProps,
     state: { selectedRowIds },
@@ -271,7 +294,7 @@ function Table<
             ]
           : [],
         selectedRowIds: formattedInitiallySelectedRows,
-        hiddenColumns: ['selection'],
+        hiddenColumns: ['selection', DROPPED_COLUMNS_COLUMN_ID],
       },
       disableMultiSort: true,
       autoResetSortBy: false,
@@ -288,7 +311,79 @@ function Table<
     useExpanded,
     useRowSelect,
     useCheckbox,
+    useDroppedColumns,
   );
+
+  const hasResponsiveColumns = useMemo(
+    () => columns.some((column) => column.dropAt != null),
+    [columns],
+  );
+  const { ref: responsiveRef, width: containerWidth } =
+    useContainerWidth<HTMLDivElement>();
+
+  // Ids this effect has itself hidden for responsiveness, so it can release
+  // exactly those when the container grows back — without clobbering columns a
+  // consumer hid manually via the context-exposed `setHiddenColumns`.
+  const responsivelyDroppedRef = useRef<Set<string>>(new Set());
+
+  // State mirror of the dropped ids so the optional `revealDroppedColumns`
+  // popover cell (which reads this through context) re-renders when it changes.
+  const [droppedColumnIds, setDroppedColumnIds] = useState<Set<string>>(
+    new Set(),
+  );
+
+  useEffect(() => {
+    if (!hasResponsiveColumns) {
+      return;
+    }
+    // Read ids from the table's resolved columns (react-table generates an id
+    // for function accessors), not the raw config where `id`/`accessor` may be
+    // absent or a function.
+    const shouldDrop = new Set(
+      allColumns
+        .filter(
+          (column) =>
+            column.dropAt != null &&
+            containerWidth != null &&
+            containerWidth < column.dropAt,
+        )
+        .map((column) => column.id),
+    );
+    const previouslyDropped = responsivelyDroppedRef.current;
+    const unchanged =
+      shouldDrop.size === previouslyDropped.size &&
+      [...shouldDrop].every((id) => previouslyDropped.has(id));
+    if (unchanged) {
+      return;
+    }
+    setHiddenColumns((previousHidden) => {
+      const next = previousHidden.filter(
+        (id) => !previouslyDropped.has(id) || shouldDrop.has(id),
+      );
+      shouldDrop.forEach((id) => {
+        if (!next.includes(id)) next.push(id);
+      });
+      // Reveal the trailing "show dropped columns" column only while at least
+      // one responsive column is hidden and the feature is opted into.
+      const shouldReveal = revealDroppedColumns && shouldDrop.size > 0;
+      const isRevealHidden = next.includes(DROPPED_COLUMNS_COLUMN_ID);
+      if (shouldReveal && isRevealHidden) {
+        return next.filter((id) => id !== DROPPED_COLUMNS_COLUMN_ID);
+      }
+      if (!shouldReveal && !isRevealHidden) {
+        return [...next, DROPPED_COLUMNS_COLUMN_ID];
+      }
+      return next;
+    });
+    setDroppedColumnIds(shouldDrop);
+    responsivelyDroppedRef.current = shouldDrop;
+  }, [
+    hasResponsiveColumns,
+    allColumns,
+    containerWidth,
+    setHiddenColumns,
+    revealDroppedColumns,
+  ]);
 
   useEffect(() => {
     if (globalFilter !== undefined && globalFilter !== null) {
@@ -337,13 +432,18 @@ function Table<
     setSyncScrollListener,
     setHasScrollbar,
     hasScrollbar,
+    droppedColumnIds,
   };
   return (
     <TableContext.Provider
       //@ts-ignore
       value={contextValue}
     >
-      <TableWrapper role="grid" className="table">
+      <TableWrapper
+        role="grid"
+        className="table"
+        ref={hasResponsiveColumns ? responsiveRef : undefined}
+      >
         {children}
       </TableWrapper>
     </TableContext.Provider>

--- a/src/lib/components/tablev2/Tablev2.test.tsx
+++ b/src/lib/components/tablev2/Tablev2.test.tsx
@@ -1,3 +1,4 @@
+import { useState } from 'react';
 import { Table, TableProps } from './Tablev2.component';
 import { render, screen, waitFor, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
@@ -381,5 +382,46 @@ describe('TableV2 responsive columns', () => {
     expect(
       screen.queryByRole('button', { name: /hidden column/i }),
     ).not.toBeInTheDocument();
+  });
+
+  test('starts offering the reveal trigger when the feature is enabled while a column is already dropped', async () => {
+    mockWidth = 400;
+    const TogglingTable = () => {
+      const [reveal, setReveal] = useState(false);
+      return (
+        <div>
+          <button type="button" onClick={() => setReveal(true)}>
+            enable reveal
+          </button>
+          <Table
+            columns={responsiveColumns}
+            data={data}
+            revealDroppedColumns={reveal}
+          >
+            <Table.SingleSelectableContent
+              rowHeight="h40"
+              separationLineVariant="backgroundLevel3"
+            />
+          </Table>
+        </div>
+      );
+    };
+    render(<TogglingTable />);
+
+    // Age is dropped, but with the feature still off there is no reveal trigger.
+    await waitFor(() =>
+      expect(screen.queryByText('Age')).not.toBeInTheDocument(),
+    );
+    expect(
+      screen.queryByRole('button', { name: /hidden column/i }),
+    ).not.toBeInTheDocument();
+
+    // Turning the feature on — while the same column stays dropped — reveals it.
+    await userEvent.click(
+      screen.getByRole('button', { name: /enable reveal/i }),
+    );
+    expect(
+      await screen.findAllByRole('button', { name: /show 1 hidden column/i }),
+    ).not.toHaveLength(0);
   });
 });

--- a/src/lib/components/tablev2/Tablev2.test.tsx
+++ b/src/lib/components/tablev2/Tablev2.test.tsx
@@ -1,5 +1,6 @@
 import { Table, TableProps } from './Tablev2.component';
-import { render, screen, waitFor } from '@testing-library/react';
+import { render, screen, waitFor, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 
 jest.mock('./TableUtils', () => ({
   ...jest.requireActual('./TableUtils'),
@@ -231,5 +232,154 @@ describe('TableV2', () => {
     const rows = getAllByRole('row');
     expect(rows.length).toBe(2); // header + 1 matching data row
     expect(rows[1]).toHaveTextContent(/Yohann/i);
+  });
+});
+
+describe('TableV2 responsive columns', () => {
+  // jsdom ships no ResizeObserver and getBoundingClientRect always reports 0,
+  // so we stub both to drive the container width the Table measures.
+  let mockWidth = 1000;
+  const originalResizeObserver = global.ResizeObserver;
+  const originalGetBoundingClientRect = Element.prototype.getBoundingClientRect;
+
+  beforeAll(() => {
+    class ResizeObserverMock {
+      observe() {}
+      unobserve() {}
+      disconnect() {}
+    }
+    // @ts-expect-error assigning a stub to the global
+    global.ResizeObserver = ResizeObserverMock;
+    Element.prototype.getBoundingClientRect = function () {
+      return { width: mockWidth, height: 600 } as DOMRect;
+    };
+  });
+
+  afterAll(() => {
+    global.ResizeObserver = originalResizeObserver;
+    Element.prototype.getBoundingClientRect = originalGetBoundingClientRect;
+  });
+
+  const responsiveColumns: TableProps['columns'] = [
+    { Header: 'First Name', accessor: 'firstName' },
+    { Header: 'Last Name', accessor: 'lastName' },
+    { Header: 'Age', accessor: 'age', dropAt: 500 },
+    { Header: 'Health', accessor: 'health', sortType: 'health' },
+  ];
+
+  const renderResponsiveTable = () =>
+    render(
+      <div>
+        <Table columns={responsiveColumns} data={data}>
+          <Table.SingleSelectableContent
+            rowHeight="h40"
+            separationLineVariant="backgroundLevel3"
+          />
+        </Table>
+      </div>,
+    );
+
+  test('it keeps a droppable column visible when the table is wide enough', async () => {
+    mockWidth = 1000;
+    renderResponsiveTable();
+    await waitFor(() => screen.queryAllByRole('img', { hidden: true }));
+
+    expect(screen.getByText('Age')).toBeInTheDocument();
+    expect(screen.getByText('First Name')).toBeInTheDocument();
+  });
+
+  test('it hides a droppable column when the table is too narrow', async () => {
+    mockWidth = 400;
+    renderResponsiveTable();
+
+    await waitFor(() =>
+      expect(screen.queryByText('Age')).not.toBeInTheDocument(),
+    );
+    // columns without a dropAt stay visible at any width
+    expect(screen.getByText('First Name')).toBeInTheDocument();
+    expect(screen.getByText('Health')).toBeInTheDocument();
+  });
+
+  test('it hides a droppable column defined with a function accessor when narrow', async () => {
+    mockWidth = 400;
+    const columns: TableProps['columns'] = [
+      { Header: 'First Name', accessor: 'firstName' },
+      {
+        Header: 'Full Name',
+        id: 'fullName',
+        accessor: (row) => `${row.firstName} ${row.lastName}`,
+        dropAt: 500,
+      },
+    ];
+    render(
+      <div>
+        <Table columns={columns} data={data}>
+          <Table.SingleSelectableContent
+            rowHeight="h40"
+            separationLineVariant="backgroundLevel3"
+          />
+        </Table>
+      </div>,
+    );
+
+    await waitFor(() =>
+      expect(screen.queryByText('Full Name')).not.toBeInTheDocument(),
+    );
+    expect(screen.getByText('First Name')).toBeInTheDocument();
+  });
+
+  const renderRevealTable = () =>
+    render(
+      <div>
+        <Table columns={responsiveColumns} data={data} revealDroppedColumns>
+          <Table.SingleSelectableContent
+            rowHeight="h40"
+            separationLineVariant="backgroundLevel3"
+          />
+        </Table>
+      </div>,
+    );
+
+  test('lets the user read a dropped column value from a per-row popover', async () => {
+    mockWidth = 400;
+    renderRevealTable();
+
+    // Age (dropAt 500) is no longer shown inline at 400px wide...
+    await waitFor(() =>
+      expect(screen.queryByText('Age')).not.toBeInTheDocument(),
+    );
+
+    // ...but each row offers a trigger that reveals it.
+    const triggers = await screen.findAllByRole('button', {
+      name: /show 1 hidden column/i,
+    });
+    await userEvent.click(triggers[0]);
+
+    const popover = screen.getByRole('dialog');
+    expect(within(popover).getByText('Age')).toBeInTheDocument();
+    expect(within(popover).getByText('90')).toBeInTheDocument();
+  });
+
+  test('does not offer the reveal trigger while every column fits', async () => {
+    mockWidth = 1000;
+    renderRevealTable();
+    await waitFor(() => screen.queryAllByRole('img', { hidden: true }));
+
+    expect(screen.getByText('Age')).toBeInTheDocument();
+    expect(
+      screen.queryByRole('button', { name: /hidden column/i }),
+    ).not.toBeInTheDocument();
+  });
+
+  test('shows no reveal trigger when the feature is not opted into', async () => {
+    mockWidth = 400;
+    renderResponsiveTable();
+
+    await waitFor(() =>
+      expect(screen.queryByText('Age')).not.toBeInTheDocument(),
+    );
+    expect(
+      screen.queryByRole('button', { name: /hidden column/i }),
+    ).not.toBeInTheDocument();
   });
 });

--- a/src/lib/components/tablev2/react-table-config.ts
+++ b/src/lib/components/tablev2/react-table-config.ts
@@ -58,6 +58,13 @@ declare module 'react-table' {
 
   export type CoreUIColumn<D extends object = {}> = Column<D> & {
     cellStyle?: CSSProperties;
+    /**
+     * Optional responsive breakpoint, in pixels. When set, the column is
+     * hidden while the table container is narrower than this value. Columns
+     * without `dropAt` are always shown. Requires no extra wiring — the Table
+     * measures its own width.
+     */
+    dropAt?: number;
   };
   export interface ColumnInstance<D extends object = {}>
     extends UseFiltersColumnProps<D>,
@@ -65,6 +72,7 @@ declare module 'react-table' {
       UseResizeColumnsColumnProps<D>,
       UseSortByColumnProps<D> {
     cellStyle?: CSSProperties;
+    dropAt?: number;
   }
 
   export interface CoreUIUseTableOptions<D extends object>

--- a/src/lib/components/tablev2/react-table-config.ts
+++ b/src/lib/components/tablev2/react-table-config.ts
@@ -18,7 +18,14 @@ declare module 'react-table' {
       UsePaginationInstanceProps<D>,
       UseRowSelectInstanceProps<D>,
       UseRowStateInstanceProps<D>,
-      UseSortByInstanceProps<D> {}
+      UseSortByInstanceProps<D> {
+    /**
+     * Mirrors the `revealDroppedColumns` Table prop, threaded as a `useTable`
+     * option so the `useDroppedColumns` plugin can gate its synthetic column on
+     * the feature being opted into.
+     */
+    revealDroppedColumns?: boolean;
+  }
 
   export function useTable<D extends object = {}>(
     options: TableOptions<D>,

--- a/src/lib/components/tablev2/useDroppedColumns.tsx
+++ b/src/lib/components/tablev2/useDroppedColumns.tsx
@@ -1,0 +1,161 @@
+import { useState } from 'react';
+import { Hooks, Row } from 'react-table';
+import styled from 'styled-components';
+import {
+  autoUpdate,
+  flip,
+  FloatingFocusManager,
+  FloatingPortal,
+  offset,
+  shift,
+  useClick,
+  useDismiss,
+  useFloating,
+  useInteractions,
+  useRole,
+} from '@floating-ui/react';
+import { spacing } from '../../spacing';
+import { fontSize, fontWeight, zIndex } from '../../style/theme';
+import { getThemePropSelector } from '../../utils';
+import { Icon } from '../icon/Icon.component';
+import { useTableContext } from './Tablev2.component';
+
+/**
+ * Id of the synthetic trailing column injected by {@link useDroppedColumns}. It
+ * starts hidden (listed in the table's `initialState.hiddenColumns`) and is
+ * revealed by the responsive effect only while at least one `dropAt` column is
+ * currently dropped and `revealDroppedColumns` is enabled.
+ */
+export const DROPPED_COLUMNS_COLUMN_ID = 'droppedColumns';
+
+const Container = styled.div`
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  height: 100%;
+  width: 100%;
+`;
+
+const TriggerButton = styled.button`
+  display: inline-flex;
+  align-items: center;
+  gap: ${spacing.r4};
+  height: 100%;
+  padding: 0 ${spacing.r8};
+  border: none;
+  background: transparent;
+  cursor: pointer;
+  color: ${getThemePropSelector('textPrimary')};
+  &:hover {
+    background-color: ${getThemePropSelector('highlight')};
+  }
+`;
+
+const Panel = styled.div`
+  min-width: 14rem;
+  max-width: 24rem;
+  padding: ${spacing.r4} 0;
+  background-color: ${getThemePropSelector('backgroundLevel1')};
+  border: 1px solid ${getThemePropSelector('border')};
+  z-index: ${zIndex.dropdown};
+`;
+
+const Field = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: ${spacing.r2};
+  padding: ${spacing.r8} ${spacing.r16};
+  color: ${getThemePropSelector('textPrimary')};
+`;
+
+const FieldLabel = styled.span`
+  font-size: ${fontSize.small};
+  color: ${getThemePropSelector('textSecondary')};
+`;
+
+const FieldValue = styled.div`
+  font-weight: ${fontWeight.base};
+`;
+
+const DroppedColumnsCell = ({ row }: { row: Row<object> }) => {
+  const { droppedColumnIds } = useTableContext();
+  const [isOpen, setIsOpen] = useState(false);
+  const { refs, floatingStyles, context } = useFloating({
+    open: isOpen,
+    onOpenChange: setIsOpen,
+    placement: 'bottom-end',
+    middleware: [offset(4), flip(), shift({ padding: 8 })],
+    whileElementsMounted: autoUpdate,
+  });
+  const { getReferenceProps, getFloatingProps } = useInteractions([
+    useClick(context),
+    useDismiss(context),
+    useRole(context, { role: 'dialog' }),
+  ]);
+
+  // react-table keeps hidden columns' cells on `row.allCells`, so the dropped
+  // values stay reachable here even though they are not rendered inline.
+  const dropped = row.allCells.filter((cell) =>
+    droppedColumnIds.has(cell.column.id),
+  );
+
+  if (dropped.length === 0) {
+    return null;
+  }
+
+  return (
+    <Container>
+      <TriggerButton
+        type="button"
+        ref={refs.setReference}
+        aria-label={`Show ${dropped.length} hidden ${
+          dropped.length > 1 ? 'columns' : 'column'
+        }`}
+        {...getReferenceProps()}
+      >
+        <span>{`+${dropped.length}`}</span>
+        <Icon name="Chevron-down" />
+      </TriggerButton>
+      {isOpen && (
+        <FloatingPortal>
+          <FloatingFocusManager context={context} modal={false}>
+            <Panel
+              ref={refs.setFloating}
+              style={floatingStyles}
+              {...getFloatingProps()}
+            >
+              {dropped.map((cell) => (
+                <Field key={cell.column.id}>
+                  <FieldLabel>{cell.column.render('Header')}</FieldLabel>
+                  <FieldValue>{cell.render('Cell')}</FieldValue>
+                </Field>
+              ))}
+            </Panel>
+          </FloatingFocusManager>
+        </FloatingPortal>
+      )}
+    </Container>
+  );
+};
+
+/**
+ * Appends a trailing column whose per-row trigger opens a popover listing the
+ * `Header: value` pairs of any column currently dropped for responsiveness, so
+ * the data stays reachable on narrow viewports. Mirrors {@link useCheckbox}:
+ * the column is injected through `hooks.visibleColumns` and its visibility is
+ * driven by the table's existing responsive effect via `setHiddenColumns`.
+ */
+export const useDroppedColumns = (hooks: Hooks<object>) => {
+  hooks.visibleColumns.push((columns) => [
+    ...columns,
+    {
+      id: DROPPED_COLUMNS_COLUMN_ID,
+      Header: () => null,
+      Cell: DroppedColumnsCell,
+      disableSortBy: true,
+      cellStyle: { width: '60px', justifyContent: 'center' },
+    },
+  ]);
+};
+
+useDroppedColumns.pluginName = 'useDroppedColumns';

--- a/src/lib/components/tablev2/useDroppedColumns.tsx
+++ b/src/lib/components/tablev2/useDroppedColumns.tsx
@@ -15,9 +15,10 @@ import {
   useRole,
 } from '@floating-ui/react';
 import { spacing } from '../../spacing';
-import { fontSize, fontWeight, zIndex } from '../../style/theme';
+import { zIndex } from '../../style/theme';
 import { getThemePropSelector } from '../../utils';
 import { Icon } from '../icon/Icon.component';
+import { Text } from '../text/Text.component';
 import { useTableContext } from './Tablev2.component';
 
 /**
@@ -66,15 +67,6 @@ const Field = styled.div`
   gap: ${spacing.r2};
   padding: ${spacing.r8} ${spacing.r16};
   color: ${getThemePropSelector('textPrimary')};
-`;
-
-const FieldLabel = styled.span`
-  font-size: ${fontSize.small};
-  color: ${getThemePropSelector('textSecondary')};
-`;
-
-const FieldValue = styled.div`
-  font-weight: ${fontWeight.base};
 `;
 
 const DroppedColumnsCell = ({ row }: { row: Row<object> }) => {
@@ -126,8 +118,10 @@ const DroppedColumnsCell = ({ row }: { row: Row<object> }) => {
             >
               {dropped.map((cell) => (
                 <Field key={cell.column.id}>
-                  <FieldLabel>{cell.column.render('Header')}</FieldLabel>
-                  <FieldValue>{cell.render('Cell')}</FieldValue>
+                  <Text variant="Small" color="textSecondary">
+                    {cell.column.render('Header')}
+                  </Text>
+                  <Text>{cell.render('Cell')}</Text>
                 </Field>
               ))}
             </Panel>
@@ -146,15 +140,25 @@ const DroppedColumnsCell = ({ row }: { row: Row<object> }) => {
  * driven by the table's existing responsive effect via `setHiddenColumns`.
  */
 export const useDroppedColumns = (hooks: Hooks<object>) => {
-  hooks.visibleColumns.push((columns) => [
-    ...columns,
-    {
-      id: DROPPED_COLUMNS_COLUMN_ID,
-      Header: () => null,
-      Cell: DroppedColumnsCell,
-      disableSortBy: true,
-      cellStyle: { width: '60px', justifyContent: 'center' },
-    },
+  hooks.visibleColumns.push((columns, { instance }) =>
+    instance.revealDroppedColumns
+      ? [
+          ...columns,
+          {
+            id: DROPPED_COLUMNS_COLUMN_ID,
+            Header: () => null,
+            Cell: DroppedColumnsCell,
+            disableSortBy: true,
+            cellStyle: { width: '60px', justifyContent: 'center' },
+          },
+        ]
+      : columns,
+  );
+  // Re-run the visibleColumns memo when the feature is toggled at runtime, so
+  // the synthetic column is added or removed accordingly.
+  hooks.visibleColumnsDeps.push((deps, { instance }) => [
+    ...deps,
+    instance.revealDroppedColumns,
   ]);
 };
 

--- a/stories/tablev2.stories.tsx
+++ b/stories/tablev2.stories.tsx
@@ -830,3 +830,109 @@ export const AutoScrollToSelected = {
     );
   },
 };
+
+const responsiveColumns: Column<Entry>[] = [
+  {
+    Header: 'First Name',
+    accessor: 'firstName',
+    cellStyle: { width: 'unset', flex: 2, textAlign: 'left' },
+  },
+  {
+    Header: 'Last Name',
+    accessor: 'lastName',
+    cellStyle: { width: 'unset', flex: 2, textAlign: 'left' },
+    dropAt: 700,
+  },
+  {
+    Header: 'Age',
+    accessor: 'age',
+    cellStyle: { width: 'unset', flex: 1, textAlign: 'left' },
+    dropAt: 550,
+  },
+  {
+    Header: 'Health',
+    accessor: 'health',
+    sortType: 'health',
+    cellStyle: { width: 'unset', flex: 1, textAlign: 'left' },
+  },
+];
+
+export const ResponsiveColumnDrop = {
+  render: () => (
+    <>
+      <Title>Responsive column drop</Title>
+      <Box mb={2}>
+        Drag the bottom-right corner to resize. Columns with a <code>dropAt</code>{' '}
+        breakpoint hide as the table gets narrower (Age below 550px, Last Name
+        below 700px). First Name and Health have no breakpoint, so they always
+        stay.
+      </Box>
+      <div
+        style={{
+          height: '320px',
+          width: '900px',
+          minWidth: '320px',
+          maxWidth: '100%',
+          resize: 'horizontal',
+          overflow: 'hidden',
+          padding: '20px',
+          border: '1px dashed currentColor',
+          boxSizing: 'border-box',
+        }}
+      >
+        <Table
+          columns={responsiveColumns}
+          data={data}
+          defaultSortingKey={'health'}
+          getRowId={getRowId}
+        >
+          <Table.SingleSelectableContent
+            rowHeight="h40"
+            separationLineVariant="backgroundLevel3"
+          />
+        </Table>
+      </div>
+    </>
+  ),
+};
+
+export const ResponsiveColumnDropWithReveal = {
+  render: () => (
+    <>
+      <Title>Responsive column drop with reveal</Title>
+      <Box mb={2}>
+        Same responsive columns as above, but with <code>revealDroppedColumns</code>.
+        Once a column drops, a trailing column appears with a per-row{' '}
+        <code>+N</code> trigger; clicking it opens a popover listing the dropped
+        columns and their values for that row, so no data is lost on a narrow
+        viewport. Drag the bottom-right corner below 700px to see it.
+      </Box>
+      <div
+        style={{
+          height: '320px',
+          width: '900px',
+          minWidth: '320px',
+          maxWidth: '100%',
+          resize: 'horizontal',
+          overflow: 'hidden',
+          padding: '20px',
+          border: '1px dashed currentColor',
+          boxSizing: 'border-box',
+        }}
+      >
+        <Table
+          columns={responsiveColumns}
+          data={data}
+          defaultSortingKey={'health'}
+          getRowId={getRowId}
+          revealDroppedColumns
+        >
+          <Table.SingleSelectableContent
+            rowHeight="h40"
+            separationLineVariant="backgroundLevel3"
+          />
+        </Table>
+      </div>
+    </>
+  ),
+};


### PR DESCRIPTION
## TL;DR

`Tablev2` columns can now opt into responsive hiding: set `dropAt: <px>` on a column and it hides itself once the table gets narrower than that, with an optional `+N` popover that keeps the hidden values reachable. Both features are opt-in — tables that don't use them are unchanged.

## Context

Second step in the progressive responsive rollout, after the `useContainerWidth` measure-only hook landed in #1144. This PR is what consumes that hook: the Table observes its own `TableWrapper` width and hides columns whose `dropAt` breakpoint the container has fallen below — no consumer wiring, no context/provider, the Table self-measures.

The design rule being followed is **restyle → CSS; count/relocate DOM → JS**. Plain column hiding could have been CSS, but the reveal popover has to *count* the hidden columns and *relocate* their values, which CSS can't do — so the whole feature stays JS-driven on the table's own measured width to keep one source of truth. react-table keeps hidden cells on `row.allCells`, so the dropped values stay reachable for the popover without duplicating data.

How a resize turns into what you see:

```mermaid
flowchart LR
  A[TableWrapper width<br/>via useContainerWidth] --> B{width &lt; column.dropAt?}
  B -- yes --> C[hide column<br/>setHiddenColumns]
  C --> D{revealDroppedColumns<br/>&& any dropped?}
  D -- yes --> E[show trailing +N column<br/>popover lists Header: value]
  D -- no --> F[no reveal column]
  B -- no --> G[column stays visible]
```

## Screenshots

**`ResponsiveColumnDrop` — wide vs. narrow.** All columns show when wide; drop the container below 550px and both `Age` (dropAt 550) and `Last Name` (dropAt 700) hide, while `First Name` and `Health` (no `dropAt`) stay.

![Tablev2 responsive column drop — wide vs. narrow](https://patrickear-dev.s3.eu-west-1.amazonaws.com/screenshots/1502ffe8-a2cb-449c-b78b-0836743ec1d5.png)

**`ResponsiveColumnDropWithReveal` — `+N` popover.** With `revealDroppedColumns`, a trailing per-row `+2` trigger opens a popover listing the dropped columns' `Header: value` pairs, so no data is lost on a narrow viewport.

![Tablev2 reveal popover showing dropped column values](https://patrickear-dev.s3.eu-west-1.amazonaws.com/screenshots/1cd7d9ba-1fbc-4502-9c86-5593648d77e9.png)

## 🔧 Usage

Opt in per column with `dropAt`, and (optionally) turn on the reveal popover at the Table level. Both are additive — omitting them keeps today's behaviour.

```tsx
// before — static columns
const columns = [
  { Header: 'First Name', accessor: 'firstName' },
  { Header: 'Last Name',  accessor: 'lastName' },
  { Header: 'Age',        accessor: 'age' },
];
<Table columns={columns} data={data} getRowId={getRowId}>
  <Table.SingleSelectableContent rowHeight="h40" />
</Table>

// after — responsive columns + reveal popover
const columns = [
  { Header: 'First Name', accessor: 'firstName' },              // no dropAt → always shown
  { Header: 'Last Name',  accessor: 'lastName', dropAt: 700 👈 },  // hidden below 700px
  { Header: 'Age',        accessor: 'age',      dropAt: 550 👈},  // hidden below 550px
];
<Table columns={columns} data={data} getRowId={getRowId} revealDroppedColumns>👈
  <Table.SingleSelectableContent rowHeight="h40" />
</Table>
```

## Review focus

- 🟡 **`Tablev2.component.tsx` › responsive `useEffect`** — the core reconciliation. It reconciles on either a changed drop-set *or* a runtime `revealDroppedColumns` toggle, and `setHiddenColumns` is written to preserve columns a consumer hid manually (only releases ids this effect itself dropped). Worth confirming the manual-hide preservation and the toggle path hold up.
- 🟡 **`useDroppedColumns.tsx` › `visibleColumns` / `visibleColumnsDeps`** — new react-table plugin injecting the synthetic `+N` column *only* when `revealDroppedColumns` is on (gated via a threaded `useTable` option), so feature-off tables keep an unchanged column pipeline. Check the gating + the popover reading dropped values off `row.allCells`.
- 🟡 **`TableCommon.tsx` › `columnsKey` / `itemData`** — virtualization sync. react-table keeps the `rows` array identity stable on visibility-only changes, so `columnsKey` (derived from visible `headerGroups`) gives `itemData` a fresh identity to force react-window past `areEqual`; otherwise the header updates while the body keeps stale cells.

## How to test

1. `npm run storybook`, open **Tablev2 › ResponsiveColumnDrop**.
2. Drag the frame's bottom-right corner to resize: **Age** drops below 550px, **Last Name** below 700px; **First Name** and **Health** (no `dropAt`) always stay.
3. Open **ResponsiveColumnDropWithReveal**, narrow below 700px until the trailing **`+N`** column appears, click a row's trigger, and confirm the popover lists the dropped columns' `Header: value` pairs for that row.
4. Sanity check a table with no `dropAt` columns is visually and behaviourally unchanged.

## References

- **#1144** — `useContainerWidth` measure-only hook; the width source this PR consumes (step 1 of the responsive rollout).

<details>
<summary>What changed</summary>

- **`useDroppedColumns.tsx`** (new) — react-table plugin: the synthetic `+N` column and its floating-ui popover cell; injected only when `revealDroppedColumns` is opted in.
- **`Tablev2.component.tsx`** — `dropAt` measuring effect, `revealDroppedColumns` prop, `droppedColumnIds` on context, and the plugin registration/gating.
- **`TableCommon.tsx`** — `columnsKey` threaded into `VirtualizedRows` to re-sync the virtualized body with the header on visibility changes.
- **`react-table-config.ts`** — types for `dropAt` (column) and `revealDroppedColumns` (table option).
- **`Tablev2.test.tsx`** — 6 new behavioural tests (jsdom stubs `ResizeObserver` + `getBoundingClientRect`).
- **`tablev2.stories.tsx`** — `ResponsiveColumnDrop` and `ResponsiveColumnDropWithReveal` stories (resizable frames).

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)