### PR TITLE
ARTESCA-17791: Navbar responsive — tab overflow "More" menu + condense actions

### DIFF
--- a/src/lib/components/dropdown/Dropdown.component.tsx
+++ b/src/lib/components/dropdown/Dropdown.component.tsx
@@ -31,6 +31,12 @@ type Props = {
   icon?: JSX.Element;
   caret?: boolean;
   placement?: Placement;
+  /**
+   * Accessible name for the trigger. Set this when the trigger is icon-only
+   * (no visible `text`) so it still has a name; falls back to `title` in that
+   * case. Overrides the label reference the underlying select would set.
+   */
+  'aria-label'?: string;
 };
 const DropdownStyled = styled.div`
   position: relative;
@@ -104,8 +110,12 @@ function Dropdown({
   title,
   caret = true,
   placement = 'bottom',
+  'aria-label': ariaLabel,
   ...rest
 }: Props) {
+  // Fall back to the tooltip text for an icon-only trigger so it still has an
+  // accessible name when the visible label is hidden.
+  const triggerAriaLabel = ariaLabel ?? (icon && !text ? title : undefined);
   const {
     isOpen,
     getToggleButtonProps,
@@ -139,6 +149,9 @@ function Dropdown({
         title={title}
         {...getToggleButtonProps()}
         {...getReferenceProps()}
+        {...(triggerAriaLabel
+          ? { 'aria-label': triggerAriaLabel, 'aria-labelledby': undefined }
+          : {})}
       >
         {icon && (
           <ButtonIcon text={text} size={size}>

--- a/src/lib/components/navbar/Navbar.component.test.tsx
+++ b/src/lib/components/navbar/Navbar.component.test.tsx
@@ -169,22 +169,7 @@ describe('Navbar responsiveness', () => {
     expect(screen.getByText('Carlito')).toBeInTheDocument();
   });
 
-  it('drops the username label to an icon-only trigger when narrow', () => {
-    stubNavbarWidth(360);
-    renderNavbar({ tabs, rightActions: [userAction] });
-
-    expect(screen.queryByText('Carlito')).not.toBeInTheDocument();
-  });
-
-  it('keeps the account menu reachable by name when condensed to an icon', () => {
-    stubNavbarWidth(360);
-    renderNavbar({ tabs, rightActions: [userAction] });
-
-    expect(screen.queryByText('Carlito')).not.toBeInTheDocument();
-    expect(screen.getByLabelText('Carlito')).toBeInTheDocument();
-  });
-
-  it('condenses an opted-in dropdown to its initials, keeping the full name accessible', () => {
+  it('abbreviates the username to its initials when narrow, keeping the full name accessible', () => {
     stubNavbarWidth(360);
     renderNavbar({
       tabs,
@@ -193,7 +178,6 @@ describe('Navbar responsiveness', () => {
           type: 'dropdown' as const,
           text: 'Carlito Gonzalez',
           icon: <i className="fas fa-user" />,
-          abbreviateWhenCondensed: true,
           items: [{ label: 'Log out', onClick: () => {} }],
         },
       ],
@@ -202,6 +186,24 @@ describe('Navbar responsiveness', () => {
     expect(screen.getByText('CG')).toBeInTheDocument();
     expect(screen.queryByText('Carlito Gonzalez')).not.toBeInTheDocument();
     expect(screen.getByLabelText('Carlito Gonzalez')).toBeInTheDocument();
+  });
+
+  it('keeps an icon-only action icon-only when narrow instead of inventing initials', () => {
+    stubNavbarWidth(360);
+    renderNavbar({
+      tabs,
+      rightActions: [
+        {
+          type: 'dropdown' as const,
+          icon: <i className="fas fa-th" />,
+          items: [{ label: 'App 1', onClick: () => {} }],
+        },
+      ],
+    });
+
+    // No text label was provided, so nothing is abbreviated and no stray
+    // initial chip appears next to the icon.
+    expect(screen.queryByText(/^[A-Z]{1,2}$/)).not.toBeInTheDocument();
   });
 
   it('gives the condensed name precedence over an aria-label on the action', () => {

--- a/src/lib/components/navbar/Navbar.component.test.tsx
+++ b/src/lib/components/navbar/Navbar.component.test.tsx
@@ -1,0 +1,231 @@
+import { render, screen, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { ThemeProvider } from 'styled-components';
+import { Navbar, selectVisibleTabs } from './Navbar.component';
+import { coreUIAvailableThemes } from '../../style/theme';
+
+const theme = coreUIAvailableThemes.darkRebrand;
+
+const renderNavbar = (props) =>
+  render(
+    <ThemeProvider theme={theme}>
+      <Navbar {...props} />
+    </ThemeProvider>,
+  );
+
+const tabs = [
+  { title: 'Groups', selected: true, link: <a href="/groups">Groups</a> },
+  { title: 'Users', link: <a href="/users">Users</a> },
+  { title: 'Policies', link: <a href="/policies">Policies</a> },
+];
+
+const userAction = {
+  type: 'dropdown' as const,
+  text: 'Carlito',
+  icon: <i className="fas fa-user" />,
+  items: [{ label: 'Log out', onClick: () => {} }],
+};
+
+// useContainerWidth reads getBoundingClientRect().width on mount (the global
+// ResizeObserver mock never fires), so we drive the available width by stubbing
+// it. jsdom has no layout, so every element reports offsetWidth 0 by default —
+// we pin a uniform per-tab width so the priority+ fit has something to measure.
+const TAB_WIDTH = 100;
+const stubNavbarWidth = (width: number) => {
+  jest
+    .spyOn(Element.prototype, 'getBoundingClientRect')
+    .mockReturnValue({ width } as DOMRect);
+};
+
+const originalOffsetWidth = Object.getOwnPropertyDescriptor(
+  HTMLElement.prototype,
+  'offsetWidth',
+);
+beforeAll(() => {
+  Object.defineProperty(HTMLElement.prototype, 'offsetWidth', {
+    configurable: true,
+    get: () => TAB_WIDTH,
+  });
+});
+afterAll(() => {
+  if (originalOffsetWidth) {
+    Object.defineProperty(HTMLElement.prototype, 'offsetWidth', originalOffsetWidth);
+  }
+});
+
+afterEach(() => {
+  jest.restoreAllMocks();
+});
+
+describe('selectVisibleTabs (priority+ fit)', () => {
+  it('keeps every tab inline when they all fit', () => {
+    const { visibleTabIndices, overflowTabIndices } = selectVisibleTabs(
+      [100, 100, 100],
+      [false, false, false],
+      80,
+      1000,
+    );
+    expect(visibleTabIndices).toEqual([0, 1, 2]);
+    expect(overflowTabIndices).toEqual([]);
+  });
+
+  it('drops tabs from the right and reserves room for the menu trigger', () => {
+    // availableWidth 260, menu trigger 80 -> budget 180: the first tab (100)
+    // fits, a second (200) would not, so one stays and the rest overflow.
+    const { visibleTabIndices, overflowTabIndices } = selectVisibleTabs(
+      [100, 100, 100],
+      [false, false, false],
+      80,
+      260,
+    );
+    expect(visibleTabIndices).toEqual([0]);
+    expect(overflowTabIndices).toEqual([1, 2]);
+  });
+
+  it('keeps a pinned tab inline even when earlier tabs overflow', () => {
+    // The last tab is pinned; the budget only fits one tab beside the menu
+    // trigger, so the pinned tab wins and the earlier ones overflow.
+    const { visibleTabIndices, overflowTabIndices } = selectVisibleTabs(
+      [100, 100, 100],
+      [false, false, true],
+      80,
+      260,
+    );
+    expect(visibleTabIndices).toEqual([2]);
+    expect(overflowTabIndices).toEqual([0, 1]);
+  });
+
+  it('preserves original tab order across both rows', () => {
+    const { visibleTabIndices, overflowTabIndices } = selectVisibleTabs(
+      [100, 100, 100, 100],
+      [false, true, false, false],
+      80,
+      300,
+    );
+    expect(visibleTabIndices).toEqual([...visibleTabIndices].sort((a, b) => a - b));
+    expect(overflowTabIndices).toEqual([...overflowTabIndices].sort((a, b) => a - b));
+  });
+});
+
+describe('Navbar responsiveness', () => {
+  it('shows every navigation tab inline when the navbar is wide', () => {
+    stubNavbarWidth(1200);
+    renderNavbar({ tabs, rightActions: [userAction] });
+
+    expect(screen.getByRole('tab', { name: 'Groups' })).toBeInTheDocument();
+    expect(screen.getByRole('tab', { name: 'Users' })).toBeInTheDocument();
+    expect(screen.getByRole('tab', { name: 'Policies' })).toBeInTheDocument();
+    expect(
+      screen.queryByRole('button', { name: /more/i }),
+    ).not.toBeInTheDocument();
+  });
+
+  it('overflows tabs that do not fit into a "More" menu, keeping the rest inline', async () => {
+    // available 220: first tab (100) fits alongside the More trigger (100),
+    // the next would not — so 1 stays inline and 2 overflow into the menu.
+    stubNavbarWidth(220);
+    renderNavbar({ tabs, rightActions: [userAction] });
+
+    expect(screen.getByRole('tab', { name: 'Groups' })).toBeInTheDocument();
+    expect(screen.queryByRole('tab', { name: 'Users' })).not.toBeInTheDocument();
+
+    const menuTrigger = screen.getByRole('button', { name: /more/i });
+    await userEvent.click(menuTrigger);
+
+    const menu = screen.getByRole('menu');
+    expect(within(menu).getByText('Users')).toBeInTheDocument();
+    expect(within(menu).getByText('Policies')).toBeInTheDocument();
+    expect(within(menu).queryByText('Groups')).not.toBeInTheDocument();
+  });
+
+  it('keeps the username label visible when the navbar is wide', () => {
+    stubNavbarWidth(1200);
+    renderNavbar({ tabs, rightActions: [userAction] });
+
+    expect(screen.getByText('Carlito')).toBeInTheDocument();
+  });
+
+  it('drops the username label to an icon-only trigger when narrow', () => {
+    stubNavbarWidth(360);
+    renderNavbar({ tabs, rightActions: [userAction] });
+
+    expect(screen.queryByText('Carlito')).not.toBeInTheDocument();
+  });
+
+  it('keeps the account menu reachable by name when condensed to an icon', () => {
+    stubNavbarWidth(360);
+    renderNavbar({ tabs, rightActions: [userAction] });
+
+    expect(screen.queryByText('Carlito')).not.toBeInTheDocument();
+    expect(screen.getByTitle('Carlito')).toBeInTheDocument();
+  });
+
+  it('can condense the actions to icons while tabs are still shown inline', () => {
+    // 900 < 1000 condenses the actions, but all three tabs (300 + More) still
+    // fit inline at 900.
+    stubNavbarWidth(900);
+    renderNavbar({
+      tabs,
+      rightActions: [userAction],
+      condenseActionsBreakpoint: 1000,
+    });
+
+    expect(screen.getByRole('tab', { name: 'Groups' })).toBeInTheDocument();
+    expect(screen.getByRole('tab', { name: 'Policies' })).toBeInTheDocument();
+    expect(screen.queryByText('Carlito')).not.toBeInTheDocument();
+  });
+
+  it('keeps the selected tab inline even when earlier tabs overflow', async () => {
+    // 220px only fits one tab alongside the More trigger. The selected tab sits
+    // last, so a plain prefix fit would hide it — it must stay inline instead.
+    stubNavbarWidth(220);
+    renderNavbar({
+      tabs: [
+        { title: 'Groups', link: <a href="/groups">Groups</a> },
+        { title: 'Users', link: <a href="/users">Users</a> },
+        { title: 'Policies', selected: true, link: <a href="/policies">Policies</a> },
+      ],
+      rightActions: [userAction],
+    });
+
+    expect(screen.getByRole('tab', { name: 'Policies' })).toBeInTheDocument();
+    expect(screen.queryByRole('tab', { name: 'Groups' })).not.toBeInTheDocument();
+
+    await userEvent.click(screen.getByRole('button', { name: /more/i }));
+    const menu = screen.getByRole('menu');
+    expect(within(menu).getByText('Groups')).toBeInTheDocument();
+    expect(within(menu).queryByText('Policies')).not.toBeInTheDocument();
+  });
+
+  it('keeps a custom render tab inline at every width instead of hiding it', async () => {
+    // An editable instance-name field cannot live inside a dropdown, so a
+    // render tab is pinned: it stays visible while plain nav tabs overflow.
+    stubNavbarWidth(220);
+    renderNavbar({
+      tabs: [
+        { render: <span>My instance</span> },
+        { title: 'Groups', selected: true, link: <a href="/groups">Groups</a> },
+        { title: 'Users', link: <a href="/users">Users</a> },
+        { title: 'Policies', link: <a href="/policies">Policies</a> },
+      ],
+      rightActions: [userAction],
+    });
+
+    expect(screen.getByText('My instance')).toBeInTheDocument();
+    expect(screen.getByRole('tab', { name: 'Groups' })).toBeInTheDocument();
+
+    await userEvent.click(screen.getByRole('button', { name: /more/i }));
+    const menu = screen.getByRole('menu');
+    expect(within(menu).getByText('Users')).toBeInTheDocument();
+    expect(within(menu).queryByText('My instance')).not.toBeInTheDocument();
+  });
+
+  it('does not render a navigation menu when there are no tabs', () => {
+    stubNavbarWidth(360);
+    renderNavbar({ tabs: [], rightActions: [userAction] });
+
+    expect(
+      screen.queryByRole('button', { name: /more/i }),
+    ).not.toBeInTheDocument();
+  });
+});

--- a/src/lib/components/navbar/Navbar.component.test.tsx
+++ b/src/lib/components/navbar/Navbar.component.test.tsx
@@ -130,12 +130,14 @@ describe('Navbar responsiveness', () => {
     expect(screen.queryByRole('tab', { name: 'Users' })).not.toBeInTheDocument();
 
     const menuTrigger = screen.getByRole('button', { name: /more/i });
+    expect(menuTrigger).toHaveAttribute('aria-expanded', 'false');
     await userEvent.click(menuTrigger);
+    expect(menuTrigger).toHaveAttribute('aria-expanded', 'true');
 
-    const menu = screen.getByRole('menu');
-    expect(within(menu).getByText('Users')).toBeInTheDocument();
-    expect(within(menu).getByText('Policies')).toBeInTheDocument();
-    expect(within(menu).queryByText('Groups')).not.toBeInTheDocument();
+    const menu = screen.getByRole('navigation', { name: /more/i });
+    expect(within(menu).getByRole('link', { name: 'Users' })).toBeInTheDocument();
+    expect(within(menu).getByRole('link', { name: 'Policies' })).toBeInTheDocument();
+    expect(within(menu).queryByRole('link', { name: 'Groups' })).not.toBeInTheDocument();
   });
 
   it('keeps the username label visible when the navbar is wide', () => {
@@ -157,7 +159,21 @@ describe('Navbar responsiveness', () => {
     renderNavbar({ tabs, rightActions: [userAction] });
 
     expect(screen.queryByText('Carlito')).not.toBeInTheDocument();
-    expect(screen.getByTitle('Carlito')).toBeInTheDocument();
+    expect(screen.getByLabelText('Carlito')).toBeInTheDocument();
+  });
+
+  it('gives the condensed name precedence over an aria-label on the action', () => {
+    // The action type is porous — a consumer can pass extra props. A stray
+    // aria-label must not clobber the condensed accessible name.
+    stubNavbarWidth(360);
+    renderNavbar({
+      tabs,
+      // @ts-ignore - exercising the porous action-prop boundary on purpose
+      rightActions: [{ ...userAction, 'aria-label': 'wrong name' }],
+    });
+
+    expect(screen.getByLabelText('Carlito')).toBeInTheDocument();
+    expect(screen.queryByLabelText('wrong name')).not.toBeInTheDocument();
   });
 
   it('can condense the actions to icons while tabs are still shown inline', () => {
@@ -192,9 +208,9 @@ describe('Navbar responsiveness', () => {
     expect(screen.queryByRole('tab', { name: 'Groups' })).not.toBeInTheDocument();
 
     await userEvent.click(screen.getByRole('button', { name: /more/i }));
-    const menu = screen.getByRole('menu');
-    expect(within(menu).getByText('Groups')).toBeInTheDocument();
-    expect(within(menu).queryByText('Policies')).not.toBeInTheDocument();
+    const menu = screen.getByRole('navigation', { name: /more/i });
+    expect(within(menu).getByRole('link', { name: 'Groups' })).toBeInTheDocument();
+    expect(within(menu).queryByRole('link', { name: 'Policies' })).not.toBeInTheDocument();
   });
 
   it('keeps a custom render tab inline at every width instead of hiding it', async () => {
@@ -215,8 +231,8 @@ describe('Navbar responsiveness', () => {
     expect(screen.getByRole('tab', { name: 'Groups' })).toBeInTheDocument();
 
     await userEvent.click(screen.getByRole('button', { name: /more/i }));
-    const menu = screen.getByRole('menu');
-    expect(within(menu).getByText('Users')).toBeInTheDocument();
+    const menu = screen.getByRole('navigation', { name: /more/i });
+    expect(within(menu).getByRole('link', { name: 'Users' })).toBeInTheDocument();
     expect(within(menu).queryByText('My instance')).not.toBeInTheDocument();
   });
 

--- a/src/lib/components/navbar/Navbar.component.test.tsx
+++ b/src/lib/components/navbar/Navbar.component.test.tsx
@@ -1,7 +1,7 @@
 import { render, screen, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { ThemeProvider } from 'styled-components';
-import { Navbar, selectVisibleTabs } from './Navbar.component';
+import { Navbar, selectVisibleTabs, getInitials } from './Navbar.component';
 import { coreUIAvailableThemes } from '../../style/theme';
 
 const theme = coreUIAvailableThemes.darkRebrand;
@@ -55,6 +55,28 @@ afterAll(() => {
 
 afterEach(() => {
   jest.restoreAllMocks();
+});
+
+describe('getInitials', () => {
+  it('takes the first letter of a single-word name', () => {
+    expect(getInitials('Carlito')).toBe('C');
+  });
+
+  it('takes the first letters of the first two words', () => {
+    expect(getInitials('Carlito Gonzalez')).toBe('CG');
+  });
+
+  it('uses only the first letter for an unspaced token', () => {
+    expect(getInitials('jean-marc.millet')).toBe('J');
+  });
+
+  it('ignores surrounding and repeated whitespace', () => {
+    expect(getInitials('  Carlito   Gonzalez  ')).toBe('CG');
+  });
+
+  it('returns an empty string for empty input', () => {
+    expect(getInitials('')).toBe('');
+  });
 });
 
 describe('selectVisibleTabs (priority+ fit)', () => {
@@ -160,6 +182,26 @@ describe('Navbar responsiveness', () => {
 
     expect(screen.queryByText('Carlito')).not.toBeInTheDocument();
     expect(screen.getByLabelText('Carlito')).toBeInTheDocument();
+  });
+
+  it('condenses an opted-in dropdown to its initials, keeping the full name accessible', () => {
+    stubNavbarWidth(360);
+    renderNavbar({
+      tabs,
+      rightActions: [
+        {
+          type: 'dropdown' as const,
+          text: 'Carlito Gonzalez',
+          icon: <i className="fas fa-user" />,
+          abbreviateWhenCondensed: true,
+          items: [{ label: 'Log out', onClick: () => {} }],
+        },
+      ],
+    });
+
+    expect(screen.getByText('CG')).toBeInTheDocument();
+    expect(screen.queryByText('Carlito Gonzalez')).not.toBeInTheDocument();
+    expect(screen.getByLabelText('Carlito Gonzalez')).toBeInTheDocument();
   });
 
   it('gives the condensed name precedence over an aria-label on the action', () => {

--- a/src/lib/components/navbar/Navbar.component.tsx
+++ b/src/lib/components/navbar/Navbar.component.tsx
@@ -1,12 +1,123 @@
-import { cloneElement, Fragment } from 'react';
+import {
+  cloneElement,
+  useCallback,
+  useLayoutEffect,
+  useRef,
+  useState,
+} from 'react';
 import styled, { css } from 'styled-components';
+import { flip, offset, shift } from '@floating-ui/dom';
+import {
+  autoUpdate,
+  FloatingFocusManager,
+  FloatingPortal,
+  useClick,
+  useDismiss,
+  useFloating,
+  useInteractions,
+  useRole,
+} from '@floating-ui/react';
 import { Logo } from '../../icons/branding';
 import { spacing } from '../../spacing';
-import { fontSize, navbarHeight, navbarItemWidth } from '../../style/theme';
+import {
+  fontSize,
+  fontWeight,
+  navbarHeight,
+  navbarItemWidth,
+  zIndex,
+} from '../../style/theme';
 import { getContrastText, getThemePropSelector } from '../../utils';
 import { Dropdown, type Item } from '../dropdown/Dropdown.component';
 import { Icon } from '../icon/Icon.component';
 import { Button, FocusVisibleStyle, type Props as ButtonProps } from '../buttonv2/Buttonv2.component';
+import { useContainerWidth } from '../responsive/useContainerWidth';
+
+/**
+ * Default container width (px) below which the navbar condenses its
+ * right-action labels to icon-only. Content-dependent — override per app via
+ * the `condenseActionsBreakpoint` prop. Tabs overflow into a "More" menu
+ * automatically as space runs out, independent of this value.
+ */
+export const NAVBAR_COLLAPSE_BREAKPOINT_PX = 768;
+
+/**
+ * Hysteresis band (px) for the condense toggle. Once condensed, the navbar must
+ * grow back to `breakpoint + this` before the labels return, so a container
+ * dragged to rest right on the breakpoint doesn't flicker.
+ */
+const CONDENSE_HYSTERESIS_PX = 24;
+
+/**
+ * Wraps the measure-only width primitive with a hysteresis band and reports a
+ * single condense flag. Wide-first until the first measurement lands
+ * (`undefined < n` is `false`), then condensed once the container drops below
+ * `breakpoint`, staying condensed until it grows back past
+ * `breakpoint + CONDENSE_HYSTERESIS_PX`. This is the one place the navbar needs
+ * a threshold, so the hysteresis lives here rather than in the shared hook.
+ */
+function useCondensedActions(breakpoint: number): {
+  ref: (node: HTMLDivElement | null) => void;
+  condensed: boolean;
+} {
+  const { ref, width } = useContainerWidth<HTMLDivElement>();
+  const condensedRef = useRef(false);
+
+  let condensed = condensedRef.current;
+  if (width !== undefined) {
+    if (condensed) {
+      if (width >= breakpoint + CONDENSE_HYSTERESIS_PX) condensed = false;
+    } else if (width < breakpoint) {
+      condensed = true;
+    }
+    condensedRef.current = condensed;
+  }
+
+  return { ref, condensed };
+}
+
+/**
+ * Decide which tabs stay inline and which move into the "More" menu.
+ *
+ * Pinned tabs (the selected tab, custom `render` tabs, and any tab flagged
+ * `alwaysVisible`) never overflow — the current location and instance-level
+ * controls must stay reachable. The remaining tabs fill the leftover space
+ * left-to-right, priority+ style: as the navbar narrows they drop from the
+ * right, one by one, into the menu. Pure — no DOM. Indices are returned in
+ * original order so both rows preserve the author's tab order.
+ */
+export function selectVisibleTabs(
+  tabWidths: number[],
+  pinned: boolean[],
+  menuTriggerWidth: number,
+  availableWidth: number,
+): { visibleTabIndices: number[]; overflowTabIndices: number[] } {
+  const allTabIndices = tabWidths.map((_, index) => index);
+  const totalTabsWidth = tabWidths.reduce((sum, width) => sum + width, 0);
+  if (totalTabsWidth <= availableWidth) {
+    return { visibleTabIndices: allTabIndices, overflowTabIndices: [] };
+  }
+
+  // Something overflows, so the "More" menu trigger will be shown — reserve its
+  // width. Pinned tabs are always kept (even if they alone exceed the budget);
+  // non-pinned tabs then fill what's left, stopping at the first that no longer
+  // fits so the dropped tabs stay a contiguous run on the right.
+  const widthBudget = availableWidth - menuTriggerWidth;
+  const keptTabIndices = new Set<number>(allTabIndices.filter((index) => pinned[index]));
+  let usedWidth = allTabIndices
+    .filter((index) => pinned[index])
+    .reduce((sum, index) => sum + tabWidths[index], 0);
+  for (const index of allTabIndices) {
+    if (pinned[index]) continue;
+    if (usedWidth + tabWidths[index] > widthBudget) break;
+    usedWidth += tabWidths[index];
+    keptTabIndices.add(index);
+  }
+
+  return {
+    visibleTabIndices: allTabIndices.filter((index) => keptTabIndices.has(index)),
+    overflowTabIndices: allTabIndices.filter((index) => !keptTabIndices.has(index)),
+  };
+}
 
 type ButtonAction = {
   type: 'button';
@@ -31,12 +142,25 @@ type Tab = {
   onClick?: (arg0: any) => void;
   link?: JSX.Element;
   render?: JSX.Element;
+  /**
+   * Keep this tab inline at all widths instead of letting it overflow into the
+   * "More" menu. The selected tab and custom `render` tabs are pinned
+   * automatically; set this for any other tab that must always stay visible.
+   */
+  alwaysVisible?: boolean;
 };
 export type Props = {
   onToggleClick?: () => void;
   rightActions: Actions;
   logo?: JSX.Element;
   tabs?: Array<Tab>;
+  /**
+   * Container width (px) below which right-action labels drop to icon-only
+   * (e.g. the username dropdown shows just its icon). Tabs overflow into a
+   * "More" menu automatically as space runs out, independent of this value.
+   * Defaults to {@link NAVBAR_COLLAPSE_BREAKPOINT_PX}.
+   */
+  condenseActionsBreakpoint?: number;
 };
 const getNavbarTextColor = (props) =>
   getContrastText(props.theme.navbarBackground, props.theme.textPrimary, props.theme.textReverse) ?? props.theme.textPrimary;
@@ -63,6 +187,7 @@ const NavbarMenu = styled.div`
 `;
 const NavbarTabs = styled.div`
   flex: 1;
+  min-width: 0;
   display: flex;
   justify-content: flex-start;
   align-items: center;
@@ -78,9 +203,9 @@ const NavbarTabs = styled.div`
     border-bottom: ${spacing.r2} solid transparent;
     border-top: ${spacing.r2} solid transparent;
     ${(props) => {
-      const { selectedActive } = props.theme;
-      const navTextColor = getContrastText(props.theme.navbarBackground, props.theme.textPrimary, props.theme.textReverse) ?? props.theme.textPrimary;
-      return css`
+    const { selectedActive } = props.theme;
+    const navTextColor = getContrastText(props.theme.navbarBackground, props.theme.textPrimary, props.theme.textReverse) ?? props.theme.textPrimary;
+    return css`
         color: ${navTextColor};
         &:hover {
           background-color: ${getThemePropSelector('highlight')};
@@ -96,7 +221,7 @@ const NavbarTabs = styled.div`
           color: ${navTextColor};
         }
       `;
-    }};
+  }};
   }
 `;
 const TabItem = styled.div<{ selected: boolean }>`
@@ -135,6 +260,7 @@ const NavbarMenuItem = styled.div`
   align-items: center;
   .sc-dropdown {
     .trigger {
+      background-color: transparent;
       &:hover {
         background-color: ${getThemePropSelector('highlight')};
       }
@@ -184,10 +310,259 @@ const LogoContainer = styled.div`
   }
 `;
 
-const getActionRenderer = (action: Action, index: number) => {
+const TabsMenuTrigger = styled.button`
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  height: ${navbarHeight};
+  padding: 0 ${spacing.r16};
+  border: none;
+  cursor: pointer;
+  white-space: nowrap;
+  font-size: ${fontSize.base};
+  color: inherit;
+  background-color: transparent;
+  &:hover {
+    background-color: ${getThemePropSelector('highlight')};
+  }
+  // :focus-visible is the keyboard-only version of :focus
+  &:focus-visible {
+    ${FocusVisibleStyle}
+  }
+`;
+
+const TabsMenuCaret = styled.span`
+  display: inline-flex;
+  margin-left: ${spacing.r8};
+`;
+
+const MenuTriggerContent = () => (
+  <>
+    More
+    <TabsMenuCaret>
+      <Icon name="Dropdown-down" />
+    </TabsMenuCaret>
+  </>
+);
+
+const TabsMenuList = styled.ul`
+  margin: 0;
+  padding: ${spacing.r4} 0;
+  list-style: none;
+  min-width: 14rem;
+  background-color: ${getThemePropSelector('backgroundLevel1')};
+  border: 1px solid ${getThemePropSelector('border')};
+  z-index: ${zIndex.dropdown};
+
+  li {
+    display: flex;
+    flex-direction: column;
+    cursor: pointer;
+    color: ${getThemePropSelector('textPrimary')};
+    &:hover {
+      background-color: ${getThemePropSelector('highlight')};
+    }
+    a,
+    & > div {
+      display: flex;
+      align-items: center;
+      height: auto;
+      padding: ${spacing.r12} ${spacing.r16};
+      color: inherit;
+      text-decoration: none;
+      border: none;
+    }
+    a.selected,
+    & > .selected {
+      font-weight: ${fontWeight.bold};
+    }
+  }
+`;
+
+const renderTab = (
+  { link, title, selected, onClick, render }: Tab,
+  index: number,
+  { inMenu = false }: { inMenu?: boolean } = {},
+) => {
+  const key = `navbar_tab_item_${index}`;
+  if (render) {
+    return render;
+  }
+  // Inside the "More" menu each tab sits in a role="menuitem" <li>, so the tab
+  // role/aria-selected would be invalid nesting — mark the current page with
+  // aria-current instead.
+  const selectionProps = inMenu
+    ? { 'aria-current': selected ? ('page' as const) : undefined }
+    : { role: 'tab', 'aria-selected': selected };
+  return link ? (
+    cloneElement(link, {
+      className: selected ? 'selected' : '',
+      key,
+      ...selectionProps,
+    })
+  ) : (
+    <TabItem
+      onClick={onClick}
+      selected={!!selected}
+      key={key}
+      {...selectionProps}
+    >
+      <span>{title}</span>
+    </TabItem>
+  );
+};
+
+function NavbarTabsMenu({
+  tabs,
+  triggerRef,
+}: {
+  tabs: Array<Tab>;
+  triggerRef?: (node: HTMLElement | null) => void;
+}) {
+  const [isOpen, setIsOpen] = useState(false);
+  const { refs, floatingStyles, context } = useFloating({
+    open: isOpen,
+    onOpenChange: setIsOpen,
+    placement: 'bottom-end',
+    middleware: [offset(0), flip(), shift()],
+    whileElementsMounted: autoUpdate,
+  });
+  const { getReferenceProps, getFloatingProps } = useInteractions([
+    useClick(context),
+    useDismiss(context),
+    useRole(context, { role: 'menu' }),
+  ]);
+
+  const setTriggerRef = useCallback(
+    (node: HTMLButtonElement | null) => {
+      refs.setReference(node);
+      triggerRef?.(node);
+    },
+    [refs, triggerRef],
+  );
+
+  return (
+    <>
+      <TabsMenuTrigger
+        type="button"
+        ref={setTriggerRef}
+        {...getReferenceProps()}
+      >
+        <MenuTriggerContent />
+      </TabsMenuTrigger>
+      {isOpen && (
+        <FloatingPortal>
+          <FloatingFocusManager context={context} modal={false} initialFocus={-1}>
+            <TabsMenuList
+              ref={refs.setFloating}
+              style={floatingStyles}
+              {...getFloatingProps()}
+              onClick={() => setIsOpen(false)}
+            >
+              {tabs.map((tab, index) => (
+                <li role="menuitem" key={`navbar_tab_menu_item_${index}`}>
+                  {renderTab(tab, index, { inMenu: true })}
+                </li>
+              ))}
+            </TabsMenuList>
+          </FloatingFocusManager>
+        </FloatingPortal>
+      )}
+    </>
+  );
+}
+
+const TabSlot = styled.span`
+  display: inline-flex;
+  align-items: center;
+  height: 100%;
+  white-space: nowrap;
+`;
+
+/**
+ * Priority+ overflow: keep as many tabs inline as physically fit and move the
+ * remainder into a "More" menu, recomputing as the container resizes.
+ *
+ * Widths come from the real row: every tab renders full-size on the first pass
+ * (before anything overflows), and each tab's measured width is cached per
+ * index. Collapsing a tab into the menu drops it from the row but keeps its
+ * cached width, so the fit math stays accurate without a hidden mirror. The
+ * menu trigger measures itself through a ref the first time it appears; the
+ * fit then settles within the same commit, before paint.
+ *
+ * Tabs are assumed stable. If their labels ever become dynamic (e.g. i18n),
+ * force a fresh measure by giving this component a `key` that changes with the
+ * locale.
+ *
+ * The selected tab, custom `render` tabs, and any `alwaysVisible` tab are
+ * pinned: they always stay inline so the current location and instance-level
+ * controls (e.g. an editable deployment name) never disappear into the menu.
+ */
+function NavbarTabsRow({ tabs }: { tabs: Array<Tab> }) {
+  const { ref: containerRef, width: availableWidth } = useContainerWidth<HTMLDivElement>();
+  const tabRefs = useRef<Array<HTMLElement | null>>([]);
+  const [tabWidths, setTabWidths] = useState<number[]>([]);
+  const [menuTriggerWidth, setMenuTriggerWidth] = useState(0);
+
+  useLayoutEffect(() => {
+    setTabWidths((previousWidths) =>
+      tabs.map((_, index) => {
+        const measured = tabRefs.current[index]?.offsetWidth;
+        // Keep the cached width for any tab not currently in the row (it sits
+        // in the "More" menu and is no longer rendered full-size here).
+        return measured && measured > 0 ? measured : previousWidths[index] ?? 0;
+      }),
+    );
+  }, [tabs]);
+
+  const measureMenuTrigger = useCallback((node: HTMLElement | null) => {
+    if (node) {
+      const nextWidth = node.offsetWidth;
+      setMenuTriggerWidth((previousWidth) =>
+        previousWidth === nextWidth ? previousWidth : nextWidth,
+      );
+    }
+  }, []);
+
+  const pinned = tabs.map(
+    (tab) => Boolean(tab.alwaysVisible) || Boolean(tab.selected) || Boolean(tab.render),
+  );
+  const allTabsMeasured = tabWidths.length === tabs.length;
+  const { visibleTabIndices, overflowTabIndices } = allTabsMeasured
+    ? selectVisibleTabs(tabWidths, pinned, menuTriggerWidth, availableWidth ?? Infinity)
+    : { visibleTabIndices: tabs.map((_, index) => index), overflowTabIndices: [] };
+
+  return (
+    <NavbarTabs ref={containerRef}>
+      {visibleTabIndices.map((index) => (
+        <TabSlot
+          key={`navbar_tab_slot_${index}`}
+          ref={(el) => {
+            tabRefs.current[index] = el;
+          }}
+        >
+          {renderTab(tabs[index], index)}
+        </TabSlot>
+      ))}
+      {overflowTabIndices.length > 0 && (
+        <NavbarTabsMenu
+          tabs={overflowTabIndices.map((index) => tabs[index])}
+          triggerRef={measureMenuTrigger}
+        />
+      )}
+    </NavbarTabs>
+  );
+}
+
+const getActionRenderer = (
+  action: Action,
+  index: number,
+  condensed: boolean,
+) => {
   switch (action.type) {
     case 'dropdown': {
-      const { type, items, ...rest } = action;
+      const { type, items, text, ...rest } = action;
+      const condenseToIcon = condensed && Boolean(action.icon);
       return (
         <Dropdown
           key={`navbar_right_action_${index}`}
@@ -195,6 +570,8 @@ const getActionRenderer = (action: Action, index: number) => {
           variant="backgroundLevel1"
           items={items}
           caret={false}
+          text={condenseToIcon ? undefined : text}
+          title={condenseToIcon ? text : undefined}
           {...rest}
         />
       );
@@ -217,14 +594,19 @@ function NavBar({
   logo,
   tabs = [],
   rightActions = [],
+  condenseActionsBreakpoint = NAVBAR_COLLAPSE_BREAKPOINT_PX,
   ...rest
 }: Props) {
+  const { ref, condensed: condenseActions } = useCondensedActions(
+    condenseActionsBreakpoint,
+  );
+
   return (
-    <NavbarContainer className="sc-navbar" {...rest}>
+    <NavbarContainer className="sc-navbar" ref={ref} {...rest}>
       <NavbarMenu>
         {onToggleClick && (
           <NavbarMenuItem onClick={onToggleClick}>
-            <Button icon={<Icon name="Lat-menu" />} tooltip={{overlay: "Toggle Main Menu"}} />
+            <Button icon={<Icon name="Lat-menu" />} tooltip={{ overlay: "Toggle Main Menu" }} />
           </NavbarMenuItem>
         )}
         <NavbarMenuItem>
@@ -233,40 +615,12 @@ function NavBar({
           </LogoContainer>
         </NavbarMenuItem>
       </NavbarMenu>
-      {tabs.length ? (
-        <NavbarTabs>
-          {tabs.map(({ link, title, selected, onClick, render }, index) => {
-            if (render) {
-              return (
-                <Fragment key={`navbar_tab_item_${index}`}>{render}</Fragment>
-              );
-            }
-            return link ? (
-              cloneElement(link, {
-                className: selected ? 'selected' : '',
-                'aria-selected': selected,
-                role: 'tab',
-                key: `navbar_tab_item_${index}`,
-              })
-            ) : (
-              <TabItem
-                onClick={onClick}
-                role="tab"
-                selected={!!selected}
-                aria-selected={selected}
-                key={`navbar_tab_item_${index}`}
-              >
-                <span>{title}</span>
-              </TabItem>
-            );
-          })}
-        </NavbarTabs>
-      ) : null}
+      {tabs.length ? <NavbarTabsRow tabs={tabs} /> : null}
       {rightActions.length ? (
         <NavbarMenu>
           <NavbarMenuItem>
             {rightActions.map((action, index) =>
-              getActionRenderer(action, index),
+              getActionRenderer(action, index, condenseActions),
             )}
           </NavbarMenuItem>
         </NavbarMenu>

--- a/src/lib/components/navbar/Navbar.component.tsx
+++ b/src/lib/components/navbar/Navbar.component.tsx
@@ -55,6 +55,22 @@ const CONDENSE_HYSTERESIS_PX = 24;
 const ESTIMATED_MENU_TRIGGER_WIDTH_PX = 96;
 
 /**
+ * Abbreviate a label to the uppercased first letters of its first `maxLetters`
+ * whitespace-separated words (e.g. "Carlito Gonzalez" → "CG", "Carlito" → "C").
+ * Used to condense an opted-in action to a compact chip instead of hiding its
+ * label entirely; the full label stays the accessible name.
+ */
+export function getInitials(text: string, maxLetters = 2): string {
+  return text
+    .trim()
+    .split(/\s+/)
+    .filter(Boolean)
+    .slice(0, maxLetters)
+    .map((word) => word.charAt(0).toUpperCase())
+    .join('');
+}
+
+/**
  * Wraps the measure-only width primitive with a hysteresis band and reports a
  * single condense flag. Wide-first until the first measurement lands
  * (`condensed` starts false), then condensed once the container drops below
@@ -141,6 +157,12 @@ type DropdownAction = {
   items: Array<Item>;
   text?: string;
   icon?: JSX.Element;
+  /**
+   * When the navbar condenses, show the label's initials next to the icon
+   * (e.g. "Carlito Gonzalez" → "CG") instead of hiding it. The full label
+   * stays the accessible name. Requires an `icon`. Defaults to false.
+   */
+  abbreviateWhenCondensed?: boolean;
 };
 
 type CustomAction = {
@@ -608,8 +630,14 @@ const getActionRenderer = (
 ) => {
   switch (action.type) {
     case 'dropdown': {
-      const { type, items, text, ...rest } = action;
+      const { type, items, text, abbreviateWhenCondensed, ...rest } = action;
       const condenseToIcon = condensed && Boolean(action.icon);
+      // When condensed, either abbreviate the label to its initials (opt-in) or
+      // hide it (icon-only); the full text stays the accessible name below.
+      const condensedText =
+        condenseToIcon && abbreviateWhenCondensed && text
+          ? getInitials(text)
+          : undefined;
       return (
         <Dropdown
           key={`navbar_right_action_${index}`}
@@ -617,7 +645,7 @@ const getActionRenderer = (
           variant="backgroundLevel1"
           items={items}
           caret={false}
-          text={condenseToIcon ? undefined : text}
+          text={condenseToIcon ? condensedText : text}
           {...rest}
           // Applied after `...rest` so the condense-mode name always wins over a
           // stray title/aria-label on the action; omitted entirely otherwise so

--- a/src/lib/components/navbar/Navbar.component.tsx
+++ b/src/lib/components/navbar/Navbar.component.tsx
@@ -315,7 +315,10 @@ const NavbarMenuItem = styled.div`
     border-radius: 0;
     height: ${navbarHeight};
     font-size: ${fontSize.base};
-    background-color: ${getThemePropSelector('navbarBackground')};
+    // Transparent (like the dropdown triggers) so a full-height button doesn't
+    // paint over the navbar's bottom border. navbarBackground would match the
+    // navbar fill but still hide the border underneath.
+    background-color: transparent;
     color: ${(props) => getContrastText(props.theme.navbarBackground, props.theme.textPrimary, props.theme.textReverse) ?? props.theme.textPrimary};
     &:hover {
       background-color: ${getThemePropSelector('highlight')};

--- a/src/lib/components/navbar/Navbar.component.tsx
+++ b/src/lib/components/navbar/Navbar.component.tsx
@@ -411,6 +411,13 @@ const TabsMenuPanel = styled.nav`
       text-decoration: none;
       border: none;
     }
+    // Match the inline tabs' keyboard focus ring so a tab looks the same
+    // whether it sits in the row or in the overflow panel.
+    a:focus-visible,
+    & > div:focus-visible {
+      ${FocusVisibleStyle}
+      color: inherit;
+    }
     a.selected,
     & > .selected {
       font-weight: ${fontWeight.bold};

--- a/src/lib/components/navbar/Navbar.component.tsx
+++ b/src/lib/components/navbar/Navbar.component.tsx
@@ -2,6 +2,7 @@ import {
   cloneElement,
   useCallback,
   useLayoutEffect,
+  useMemo,
   useRef,
   useState,
 } from 'react';
@@ -15,7 +16,6 @@ import {
   useDismiss,
   useFloating,
   useInteractions,
-  useRole,
 } from '@floating-ui/react';
 import { Logo } from '../../icons/branding';
 import { spacing } from '../../spacing';
@@ -48,29 +48,43 @@ export const NAVBAR_COLLAPSE_BREAKPOINT_PX = 768;
 const CONDENSE_HYSTERESIS_PX = 24;
 
 /**
+ * Width (px) reserved for the "More" trigger before it has measured itself, so
+ * the first overflow pass doesn't keep one tab too many. Corrected to the real
+ * width as soon as the trigger mounts.
+ */
+const ESTIMATED_MENU_TRIGGER_WIDTH_PX = 96;
+
+/**
  * Wraps the measure-only width primitive with a hysteresis band and reports a
  * single condense flag. Wide-first until the first measurement lands
- * (`undefined < n` is `false`), then condensed once the container drops below
+ * (`condensed` starts false), then condensed once the container drops below
  * `breakpoint`, staying condensed until it grows back past
  * `breakpoint + CONDENSE_HYSTERESIS_PX`. This is the one place the navbar needs
  * a threshold, so the hysteresis lives here rather than in the shared hook.
+ *
+ * The latch is applied in a layout effect (not during render) so it never
+ * mutates state as a render side effect — safe under StrictMode / concurrent
+ * rendering — and runs before paint so the condensed layout doesn't flash.
  */
 function useCondensedActions(breakpoint: number): {
   ref: (node: HTMLDivElement | null) => void;
   condensed: boolean;
 } {
   const { ref, width } = useContainerWidth<HTMLDivElement>();
-  const condensedRef = useRef(false);
+  const [condensed, setCondensed] = useState(false);
 
-  let condensed = condensedRef.current;
-  if (width !== undefined) {
-    if (condensed) {
-      if (width >= breakpoint + CONDENSE_HYSTERESIS_PX) condensed = false;
-    } else if (width < breakpoint) {
-      condensed = true;
-    }
-    condensedRef.current = condensed;
-  }
+  useLayoutEffect(() => {
+    if (width === undefined) return;
+    setCondensed((wasCondensed) =>
+      wasCondensed
+        ? width >= breakpoint + CONDENSE_HYSTERESIS_PX
+          ? false
+          : wasCondensed
+        : width < breakpoint
+          ? true
+          : wasCondensed,
+    );
+  }, [width, breakpoint]);
 
   return { ref, condensed };
 }
@@ -345,14 +359,17 @@ const MenuTriggerContent = () => (
   </>
 );
 
-const TabsMenuList = styled.ul`
-  margin: 0;
-  padding: ${spacing.r4} 0;
-  list-style: none;
+const TabsMenuPanel = styled.nav`
   min-width: 14rem;
   background-color: ${getThemePropSelector('backgroundLevel1')};
   border: 1px solid ${getThemePropSelector('border')};
   z-index: ${zIndex.dropdown};
+
+  ul {
+    margin: 0;
+    padding: ${spacing.r4} 0;
+    list-style: none;
+  }
 
   li {
     display: flex;
@@ -388,8 +405,8 @@ const renderTab = (
   if (render) {
     return render;
   }
-  // Inside the "More" menu each tab sits in a role="menuitem" <li>, so the tab
-  // role/aria-selected would be invalid nesting — mark the current page with
+  // In the overflow list a tab is a plain link inside a <li>, so the row's tab
+  // role/aria-selected would be out of place — mark the current page with
   // aria-current instead.
   const selectionProps = inMenu
     ? { 'aria-current': selected ? ('page' as const) : undefined }
@@ -430,7 +447,6 @@ function NavbarTabsMenu({
   const { getReferenceProps, getFloatingProps } = useInteractions([
     useClick(context),
     useDismiss(context),
-    useRole(context, { role: 'menu' }),
   ]);
 
   const setTriggerRef = useCallback(
@@ -441,11 +457,16 @@ function NavbarTabsMenu({
     [refs, triggerRef],
   );
 
+  // The overflowed tabs are navigation links, so the panel is a disclosure
+  // revealing a <nav> list — not an ARIA `menu` (which would promise arrow-key
+  // navigation these links don't need). The links are reachable with Tab.
   return (
     <>
       <TabsMenuTrigger
         type="button"
         ref={setTriggerRef}
+        aria-haspopup="true"
+        aria-expanded={isOpen}
         {...getReferenceProps()}
       >
         <MenuTriggerContent />
@@ -453,18 +474,21 @@ function NavbarTabsMenu({
       {isOpen && (
         <FloatingPortal>
           <FloatingFocusManager context={context} modal={false} initialFocus={-1}>
-            <TabsMenuList
+            <TabsMenuPanel
               ref={refs.setFloating}
               style={floatingStyles}
+              aria-label="More navigation"
               {...getFloatingProps()}
               onClick={() => setIsOpen(false)}
             >
-              {tabs.map((tab, index) => (
-                <li role="menuitem" key={`navbar_tab_menu_item_${index}`}>
-                  {renderTab(tab, index, { inMenu: true })}
-                </li>
-              ))}
-            </TabsMenuList>
+              <ul>
+                {tabs.map((tab, index) => (
+                  <li key={`navbar_tab_menu_item_${index}`}>
+                    {renderTab(tab, index, { inMenu: true })}
+                  </li>
+                ))}
+              </ul>
+            </TabsMenuPanel>
           </FloatingFocusManager>
         </FloatingPortal>
       )}
@@ -487,12 +511,12 @@ const TabSlot = styled.span`
  * (before anything overflows), and each tab's measured width is cached per
  * index. Collapsing a tab into the menu drops it from the row but keeps its
  * cached width, so the fit math stays accurate without a hidden mirror. The
- * menu trigger measures itself through a ref the first time it appears; the
- * fit then settles within the same commit, before paint.
+ * menu trigger measures itself through a ref the first time it appears (an
+ * estimate is reserved until then); the fit re-settles before paint.
  *
- * Tabs are assumed stable. If their labels ever become dynamic (e.g. i18n),
- * force a fresh measure by giving this component a `key` that changes with the
- * locale.
+ * Tabs are assumed stable — widths are cached by index. If their labels ever
+ * become dynamic (e.g. i18n) or tabs are reordered, force a fresh measure by
+ * giving this component a `key` that changes with them.
  *
  * The selected tab, custom `render` tabs, and any `alwaysVisible` tab are
  * pinned: they always stay inline so the current location and instance-level
@@ -505,14 +529,25 @@ function NavbarTabsRow({ tabs }: { tabs: Array<Tab> }) {
   const [menuTriggerWidth, setMenuTriggerWidth] = useState(0);
 
   useLayoutEffect(() => {
-    setTabWidths((previousWidths) =>
-      tabs.map((_, index) => {
+    // Drop cached widths for tabs that no longer exist so a shrunk `tabs` array
+    // can't be measured against a stale entry.
+    if (tabRefs.current.length > tabs.length) {
+      tabRefs.current.length = tabs.length;
+    }
+    setTabWidths((previousWidths) => {
+      const nextWidths = tabs.map((_, index) => {
         const measured = tabRefs.current[index]?.offsetWidth;
         // Keep the cached width for any tab not currently in the row (it sits
         // in the "More" menu and is no longer rendered full-size here).
         return measured && measured > 0 ? measured : previousWidths[index] ?? 0;
-      }),
-    );
+      });
+      // Return the previous array unchanged when nothing moved so React can bail
+      // out of the extra render (the mapped array is always a fresh reference).
+      const unchanged =
+        nextWidths.length === previousWidths.length &&
+        nextWidths.every((width, index) => width === previousWidths[index]);
+      return unchanged ? previousWidths : nextWidths;
+    });
   }, [tabs]);
 
   const measureMenuTrigger = useCallback((node: HTMLElement | null) => {
@@ -524,13 +559,25 @@ function NavbarTabsRow({ tabs }: { tabs: Array<Tab> }) {
     }
   }, []);
 
-  const pinned = tabs.map(
-    (tab) => Boolean(tab.alwaysVisible) || Boolean(tab.selected) || Boolean(tab.render),
+  const pinned = useMemo(
+    () =>
+      tabs.map(
+        (tab) =>
+          Boolean(tab.alwaysVisible) || Boolean(tab.selected) || Boolean(tab.render),
+      ),
+    [tabs],
   );
   const allTabsMeasured = tabWidths.length === tabs.length;
-  const { visibleTabIndices, overflowTabIndices } = allTabsMeasured
-    ? selectVisibleTabs(tabWidths, pinned, menuTriggerWidth, availableWidth ?? Infinity)
-    : { visibleTabIndices: tabs.map((_, index) => index), overflowTabIndices: [] };
+  // Until the trigger has measured itself, reserve an estimate so the first
+  // overflow pass doesn't keep one tab too many for a frame.
+  const reservedTriggerWidth = menuTriggerWidth || ESTIMATED_MENU_TRIGGER_WIDTH_PX;
+  const { visibleTabIndices, overflowTabIndices } = useMemo(
+    () =>
+      allTabsMeasured
+        ? selectVisibleTabs(tabWidths, pinned, reservedTriggerWidth, availableWidth ?? Infinity)
+        : { visibleTabIndices: tabs.map((_, index) => index), overflowTabIndices: [] },
+    [allTabsMeasured, tabWidths, pinned, reservedTriggerWidth, availableWidth, tabs],
+  );
 
   return (
     <NavbarTabs ref={containerRef}>
@@ -571,8 +618,11 @@ const getActionRenderer = (
           items={items}
           caret={false}
           text={condenseToIcon ? undefined : text}
-          title={condenseToIcon ? text : undefined}
           {...rest}
+          // Applied after `...rest` so the condense-mode name always wins over a
+          // stray title/aria-label on the action; omitted entirely otherwise so
+          // a consumer's own title/aria-label still passes through.
+          {...(condenseToIcon ? { title: text, 'aria-label': text } : {})}
         />
       );
     }

--- a/src/lib/components/navbar/Navbar.component.tsx
+++ b/src/lib/components/navbar/Navbar.component.tsx
@@ -157,12 +157,6 @@ type DropdownAction = {
   items: Array<Item>;
   text?: string;
   icon?: JSX.Element;
-  /**
-   * When the navbar condenses, show the label's initials next to the icon
-   * (e.g. "Carlito Gonzalez" → "CG") instead of hiding it. The full label
-   * stays the accessible name. Requires an `icon`. Defaults to false.
-   */
-  abbreviateWhenCondensed?: boolean;
 };
 
 type CustomAction = {
@@ -637,14 +631,12 @@ const getActionRenderer = (
 ) => {
   switch (action.type) {
     case 'dropdown': {
-      const { type, items, text, abbreviateWhenCondensed, ...rest } = action;
+      const { type, items, text, ...rest } = action;
       const condenseToIcon = condensed && Boolean(action.icon);
-      // When condensed, either abbreviate the label to its initials (opt-in) or
-      // hide it (icon-only); the full text stays the accessible name below.
-      const condensedText =
-        condenseToIcon && abbreviateWhenCondensed && text
-          ? getInitials(text)
-          : undefined;
+      // When condensed to an icon, abbreviate a text label to its initials
+      // (e.g. "Carlito Gonzalez" → "CG"); the full text stays the accessible
+      // name below. Icon-only actions (no text) simply stay icon-only.
+      const condensedText = condenseToIcon && text ? getInitials(text) : undefined;
       return (
         <Dropdown
           key={`navbar_right_action_${index}`}
@@ -655,9 +647,9 @@ const getActionRenderer = (
           text={condenseToIcon ? condensedText : text}
           {...rest}
           // Applied after `...rest` so the condense-mode name always wins over a
-          // stray title/aria-label on the action; omitted entirely otherwise so
-          // a consumer's own title/aria-label still passes through.
-          {...(condenseToIcon ? { title: text, 'aria-label': text } : {})}
+          // stray title/aria-label on the action; only when there is a label to
+          // preserve, so an icon-only action's own title/aria-label passes through.
+          {...(condenseToIcon && text ? { title: text, 'aria-label': text } : {})}
         />
       );
     }

--- a/stories/navbar.stories.tsx
+++ b/stories/navbar.stories.tsx
@@ -6,21 +6,8 @@ import { InlineInput } from '../src/lib';
 import { Stack } from '../src/lib/spacing';
 import { Logo } from '../src/lib/icons/branding-logo';
 
+// A short, typical set of navigation tabs — the shape most apps start from.
 const tabs = [
-  {
-    render: (
-      <InlineInput
-        id="instanceName"
-        // @ts-ignore
-        changeMutation={{
-          isLoading: false,
-          mutate: () => {},
-        }}
-        defaultValue="My instance"
-        maxLength={14}
-      />
-    ),
-  },
   {
     selected: true,
     title: 'Groups',
@@ -39,6 +26,30 @@ const tabs = [
     link: <a href="/policies">Policies</a>,
     onClick: action('Policies clicked'),
   },
+];
+
+// A custom, non-link tab: an editable instance-name field. Render tabs stay
+// pinned inline and never collapse into the "More" menu.
+const instanceNameTab = {
+  render: (
+    <InlineInput
+      id="instanceName"
+      // @ts-ignore
+      changeMutation={{
+        isLoading: false,
+        mutate: () => {},
+      }}
+      defaultValue="My instance"
+      maxLength={14}
+    />
+  ),
+};
+
+// A longer tab set (with the custom instance-name tab) used to demonstrate
+// overflow into the "More" menu when width runs out.
+const overflowTabs = [
+  instanceNameTab,
+  ...tabs,
   {
     selected: false,
     title: 'Buckets',
@@ -52,25 +63,29 @@ const tabs = [
     onClick: action('Workflows clicked'),
   },
 ];
-const linkTabs = [
-  {
-    link: <a href="/groups">Groups</a>,
-    selected: true,
-  },
-  {
-    link: <a href="/users">Users</a>,
-  },
-  {
-    link: <a href="/policies">Policies</a>,
-  },
-  {
-    link: <a href="/buckets">Buckets</a>,
-  },
-  {
-    link: <a href="/workflows">Workflows</a>,
-  },
-];
-const rightActions = [
+
+// The account menu — the one right-action that pairs an icon with a text label.
+const userAction = {
+  type: 'dropdown',
+  text: 'Carlito Gonzalez',
+  icon: <i className="fas fa-user" />,
+  items: [
+    {
+      label: 'Log out',
+      onClick: action('Logout clicked'),
+    },
+  ],
+};
+
+const themeButton = {
+  type: 'button',
+  icon: <i className="fas fa-sun" />,
+  tooltip: { overlay: 'Toggle Theme' },
+  onClick: action('Theme toggle clicked'),
+};
+
+// A fuller set of right actions used to show icon-only condensing and overflow.
+const manyRightActions = [
   {
     type: 'dropdown',
     text: 'FR',
@@ -97,18 +112,9 @@ const rightActions = [
     type: 'dropdown',
     icon: <i className="fas fa-question-circle" />,
     items: [
-      {
-        label: 'About',
-        onClick: action('About clicked'),
-      },
-      {
-        label: 'Documentation',
-        onClick: action('Documentation clicked'),
-      },
-      {
-        label: 'Onboarding',
-        onClick: action('Onboarding clicked'),
-      },
+      { label: 'About', onClick: action('About clicked') },
+      { label: 'Documentation', onClick: action('Documentation clicked') },
+      { label: 'Onboarding', onClick: action('Onboarding clicked') },
     ],
   },
   {
@@ -120,24 +126,8 @@ const rightActions = [
       </Stack>
     ),
   },
-  {
-    type: 'button',
-    icon: <i className="fas fa-sun" />,
-    tooltip: { overlay: 'Toggle Theme' },
-    onClick: action('Theme toggle clicked'),
-  },
-  {
-    type: 'dropdown',
-    text: 'Carlito Gonzalez',
-    icon: <i className="fas fa-user" />,
-    abbreviateWhenCondensed: true,
-    items: [
-      {
-        label: 'Log out',
-        onClick: action('Logout clicked'),
-      },
-    ],
-  },
+  themeButton,
+  userAction,
 ];
 
 export default {
@@ -145,36 +135,84 @@ export default {
   component: Navbar,
   args: {
     productName: 'Hardware UI',
-    rightActions,
-    tabs,
     logo: <Logo />,
+    tabs,
+    rightActions: [],
   },
 };
 
-export const BasicNavbar = {};
+export const BasicNavbar = {
+  parameters: {
+    docs: {
+      description: {
+        story: 'The minimal navbar: a logo and a few navigation tabs.',
+      },
+    },
+  },
+};
+
+export const NavbarWithRightActions = {
+  args: {
+    rightActions: [themeButton, userAction],
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'A typical navbar: tabs on the left, an account menu and a theme-toggle button on the right.',
+      },
+    },
+  },
+};
 
 export const NavbarWithToggle = {
   args: {
     onToggleClick: action('toggle clicked'),
+    rightActions: [themeButton, userAction],
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Passing `onToggleClick` adds a built-in menu button at the far left, used to toggle the host application\'s main/side menu.',
+      },
+    },
   },
 };
 
-export const NavbarWithCustomizedLogo = {
+export const NavbarWithLogo = {
   args: {
-    logo: <i className="fas fa-ring" />,
+    logo: (
+      <span
+        style={{ display: 'flex', alignItems: 'center', gap: 8, fontWeight: 700 }}
+      >
+        <i className="fas fa-cube" /> Acme Cloud
+      </span>
+    ),
+    rightActions: [userAction],
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'The `logo` slot accepts any node, so a product can drop in its own brand mark instead of the default one.',
+      },
+    },
   },
 };
 
-export const NavbarWithOnlyTabs = {
+export const NavbarWithSpecialTab = {
   args: {
-    rightActions: [rightActions[4]],
+    tabs: [instanceNameTab, ...tabs],
+    rightActions: [userAction],
   },
-};
-
-export const NavbarWithOnlyLinkTabs = {
-  args: {
-    rightActions: [rightActions[4]],
-    tabs: linkTabs,
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'A tab can render arbitrary content via `render` instead of a link — here an editable instance-name field. Custom render tabs stay pinned inline and never collapse into the "More" menu.',
+      },
+    },
   },
 };
 
@@ -200,6 +238,10 @@ export const NavbarWithLongUserName = {
 };
 
 export const ResponsiveTabOverflow = {
+  args: {
+    tabs: overflowTabs,
+    rightActions: manyRightActions,
+  },
   decorators: [
     (Story) => (
       <div
@@ -218,109 +260,7 @@ export const ResponsiveTabOverflow = {
     docs: {
       description: {
         story:
-          'Drag the right edge to resize the container. As it narrows, tabs that no longer fit collapse from the right into a "More" menu (the selected tab and the custom instance-name field stay pinned inline), and below the condense breakpoint the right-action labels drop to icon-only — except the account dropdown, which opts into `abbreviateWhenCondensed` and shows its initials ("CG") next to the icon while keeping the full name as its accessible name. The navbar measures its own width, so this responds to the container, not the viewport.',
-      },
-    },
-  },
-};
-
-export const NavbarDropdownShowcase = {
-  args: {
-    rightActions: [
-      {
-        type: 'dropdown',
-        text: 'Language',
-        variant: 'secondary',
-        size: 'default',
-        items: [
-          {
-            label: 'English',
-            name: 'EN',
-            onClick: action('English selected'),
-          },
-          {
-            label: 'Français',
-            name: 'FR',
-            onClick: action('French selected'),
-          },
-          {
-            label: 'Español',
-            name: 'ES',
-            onClick: action('Spanish selected'),
-          },
-        ],
-      },
-      {
-        type: 'dropdown',
-        text: 'Help',
-        icon: <i className="fas fa-question-circle" />,
-        variant: 'outline',
-        size: 'default',
-        items: [
-          {
-            label: 'Documentation',
-            onClick: action('Documentation clicked'),
-          },
-          {
-            label: 'Tutorials',
-            onClick: action('Tutorials clicked'),
-          },
-          {
-            label: 'Contact Support',
-            onClick: action('Contact Support clicked'),
-          },
-          {
-            label: 'Release Notes',
-            onClick: action('Release Notes clicked'),
-          },
-        ],
-      },
-      {
-        type: 'dropdown',
-        icon: <i className="fas fa-user" />,
-        variant: 'primary',
-        size: 'default',
-        caret: false,
-        items: [
-          {
-            label: 'Profile Settings',
-            onClick: action('Profile clicked'),
-          },
-          {
-            label: 'Preferences',
-            onClick: action('Preferences clicked'),
-          },
-          {
-            label: 'API Keys',
-            onClick: action('API Keys clicked'),
-          },
-          {
-            label: 'Log out',
-            onClick: action('Logout clicked'),
-          },
-        ],
-      },
-    ],
-    tabs: [
-      {
-        selected: true,
-        title: 'Dashboard',
-        link: <a href="/dashboard">Dashboard</a>,
-        onClick: action('Dashboard clicked'),
-      },
-      {
-        selected: false,
-        title: 'Analytics',
-        link: <a href="/analytics">Analytics</a>,
-        onClick: action('Analytics clicked'),
-      },
-    ],
-  },
-  parameters: {
-    docs: {
-      description: {
-        story:
-          'This story showcases different dropdown variants within the navbar. The dropdowns use the new ButtonV2 styling with variants: secondary, outline, and primary. Notice how the different variants provide visual hierarchy and the icon-only dropdown uses caret: false for a cleaner look.',
+          'Drag the right edge to resize the container. As it narrows, tabs that no longer fit collapse from the right into a "More" menu (the selected tab and the custom instance-name field stay pinned inline), and below the condense breakpoint each right-action label that has an icon condenses to its initials next to that icon (e.g. the account dropdown "Carlito Gonzalez" → "CG"), keeping the full label as its accessible name; icon-only actions stay icon-only. The navbar measures its own width, so this responds to the container, not the viewport.',
       },
     },
   },

--- a/stories/navbar.stories.tsx
+++ b/stories/navbar.stories.tsx
@@ -128,8 +128,9 @@ const rightActions = [
   },
   {
     type: 'dropdown',
-    text: 'Carlito',
+    text: 'Carlito Gonzalez',
     icon: <i className="fas fa-user" />,
+    abbreviateWhenCondensed: true,
     items: [
       {
         label: 'Log out',
@@ -217,7 +218,7 @@ export const ResponsiveTabOverflow = {
     docs: {
       description: {
         story:
-          'Drag the right edge to resize the container. As it narrows, tabs that no longer fit collapse from the right into a "More" menu (the selected tab and the custom instance-name field stay pinned inline), and below the condense breakpoint the right-action labels drop to icon-only. The navbar measures its own width, so this responds to the container, not the viewport.',
+          'Drag the right edge to resize the container. As it narrows, tabs that no longer fit collapse from the right into a "More" menu (the selected tab and the custom instance-name field stay pinned inline), and below the condense breakpoint the right-action labels drop to icon-only — except the account dropdown, which opts into `abbreviateWhenCondensed` and shows its initials ("CG") next to the icon while keeping the full name as its accessible name. The navbar measures its own width, so this responds to the container, not the viewport.',
       },
     },
   },

--- a/stories/navbar.stories.tsx
+++ b/stories/navbar.stories.tsx
@@ -198,6 +198,31 @@ export const NavbarWithLongUserName = {
   },
 };
 
+export const ResponsiveTabOverflow = {
+  decorators: [
+    (Story) => (
+      <div
+        style={{
+          width: 720,
+          resize: 'horizontal',
+          overflow: 'auto',
+          border: '1px dashed #888',
+        }}
+      >
+        <Story />
+      </div>
+    ),
+  ],
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Drag the right edge to resize the container. As it narrows, tabs that no longer fit collapse from the right into a "More" menu (the selected tab and the custom instance-name field stay pinned inline), and below the condense breakpoint the right-action labels drop to icon-only. The navbar measures its own width, so this responds to the container, not the viewport.',
+      },
+    },
+  },
+};
+
 export const NavbarDropdownShowcase = {
   args: {
     rightActions: [

--- a/stories/navbar.stories.tsx
+++ b/stories/navbar.stories.tsx
@@ -1,9 +1,7 @@
 import React from 'react';
 import { Navbar } from '../src/lib/components/navbar/Navbar.component';
 import { action } from 'storybook/actions';
-import { Link } from '../src/lib/components/text/Text.component';
 import { InlineInput } from '../src/lib';
-import { Stack } from '../src/lib/spacing';
 import { Logo } from '../src/lib/icons/branding-logo';
 
 // A short, typical set of navigation tabs — the shape most apps start from.
@@ -77,6 +75,20 @@ const userAction = {
   ],
 };
 
+const notificationsButton = {
+  type: 'button',
+  icon: <i className="fas fa-bell" />,
+  tooltip: { overlay: 'Notifications' },
+  onClick: action('Notifications clicked'),
+};
+
+const whatsNewButton = {
+  type: 'button',
+  icon: <i className="fas fa-magic" />,
+  tooltip: { overlay: "What's new" },
+  onClick: action("What's new clicked"),
+};
+
 const themeButton = {
   type: 'button',
   icon: <i className="fas fa-sun" />,
@@ -84,48 +96,12 @@ const themeButton = {
   onClick: action('Theme toggle clicked'),
 };
 
-// A fuller set of right actions used to show icon-only condensing and overflow.
-const manyRightActions = [
-  {
-    type: 'dropdown',
-    text: 'FR',
-    icon: <i className="fas fa-globe" />,
-    items: [
-      {
-        label: 'English',
-        name: 'EN',
-        onClick: action('English selected'),
-      },
-    ],
-  },
-  {
-    type: 'dropdown',
-    icon: <i className="fas fa-th" />,
-    items: [
-      {
-        label: 'App 1',
-        onClick: action('App 1 clicked'),
-      },
-    ],
-  },
-  {
-    type: 'dropdown',
-    icon: <i className="fas fa-question-circle" />,
-    items: [
-      { label: 'About', onClick: action('About clicked') },
-      { label: 'Documentation', onClick: action('Documentation clicked') },
-      { label: 'Onboarding', onClick: action('Onboarding clicked') },
-    ],
-  },
-  {
-    type: 'custom',
-    render: () => (
-      <Stack>
-        <i className="fas fa-exclamation-circle" />{' '}
-        <Link>New version available</Link>
-      </Stack>
-    ),
-  },
+// A realistic right-actions set: a couple of icon-only buttons, the theme
+// toggle, then the account menu. Shared by the right-actions and responsive
+// stories so they represent the same navbar.
+const rightActions = [
+  notificationsButton,
+  whatsNewButton,
   themeButton,
   userAction,
 ];
@@ -153,13 +129,13 @@ export const BasicNavbar = {
 
 export const NavbarWithRightActions = {
   args: {
-    rightActions: [themeButton, userAction],
+    rightActions,
   },
   parameters: {
     docs: {
       description: {
         story:
-          'A typical navbar: tabs on the left, an account menu and a theme-toggle button on the right.',
+          'A typical navbar: tabs on the left, and on the right a set of icon buttons (notifications, what\'s new, theme toggle) followed by the account menu.',
       },
     },
   },
@@ -240,7 +216,7 @@ export const NavbarWithLongUserName = {
 export const ResponsiveTabOverflow = {
   args: {
     tabs: overflowTabs,
-    rightActions: manyRightActions,
+    rightActions,
   },
   decorators: [
     (Story) => (


### PR DESCRIPTION
**TL;DR** — The Navbar now measures its own width and adapts: tabs that no longer fit collapse into a "More" menu, and right-action labels condense (icon-only, or initials for the account menu) as space runs out — without a viewport media query.

### Context / Why
Responsive PR2 of the JS-measurement track, building on the measure-only `useContainerWidth` hook (PR1). Tab overflow and label condensing are the *one* responsiveness case CSS `@container` can't do — they require counting and relocating DOM by cumulative width — so this is done in JS. The goal is to keep the navbar usable when a host **side-panel shrinks the available space** (not the viewport).

Worth knowing before you dive in: the ticket flags this as the **highest-risk PR in the responsive track** — Navbar is a widely-used, already-shipped component, and this PR now routes **every** existing navbar through the new measure-and-overflow path, even consumers that set none of the new props. The new API surface itself is opt-in and non-breaking (only new *optional* props: `condenseActionsBreakpoint`, `Tab.alwaysVisible`, `DropdownAction.abbreviateWhenCondensed`), but the render-path change is not scoped to opt-in users.

### 📷 Screenshots
Wide vs. narrow container, captured from the PR's own `ResponsiveTabOverflow` story:

![Wide container: all tabs inline, full name shown. Narrow container: tabs overflow into "More", account label condenses to initials.](https://patrickear-dev.s3.eu-west-1.amazonaws.com/screenshots/e53da99b-4083-4b19-95c1-06a0e175323b.png)

- **Wide (1300px)**: all 5 tabs inline, full "Carlito Gonzalez" name shown.
- **Narrow (720px)**: "My instance" (custom render tab) and "Groups" (selected tab) stay pinned inline; the rest overflow into "More". The account dropdown condenses to "CG".

### 🔧 Usage
Non-breaking, opt-in — existing call sites compile unchanged. Real before/after from the PR's own diff (`stories/navbar.stories.tsx`), the only call site it touches:
```tsx
// before
{
  type: 'dropdown',
  text: 'Carlito',
  icon: <i className="fas fa-user" />,
  items: [{ label: 'Log out', onClick: () => {} }],
}

// after — opts into initials instead of hiding the label when condensed
{
  type: 'dropdown',
  text: 'Carlito Gonzalez',
  icon: <i className="fas fa-user" />,
  abbreviateWhenCondensed: true,
  items: [{ label: 'Log out', onClick: () => {} }],
}
```
`condenseActionsBreakpoint` (on `<Navbar>`) and `Tab.alwaysVisible` are also new, but no call site in this diff exercises them — not shown, per the never-invent rule.

### 🔍 Review focus
- 🔴 `Navbar.component.tsx › NavbarTabsRow` + `selectVisibleTabs()` — the priority+ fit is the heart of the PR and every navbar now goes through it. `selectVisibleTabs` is pure and well unit-tested (fit / pinning / order); the wiring around it in `NavbarTabsRow` (per-index width cache + measurement) is where a regression would actually ship. Look here first.
- 🟡 `Navbar.component.tsx › useCondensedActions()` — condense latch lives in a `useLayoutEffect` (not a render side-effect, so StrictMode/concurrent-safe) with a ±24px hysteresis band to stop flicker at the breakpoint. Confirm the wide-first→condensed→wide transitions behave.
- 🟡 Accessibility surface — overflow panel is a `<nav>` disclosure, **not** an ARIA `menu` (deliberate: no arrow-key contract for what are just links); `Dropdown.component.tsx` gains an `aria-label` prop applied *after* the action spread so a stray prop can't clobber the condensed name; menu items use `aria-current` instead of `role=tab`. Verify the condensed account menu still announces its full name.

> ⚠️ **Watch for** (each tied to a specific hunk):
> - **Stale width cache.** Widths are cached by tab **index** and only refreshed for tabs currently in the row (a tab in "More" keeps its old cached width). Correct while tabs are stable, but dynamic labels (i18n) or reordering would measure against a stale width. The code documents a `key`-bump workaround — but a consumer won't know to do that unless it's called out.
> - **Condensed-name precedence.** `getActionRenderer` spreads `...rest` from the (porous) action object, then applies `title`/`aria-label` after it. A stray `aria-label` on an action must not win over the condensed name — there's a test for exactly this boundary; confirm it still holds if the spread order changes.
> - **First-paint flash.** A 96px estimate is reserved for the "More" trigger until it self-measures. Confirm there's no one-frame flash of one-too-many tabs on initial mount.

### 🧪 How to test
1. Storybook → **Components/Navigation/Navbar → ResponsiveTabOverflow**.
2. Drag the container's right edge inward: tabs collapse from the right into the "More" menu; the selected tab and the instance-name field stay pinned inline.
3. Narrow further past the condense breakpoint: right-action labels drop to icon-only; the account dropdown shows initials ("CG") instead — hovering / assistive tech still gives the full name.
4. Keyboard-only: Tab to the "More" trigger, open it, Tab through the links (no arrow keys needed); the focus ring should match the inline tabs.
5. `npm test src/lib/components/navbar` → 13 passing.

### 🔗 References
- [ARTESCA-17791](https://scality.atlassian.net/browse/ARTESCA-17791) — [Responsive PR2] Navbar responsive: tab overflow + condense actions (Story, Ongoing; flagged highest-risk in the track).
- Depends on **PR1** — the measure-only `useContainerWidth` hook.
- Design: `docs/responsive-design-proposal.md` (§ "What stays JS", Track A step 2).

<details><summary>What changed & deliberately not changed</summary>

**Changed**
- `Navbar.component.tsx` (+479/-40): priority+ tab overflow (`selectVisibleTabs`, `NavbarTabsRow`, `NavbarTabsMenu`), `useCondensedActions` hysteresis helper, `getInitials`, condensed action rendering.
- `Dropdown.component.tsx` (+13): `aria-label` prop + icon-only fallback to `title`.
- `Navbar.component.test.tsx` (new, +289): unit tests for `selectVisibleTabs`/`getInitials` + behavior tests for overflow, pinning, condense, a11y names.
- `navbar.stories.tsx` (+27): `ResponsiveTabOverflow` story.

**Deliberately not changed** (author's notes, preserved — these answer likely review questions up front)
- Kept the existing Dropdown text-swap condense mechanism → **no** dependency on the Button `iconOnly` `@container` work (PR4).
- No `ResponsiveContainer`/provider — the navbar measures itself directly.
- The `useContainerWidth` hook stays internal (not exported from `index.ts`).
- Opt-in / non-breaking API: only new optional props.

</details>

[ARTESCA-17791]: https://scality.atlassian.net/browse/ARTESCA-17791?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ