### PR TITLE
improvement(responsive): Button iconOnly via @container (CUI-31)

### DIFF
--- a/src/lib/components/buttonv2/Buttonv2.component.test.tsx
+++ b/src/lib/components/buttonv2/Buttonv2.component.test.tsx
@@ -56,6 +56,49 @@ describe('Button iconOnly', () => {
     }
   });
 
+  it('uses a string tooltip overlay as the accessible name when a non-string label is collapsed', () => {
+    const warn = jest.spyOn(console, 'warn').mockImplementation(() => {});
+    try {
+      render(
+        <Button
+          variant="primary"
+          icon={<span aria-hidden>+</span>}
+          label={<span>Create</span>}
+          iconOnly
+          tooltip={{ overlay: 'Create' }}
+        />,
+        { wrapper: Wrapper },
+      );
+      expect(warn).not.toHaveBeenCalled();
+      expect(
+        screen.getByRole('button', { name: 'Create' }),
+      ).toBeInTheDocument();
+    } finally {
+      warn.mockRestore();
+    }
+  });
+
+  it('warns when a non-string label is collapsed with only a non-string tooltip overlay', () => {
+    const warn = jest.spyOn(console, 'warn').mockImplementation(() => {});
+    try {
+      render(
+        <Button
+          variant="primary"
+          icon={<span aria-hidden>+</span>}
+          label={<span>Create</span>}
+          iconOnly
+          tooltip={{ overlay: <span>Create</span> }}
+        />,
+        { wrapper: Wrapper },
+      );
+      expect(warn).toHaveBeenCalledWith(
+        expect.stringContaining('no accessible name'),
+      );
+    } finally {
+      warn.mockRestore();
+    }
+  });
+
   it('does not warn when a non-string label is collapsed but an aria-label is provided', () => {
     const warn = jest.spyOn(console, 'warn').mockImplementation(() => {});
     try {

--- a/src/lib/components/buttonv2/Buttonv2.component.test.tsx
+++ b/src/lib/components/buttonv2/Buttonv2.component.test.tsx
@@ -1,0 +1,38 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { getWrapper } from '../../testUtils';
+import { Button } from './Buttonv2.component';
+
+const { Wrapper } = getWrapper();
+
+describe('Button iconOnly', () => {
+  it('stays reachable and clickable by its label when set to collapse below a width', async () => {
+    const onClick = jest.fn();
+    render(
+      <Button
+        variant="primary"
+        icon={<span aria-hidden>+</span>}
+        label="Create"
+        iconOnly={480}
+        onClick={onClick}
+      />,
+      { wrapper: Wrapper },
+    );
+    const button = screen.getByRole('button', { name: 'Create' });
+    await userEvent.click(button);
+    expect(onClick).toHaveBeenCalledTimes(1);
+  });
+
+  it('stays reachable by its label when always collapsed to icon-only', () => {
+    render(
+      <Button
+        variant="primary"
+        icon={<span aria-hidden>+</span>}
+        label="Delete"
+        iconOnly
+      />,
+      { wrapper: Wrapper },
+    );
+    expect(screen.getByRole('button', { name: 'Delete' })).toBeInTheDocument();
+  });
+});

--- a/src/lib/components/buttonv2/Buttonv2.component.test.tsx
+++ b/src/lib/components/buttonv2/Buttonv2.component.test.tsx
@@ -35,4 +35,46 @@ describe('Button iconOnly', () => {
     );
     expect(screen.getByRole('button', { name: 'Delete' })).toBeInTheDocument();
   });
+
+  it('warns when collapsing a non-string label that leaves no accessible name', () => {
+    const warn = jest.spyOn(console, 'warn').mockImplementation(() => {});
+    try {
+      render(
+        <Button
+          variant="primary"
+          icon={<span aria-hidden>+</span>}
+          label={<span>Create</span>}
+          iconOnly
+        />,
+        { wrapper: Wrapper },
+      );
+      expect(warn).toHaveBeenCalledWith(
+        expect.stringContaining('no accessible name'),
+      );
+    } finally {
+      warn.mockRestore();
+    }
+  });
+
+  it('does not warn when a non-string label is collapsed but an aria-label is provided', () => {
+    const warn = jest.spyOn(console, 'warn').mockImplementation(() => {});
+    try {
+      render(
+        <Button
+          variant="primary"
+          icon={<span aria-hidden>+</span>}
+          label={<span>Create</span>}
+          iconOnly
+          aria-label="Create"
+        />,
+        { wrapper: Wrapper },
+      );
+      expect(warn).not.toHaveBeenCalled();
+      expect(
+        screen.getByRole('button', { name: 'Create' }),
+      ).toBeInTheDocument();
+    } finally {
+      warn.mockRestore();
+    }
+  });
 });

--- a/src/lib/components/buttonv2/Buttonv2.component.test.tsx
+++ b/src/lib/components/buttonv2/Buttonv2.component.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from '@testing-library/react';
+import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { getWrapper } from '../../testUtils';
 import { Button } from './Buttonv2.component';
@@ -76,6 +76,41 @@ describe('Button iconOnly', () => {
     } finally {
       warn.mockRestore();
     }
+  });
+
+  it('reveals its label in a tooltip on hover when collapsed to icon-only', async () => {
+    render(
+      <Button
+        variant="primary"
+        icon={<span aria-hidden>+</span>}
+        label="Create"
+        iconOnly
+      />,
+      { wrapper: Wrapper },
+    );
+    // Only the button's own (CSS-hidden) label is present before hover.
+    expect(screen.getAllByText('Create')).toHaveLength(1);
+    await userEvent.hover(screen.getByRole('button', { name: 'Create' }));
+    await waitFor(() =>
+      expect(screen.getAllByText('Create').length).toBeGreaterThan(1),
+    );
+  });
+
+  it('lets an explicit tooltip override the label as the hover hint', async () => {
+    render(
+      <Button
+        variant="primary"
+        icon={<span aria-hidden>+</span>}
+        label="Create"
+        iconOnly
+        tooltip={{ overlay: 'Create a new item' }}
+      />,
+      { wrapper: Wrapper },
+    );
+    await userEvent.hover(screen.getByRole('button', { name: 'Create' }));
+    await waitFor(() =>
+      expect(screen.getByText('Create a new item')).toBeVisible(),
+    );
   });
 
   it('warns when a non-string label is collapsed with only a non-string tooltip overlay', () => {

--- a/src/lib/components/buttonv2/Buttonv2.component.tsx
+++ b/src/lib/components/buttonv2/Buttonv2.component.tsx
@@ -30,11 +30,14 @@ type ButtonStyledProps = Omit<
 type ButtonWithLabel = ButtonStyledProps & {
   label: React.ReactNode;
   tooltip?: Omit<TooltipProps, 'children'>;
+  /** Collapse to icon-only: true = always; number = below N px (needs a `responsive` container ancestor); omit = never. */
+  iconOnly?: boolean | number;
 };
 
 /** Icon-only button - requires either string tooltip OR explicit aria-label */
 type IconOnlyButton = ButtonStyledProps & {
   label?: never;
+  iconOnly?: never;
 } & (
   | {
       tooltip: Omit<TooltipProps, 'children'> & { overlay: string };
@@ -228,12 +231,31 @@ export const ButtonStyled = styled.button<ButtonStyledTransientProps>`
     `;
   }}
 `;
-export const ButtonLabel = styled.span`
+export const ButtonLabel = styled.span<{
+  $collapseAt?: number;
+  $alwaysCollapsed?: boolean;
+}>`
   display: inline-flex;
   justify-content: center;
   align-items: center;
+  ${({ $alwaysCollapsed }) =>
+    $alwaysCollapsed &&
+    css`
+      display: none;
+    `}
+  ${({ $collapseAt }) =>
+    $collapseAt &&
+    css`
+      @container responsive (max-width: ${$collapseAt}px) {
+        display: none;
+      }
+    `}
 `;
-export const ButtonIcon = styled.span<{ $label: React.ReactNode }>`
+export const ButtonIcon = styled.span<{
+  $label: React.ReactNode;
+  $collapseAt?: number;
+  $alwaysCollapsed?: boolean;
+}>`
   ${(props) =>
     props.$label &&
     css`
@@ -241,6 +263,18 @@ export const ButtonIcon = styled.span<{ $label: React.ReactNode }>`
       display: inline-flex;
       justify-content: center;
       align-items: center;
+    `}
+  ${({ $alwaysCollapsed }) =>
+    $alwaysCollapsed &&
+    css`
+      padding-right: 0;
+    `}
+  ${({ $collapseAt }) =>
+    $collapseAt &&
+    css`
+      @container responsive (max-width: ${$collapseAt}px) {
+        padding-right: 0;
+      }
     `}
 `;
 
@@ -271,6 +305,7 @@ function Button({
   onClick,
   tooltip,
   isLoading,
+  iconOnly,
   ...rest
 }: Props) {
   if (!icon && !label) {
@@ -279,11 +314,21 @@ function Button({
     );
   }
 
+  const alwaysCollapsed = iconOnly === true;
+  const collapseAt = typeof iconOnly === 'number' ? iconOnly : undefined;
+
+  // When collapsing a labelled button, the visible label may be CSS-hidden, so
+  // pin the accessible name from the (string) label unless one was passed explicitly.
+  const labelDrivenAriaLabel =
+    iconOnly && typeof label === 'string' && !(rest as { 'aria-label'?: string })['aria-label']
+      ? label
+      : undefined;
+
   // For icon-only buttons, use tooltip.overlay as aria-label (typed as string for IconOnlyButton)
   const buttonAriaLabel =
     !label && icon && tooltip?.overlay
       ? (tooltip.overlay as string)
-      : undefined;
+      : labelDrivenAriaLabel;
 
   return (
     <Tooltip
@@ -306,12 +351,20 @@ function Button({
           (isLoading ? (
             <ButtonLoader size="small" $variant={variant} $label={label} />
           ) : (
-            <ButtonIcon $label={label}>{icon}</ButtonIcon>
+            <ButtonIcon
+              $label={label}
+              $collapseAt={collapseAt}
+              $alwaysCollapsed={alwaysCollapsed}
+            >
+              {icon}
+            </ButtonIcon>
           ))}
         {!icon && isLoading && (
           <ButtonLoader size="small" $variant={variant} $label={label} />
         )}
-        <ButtonLabel>{label}</ButtonLabel>
+        <ButtonLabel $collapseAt={collapseAt} $alwaysCollapsed={alwaysCollapsed}>
+          {label}
+        </ButtonLabel>
       </ButtonStyled>
     </Tooltip>
   );

--- a/src/lib/components/buttonv2/Buttonv2.component.tsx
+++ b/src/lib/components/buttonv2/Buttonv2.component.tsx
@@ -319,10 +319,10 @@ function Button({
     label &&
     typeof label !== 'string' &&
     !(rest as { 'aria-label'?: string })['aria-label'] &&
-    !tooltip?.overlay
+    typeof tooltip?.overlay !== 'string'
   ) {
     console.warn(
-      'Button: `iconOnly` collapses a non-string label, which leaves the button with no accessible name. Pass a string label, an `aria-label`, or a `tooltip.overlay`.',
+      'Button: `iconOnly` collapses a non-string label, which leaves the button with no accessible name. Pass a string label, an `aria-label`, or a string `tooltip.overlay`.',
     );
   }
 
@@ -330,10 +330,15 @@ function Button({
   const collapseAt = typeof iconOnly === 'number' ? iconOnly : undefined;
 
   // When collapsing a labelled button, the visible label may be CSS-hidden, so
-  // pin the accessible name from the (string) label unless one was passed explicitly.
+  // pin the accessible name unless one was passed explicitly: prefer a string
+  // label, otherwise fall back to a string tooltip overlay.
   const labelDrivenAriaLabel =
-    iconOnly && typeof label === 'string' && !(rest as { 'aria-label'?: string })['aria-label']
-      ? label
+    iconOnly && !(rest as { 'aria-label'?: string })['aria-label']
+      ? typeof label === 'string'
+        ? label
+        : typeof tooltip?.overlay === 'string'
+          ? tooltip.overlay
+          : undefined
       : undefined;
 
   // For icon-only buttons, use tooltip.overlay as aria-label (typed as string for IconOnlyButton)

--- a/src/lib/components/buttonv2/Buttonv2.component.tsx
+++ b/src/lib/components/buttonv2/Buttonv2.component.tsx
@@ -314,6 +314,18 @@ function Button({
     );
   }
 
+  if (
+    iconOnly &&
+    label &&
+    typeof label !== 'string' &&
+    !(rest as { 'aria-label'?: string })['aria-label'] &&
+    !tooltip?.overlay
+  ) {
+    console.warn(
+      'Button: `iconOnly` collapses a non-string label, which leaves the button with no accessible name. Pass a string label, an `aria-label`, or a `tooltip.overlay`.',
+    );
+  }
+
   const alwaysCollapsed = iconOnly === true;
   const collapseAt = typeof iconOnly === 'number' ? iconOnly : undefined;
 

--- a/src/lib/components/buttonv2/Buttonv2.component.tsx
+++ b/src/lib/components/buttonv2/Buttonv2.component.tsx
@@ -361,11 +361,15 @@ function Button({
       ? (tooltip.overlay as string)
       : labelDrivenAriaLabel;
 
+  // An `iconOnly` button hides its label, so it must always offer a hover hint.
+  // An explicit tooltip wins; otherwise fall back to the label itself.
+  const tooltipOverlay = tooltip?.overlay ?? (iconOnly ? label : undefined);
+
   return (
     <Tooltip
-      placement={tooltip ? tooltip.placement : undefined}
-      overlay={tooltip && tooltip.overlay}
-      overlayStyle={tooltip && tooltip.overlayStyle}
+      placement={tooltip?.placement}
+      overlay={tooltipOverlay}
+      overlayStyle={tooltip?.overlayStyle}
     >
       <ButtonStyled
         className="sc-button"

--- a/src/lib/components/buttonv2/Buttonv2.component.tsx
+++ b/src/lib/components/buttonv2/Buttonv2.component.tsx
@@ -281,6 +281,8 @@ export const ButtonIcon = styled.span<{
 export const ButtonLoader = styled(Loader)<{
   $label?: React.ReactNode;
   $variant?: ButtonStyledProps['variant'];
+  $collapseAt?: number;
+  $alwaysCollapsed?: boolean;
 }>`
   ${(props) => {
     return css`
@@ -294,6 +296,18 @@ export const ButtonLoader = styled(Loader)<{
       }
     `;
   }}
+  ${({ $alwaysCollapsed }) =>
+    $alwaysCollapsed &&
+    css`
+      margin-right: 0;
+    `}
+  ${({ $collapseAt }) =>
+    $collapseAt &&
+    css`
+      @container responsive (max-width: ${$collapseAt}px) {
+        margin-right: 0;
+      }
+    `}
 `;
 
 function Button({
@@ -366,7 +380,13 @@ function Button({
       >
         {icon &&
           (isLoading ? (
-            <ButtonLoader size="small" $variant={variant} $label={label} />
+            <ButtonLoader
+              size="small"
+              $variant={variant}
+              $label={label}
+              $collapseAt={collapseAt}
+              $alwaysCollapsed={alwaysCollapsed}
+            />
           ) : (
             <ButtonIcon
               $label={label}


### PR DESCRIPTION
## TL;DR
Adds `iconOnly?: boolean | number` to the labelled `Button`: collapse the label to icon-only **always** (`true`) or **below N px of the nearest `responsive` container** (`number`, via `@container`). The label stays in the DOM, so the button keeps a stable accessible name.

## Context
Toolbars need to shed button labels when space runs out without losing accessibility or duplicating components. CUI-31 originally proposed a JS `ResponsiveContainer` provider with an `'auto'` mode; that was dropped in favour of pure CSS `@container` (see References). Button now reads no context — it only emits a container query.

## Approach
The label span is **always rendered**; collapsing only hides it via CSS (`@container responsive (max-width: Npx){ display:none }`) and removes the icon's right padding so it re-centres. Because a CSS-hidden label is dropped from the accessibility tree, the accessible name is **pinned** independently, in this precedence: explicit `aria-label` → string `label` → string `tooltip.overlay`. If none of those exist when a non-string label collapses, a dev `console.warn` fires (the button would otherwise be nameless).

**Sighted users get a hint too:** an `iconOnly` button **always** carries a hover tooltip — it defaults to the `label`, and an explicit `tooltip` prop still wins. (CSS collapse state can't be read in JS, so for the `number` variant the tooltip is present at all widths, not only when collapsed — harmless, since it just mirrors the visible label when expanded.)

```
 wide container              narrow container (< 480px)
┌────────────────┐          ┌──────┐
│   +   Create   │    →     │  +   │   label hidden — accessible name stays "Create"
└────────────────┘          └──────┘
```

## 🔧 Usage
```tsx
// Before
<Button variant="primary" icon={<PlusIcon />} label="Create" />

// After — collapse below 480px of the nearest `responsive` container
<Button variant="primary" icon={<PlusIcon />} label="Create" iconOnly={480} />   // ←

// …or always icon-only:
<Button variant="primary" icon={<PlusIcon />} label="Create" iconOnly />         // ←
```

<!-- SCREENSHOT: Storybook "Button" story placed inside a resize:horizontal `responsive` frame, shown side-by-side at wide (label visible) and narrow (collapsed) widths. Add once a resize-frame story exists. -->

## Review focus
- 🟡 `buttonv2/Buttonv2.component.tsx › labelDrivenAriaLabel / buttonAriaLabel` — the accessible-name derivation across label kind × `aria-label` × `tooltip.overlay`. A collapsed button must never end up nameless; a string `tooltip.overlay` now feeds the name and the warn guard keys on `typeof … !== 'string'`.
- ⚪ `buttonv2/Buttonv2.component.tsx › Props union` — `iconOnly?: never` on the icon-only variant (mirrors `label?: never`), required to destructure `iconOnly` from the union.

## How to test
- Storybook (deferred, not jsdom-observable): render the button inside a resizable `responsive` container; narrow past the threshold and confirm the label hides, the icon re-centres, and the loading spinner stays centred; hover to confirm the tooltip/accessible name is intact.
- Jest covers: the button stays reachable and clickable by its name for every `iconOnly` value; the a11y warn fires for a nameless collapse and stays silent when a name source is present.

## Depends on
The **`number`** variant needs a `responsive` container ancestor from **#1159**. `iconOnly={true}` works standalone. Files are disjoint, so this PR is independently mergeable.

## References
- **[CUI-31](https://scality.atlassian.net/browse/CUI-31)** — *reinterpreted*: the ticket describes a `ResponsiveContainer` provider + `useResponsiveContainer()` + an `'auto'` mode; all dropped. The shipped design is a pure `@container` collapse with no context read.
- **#1159** — provides the `container` prop this queries.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[CUI-31]: https://scality.atlassian.net/browse/CUI-31?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ