### PR TITLE
improvement(responsive): opt-in container prop on Box/Stack/Wrap + TwoPanelLayout

### DIFF
--- a/src/lib/components/box/Box.test.tsx
+++ b/src/lib/components/box/Box.test.tsx
@@ -1,6 +1,7 @@
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { Box } from './Box';
+import { Stack } from '../../spacing';
 
 describe('Box', () => {
   it('keeps design-system style props out of the rendered HTML', () => {
@@ -50,5 +51,22 @@ describe('Box', () => {
   it('renders as the element given by the "as" prop', () => {
     render(<Box as="section" data-testid="b" />);
     expect(screen.getByTestId('b').tagName).toBe('SECTION');
+  });
+});
+
+describe('Box container', () => {
+  it('still shows its children when opted into being a responsive container', () => {
+    render(
+      <Stack container>
+        <span>panel content</span>
+      </Stack>,
+    );
+    expect(screen.getByText('panel content')).toBeVisible();
+  });
+
+  it('does not emit the container prop as a DOM attribute', () => {
+    render(<Box container data-testid="c" />);
+    const el = screen.getByTestId('c');
+    expect(el.hasAttribute('container')).toBe(false);
   });
 });

--- a/src/lib/components/box/Box.ts
+++ b/src/lib/components/box/Box.ts
@@ -1,4 +1,4 @@
-import styled from 'styled-components';
+import styled, { css } from 'styled-components';
 import shouldForwardProp from '@styled-system/should-forward-prop';
 import {
   layout,
@@ -35,11 +35,17 @@ export type BoxComponentProps = LayoutProps &
   BackgroundProps &
   BordersProps &
   TypographyProps &
-  ShadowProps & { gap?: string | number };
+  ShadowProps & { gap?: string | number; container?: boolean };
 
 const Box = styled.div.withConfig({
-  shouldForwardProp: (prop) => shouldForwardProp(prop),
+  shouldForwardProp: (prop) => prop !== 'container' && shouldForwardProp(prop),
 })<BoxComponentProps>`
+  ${({ container }) =>
+    container &&
+    css`
+      container-type: inline-size;
+      container-name: responsive;
+    `}
   ${layout}
   ${flexbox}
   ${grid}

--- a/src/lib/components/layout/v2/panels.test.tsx
+++ b/src/lib/components/layout/v2/panels.test.tsx
@@ -1,0 +1,21 @@
+import { render, screen } from '@testing-library/react';
+import { getWrapper } from '../../../testUtils';
+import { TwoPanelLayout } from './panels';
+
+const { Wrapper } = getWrapper();
+
+describe('TwoPanelLayout', () => {
+  it("renders both panels' content when the right panel opts into being a container", () => {
+    render(
+      <TwoPanelLayout
+        panelsRatio="50-50"
+        container="right"
+        leftPanel={{ children: <div>left content</div> }}
+        rightPanel={{ children: <div>right content</div> }}
+      />,
+      { wrapper: Wrapper },
+    );
+    expect(screen.getByText('left content')).toBeVisible();
+    expect(screen.getByText('right content')).toBeVisible();
+  });
+});

--- a/src/lib/components/layout/v2/panels.tsx
+++ b/src/lib/components/layout/v2/panels.tsx
@@ -1,4 +1,4 @@
-import styled from 'styled-components';
+import styled, { css } from 'styled-components';
 import { ReactElement } from 'react';
 import { ThemeColors } from '../../../style/theme';
 import { AppContainer } from './AppContainer';
@@ -38,22 +38,36 @@ const LeftPanel = styled.div<{
   $hasPadding?: boolean;
   $flex?: number;
   $background?: ThemeColors;
+  $container?: boolean;
 }>`
   flex: ${(props) => props.$flex || '0 auto'};
   background: ${(props) => props.theme[props.$background || 'backgroundLevel3']};
   display: flex;
   min-width: 0;
+  ${({ $container }) =>
+    $container &&
+    css`
+      container-type: inline-size;
+      container-name: responsive;
+    `}
 `;
 
 const RightPanel = styled.div<{
   $hasPadding?: boolean;
   $flex?: number;
   $background?: ThemeColors;
+  $container?: boolean;
 }>`
   flex: ${(props) => props.$flex || '0 auto'};
   background: ${(props) => props.theme[props.$background || 'backgroundLevel4']};
   display: flex;
   min-width: 0;
+  ${({ $container }) =>
+    $container &&
+    css`
+      container-type: inline-size;
+      container-name: responsive;
+    `}
 `;
 
 type RatioString = '50-50' | '65-35' | '30-70';
@@ -77,12 +91,14 @@ export const TwoPanelLayout = ({
   leftPanel,
   rightPanel,
   noGap,
+  container,
   ...rest
 }: {
   panelsRatio: RatioString;
   leftPanel: { children: ReactElement; background?: ThemeColors };
   rightPanel: { children: ReactElement; background?: ThemeColors };
   noGap?: boolean;
+  container?: 'left' | 'right' | 'both';
 }) => {
   const panelsObjectRatio = getPanelsObjectRation(panelsRatio);
 
@@ -91,12 +107,14 @@ export const TwoPanelLayout = ({
       <LeftPanel
         $flex={panelsObjectRatio.left}
         $background={leftPanel.background}
+        $container={container === 'left' || container === 'both'}
       >
         {leftPanel.children}
       </LeftPanel>
       <RightPanel
         $flex={panelsObjectRatio.right}
         $background={rightPanel.background}
+        $container={container === 'right' || container === 'both'}
       >
         {rightPanel.children}
       </RightPanel>

--- a/src/lib/spacing.tsx
+++ b/src/lib/spacing.tsx
@@ -67,6 +67,7 @@ export const Stack = ({
   direction?: 'vertical' | 'horizontal';
   withSeparators?: boolean;
   children: ReactNode[];
+  container?: boolean;
 } & HTMLAttributes<HTMLDivElement>) => {
   gap = gap || 'r8';
   direction = direction || 'horizontal';


### PR DESCRIPTION
## TL;DR
Adds an **opt-in `container` prop** that turns a layout element into a CSS `@container` query container named `responsive`, so descendant components can restyle based on that element's inline width — with no JS and no extra wrapper node.

## Context
This is the foundation the responsive Button (#1160) and Form (#1161) work builds on: those components write `@container responsive (…)` rules, which need an ancestor that actually *establishes* a container named `responsive`. This PR is the only place that establishes it. Independent, mergeable on its own.

## Approach
Two hosts, one fixed contract:
- **Box/Stack/Wrap** get `container?: boolean`. `Stack`/`Wrap` render a `Box`, so one prop covers all three.
- **TwoPanelLayout** gets `container?: 'left' | 'right' | 'both'` — panels are the highest-value host because they're what actually shrinks when the layout narrows.

The container **name is fixed to `responsive`** (not exposed as a prop) — it's the contract querying components rely on. Resolution is **nearest-wins**: a `@container responsive (…)` rule binds to the closest ancestor named `responsive`, so wrapping a subtree in `<Stack container>` declares a new responsive frame for its children. This is intended; exposing the name is a documented, non-breaking future escape hatch if nesting ever needs it.

```
<TwoPanelLayout container="right">   ← establishes `responsive`
  └─ RightPanel
       └─ <Button iconOnly={480}/>   ← queries nearest `responsive` = the panel
```

## 🔧 Usage
```tsx
// Before — a plain layout
<Stack>{children}</Stack>

// After — opt into being a @container named "responsive"
<Stack container>{children}</Stack>            // ←

// Panels: make a specific panel the query container
<TwoPanelLayout
  panelsRatio="50-50"
  container="right"                             // ←
  leftPanel={{ children: <LeftContent /> }}
  rightPanel={{ children: <RightContent /> }}
/>
```

## Review focus
- 🟡 `layout/v2/panels.tsx › LeftPanel/RightPanel` — the panel container **must stay opt-in**. `container-type: inline-size` makes an element stop sizing to its content on the inline axis, which would collapse a content-sized (`flex: 0 auto`) panel; ratio panels (`50-50`/`65-35`/`30-70`) size from flex and are safe.
- ⚪ `box/Box.ts › shouldForwardProp` — styled-components v6 forwards unknown props to the DOM, so `container` is explicitly filtered (`prop !== 'container'`). Guarded by a DOM-leak regression test.
- ⚪ Fixed name `responsive` + nearest-wins is a deliberate contract, not an oversight.

## How to test
- Wrap any component in `<Stack container>` (or set `container` on a panel) and confirm children still render unchanged.
- Storybook (deferred): drop a responsive Button/Form inside a `container` panel and resize the panel — the descendant should react to the panel's width. Not observable in jsdom.

## References
- **[CUI-31](https://scality.atlassian.net/browse/CUI-31)** (#1160) — Button `iconOnly`; the first consumer of this container.
- **[CUI-32](https://scality.atlassian.net/browse/CUI-32)** (#1161) — Form `flipAt` self-hosts a `responsive` container using the same contract.

<details>
<summary>What changed</summary>

`Box` gains a `$container`-style boolean emitting `container-type: inline-size; container-name: responsive`, filtered from the DOM via `shouldForwardProp`. `Stack` forwards `container` to `Box` through its rest-spread; `Wrap` inherits it via its `BoxComponentProps` type (no code change). `TwoPanelLayout`'s `LeftPanel`/`RightPanel` take a transient `$container` derived from the `'left' | 'right' | 'both'` prop.
</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[CUI-31]: https://scality.atlassian.net/browse/CUI-31?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ