### PR TITLE
improvement(ButtonGroup): align selected look & feel with design spec (MSTRO-117)

### DIFF
--- a/src/lib/components/buttongroup/ButtonGroup.component.tsx
+++ b/src/lib/components/buttongroup/ButtonGroup.component.tsx
@@ -61,6 +61,19 @@ const ButtonGroupContainer = styled.div<{ $orientation: Orientation }>`
     background: transparent;
     box-shadow: none;
     color: ${(props) => props.theme.textSecondary};
+    /* Trailing icon: the label reads first, the icon (e.g. the sort
+       direction arrow) sits to its right. */
+    flex-direction: row-reverse;
+  }
+  .sc-button:enabled {
+    cursor: pointer;
+  }
+
+  /* An icon accompanying a label carries a right gap from Button; with the
+     row reversed the gap belongs on its left instead. */
+  .sc-button > span:first-child:not(:last-child) {
+    padding-right: 0;
+    padding-left: ${spacing.r8};
   }
 
   /* A single hairline separator between adjacent buttons. */
@@ -85,9 +98,10 @@ const ButtonGroupContainer = styled.div<{ $orientation: Orientation }>`
   }
 
   && .sc-button[aria-pressed='true'] {
-    background: ${(props) => props.theme.backgroundLevel1};
+    background: ${(props) => props.theme.highlight};
     color: ${(props) => props.theme.textPrimary};
-    box-shadow: inset 0 0 0 ${spacing.r1} ${(props) => props.theme.selectedActive};
+    box-shadow: inset 0 calc(-1 * ${spacing.r2}) 0
+      ${(props) => props.theme.selectedActive};
   }
 `;
 


### PR DESCRIPTION
## TL;DR

Aligns the `ButtonGroup` segmented control (used for maestro's Sort by / Group by controls) with the design spec. The selected button now shows a blue-shade background with a stronger blue inner bottom border instead of a full inset outline, the icon renders after the label (trailing, e.g. the sort-direction arrow), and the enabled buttons get a pointer cursor.

Relates to [MSTRO-117](https://scality.atlassian.net/browse/MSTRO-117).

## Changes

- Selected state (`[aria-pressed='true']`): `highlight` background + `inset 0 -2px` `selectedActive` bottom border, replacing the full `inset 0 0 0 1px selectedActive` outline.
- `.sc-button` uses `flex-direction: row-reverse` so the label reads first and the icon sits to its right; the icon's gap is flipped to its left accordingly.
- `cursor: pointer` on the enabled buttons.

All uses design-system theme tokens, so it stays correct across every theme.

[MSTRO-117]: https://scality.atlassian.net/browse/MSTRO-117?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

## Before / After

| Before | After |
| --- | --- |
| <img width="280" alt="before" src="https://github.com/user-attachments/assets/7d182552-806d-4488-b5e2-cadc3ede4efc" /> | <img width="280" alt="after" src="https://github.com/user-attachments/assets/404a6d44-9d99-49af-9e32-ab7de8d8422d" /> |
