### PR TITLE
improvement(Button): pointer cursor on hover for all buttons (MSTRO-116)

### DIFF
--- a/src/lib/components/buttonv2/Buttonv2.component.tsx
+++ b/src/lib/components/buttonv2/Buttonv2.component.tsx
@@ -75,6 +75,7 @@ export const ButtonStyled = styled.button<ButtonStyledTransientProps>`
   font-size: ${fontSize.base};
   border-radius: ${spacing.r4};
   white-space: nowrap;
+  cursor: pointer;
   height: ${(props) => (props.$size === 'inline' ? spacing.r24 : spacing.r32)};
   ${(props) => {
     const brand = props.theme;


### PR DESCRIPTION
**TL;DR** — Buttons rendered without a `variant` (notably the segmented **Sort by** / **Group by** controls built on `ButtonGroup`) only received `cursor: pointer` inside each variant's `:hover:enabled` block, so a no-variant labelled button kept the default arrow cursor on hover and didn't read as an action. This sets `cursor: pointer` on the base button style so every enabled button gets it; the existing `disabled` rule still overrides it with `not-allowed`.

Reported downstream in [MSTRO-116](https://scality.atlassian.net/browse/MSTRO-116) (Maestro Remote uses these controls via `@scality/core-ui/dist/next`).

### Changes
- `Buttonv2.component.tsx`: add a base `cursor: pointer` to `ButtonStyled` (previously only present per-variant on hover). Disabled buttons are unaffected — their `cursor: not-allowed !important` still wins.

The `ButtonGroup` "Sort by" / "GroupByClearable" stories exercise the no-variant path and now show the pointer cursor on hover.

[MSTRO-116]: https://scality.atlassian.net/browse/MSTRO-116?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ