### PR TITLE
improvement(responsive): Input fluid + Form responsive (CUI-32)

### DIFF
--- a/src/lib/components/form/Form.component.tsx
+++ b/src/lib/components/form/Form.component.tsx
@@ -104,6 +104,46 @@ const ScrollArea = styled(BasicPageLayout)`
   overflow-y: auto;
 `;
 
+const FieldRow = styled.div<{
+  $direction: 'vertical' | 'horizontal';
+  $responsive?: boolean;
+  $flipAt?: number;
+}>`
+  display: flex;
+  flex-direction: ${({ $direction }) =>
+    $direction === 'horizontal' ? 'row' : 'column'};
+  align-items: baseline;
+  gap: ${({ $direction }) =>
+    $direction === 'horizontal' ? spacing.r32 : spacing.r4};
+  ${({ $responsive }) =>
+    $responsive &&
+    css`
+      min-width: 0;
+    `}
+  ${({ $flipAt }) =>
+    $flipAt &&
+    css`
+      @container responsive (max-width: ${$flipAt}px) {
+        flex-direction: column;
+        align-items: stretch;
+        gap: ${spacing.r4};
+      }
+    `}
+`;
+
+const FieldLabelBox = styled.div<{ $width: string; $flipAt?: number }>`
+  width: ${({ $width }) => $width};
+  flex: none;
+  ${({ $flipAt }) =>
+    $flipAt &&
+    css`
+      @container responsive (max-width: ${$flipAt}px) {
+        width: auto;
+        flex: initial;
+      }
+    `}
+`;
+
 const LabelContext = createContext<{
   maxLabelWidth: number;
   setMaxLabelWidth: (setter: (value: number) => number) => void;
@@ -177,17 +217,10 @@ const FormGroup = ({
 
   return (
     <FieldContext.Provider value={value}>
-      <Box
-        display="flex"
-        flexDirection={direction === 'horizontal' ? 'row' : 'column'}
-        alignItems="baseline"
-        gap={direction === 'horizontal' ? spacing['r32'] : spacing['r4']}
-      >
-        <div
-          style={{
-            width: maxLabelWidth === 0 ? 'max-content' : `${maxLabelWidth}px`,
-            flex: 'none',
-          }}
+      <FieldRow $direction={direction} $responsive={responsive} $flipAt={flipAt}>
+        <FieldLabelBox
+          $width={maxLabelWidth === 0 ? 'max-content' : `${maxLabelWidth}px`}
+          $flipAt={flipAt}
         >
           <label
             htmlFor={id}
@@ -213,10 +246,11 @@ const FormGroup = ({
               </Box>
             )}
           </label>
-        </div>
+        </FieldLabelBox>
         <Stack
           direction={helpErrorPosition === 'right' ? 'horizontal' : 'vertical'}
           gap={helpErrorPosition === 'right' ? 'r8' : 'r4'}
+          style={responsive ? { minWidth: 0 } : undefined}
         >
           {content}
           {error ? (
@@ -235,7 +269,7 @@ const FormGroup = ({
             </HelperText>
           )}
         </Stack>
-      </Box>
+      </FieldRow>
     </FieldContext.Provider>
   );
 };

--- a/src/lib/components/form/Form.component.tsx
+++ b/src/lib/components/form/Form.component.tsx
@@ -34,19 +34,16 @@ type FormProps = Omit<
   rightActions?: ReactNode;
   banner?: ReactNode;
   /**
-   * Makes contained fields fluid: their `size`-derived width becomes a
-   * preferred width that shrinks to fit the column (capped at `max-width: 100%`)
-   * instead of overflowing. Note: only `Input` currently honors this — `Select`,
-   * `SearchInput`, `TextArea` and other size-driven field content keep their
-   * fixed width for now (tracked in CUI-36). Flex ancestors between the Form and
-   * the field must allow shrinking (`min-width: 0`) for this to take effect.
+   * Makes contained fields fluid: their `size`-derived width becomes a preferred
+   * width that shrinks to fit the column (capped at `max-width: 100%`) instead of
+   * overflowing. It also lays each `FormSection` out as a two-column grid that
+   * auto-flips to a stacked single column on narrow widths — there is no
+   * breakpoint prop; the flip point is derived from the layout (see below).
+   * Note: only `Input` currently honors the fluid width — `Select`, `SearchInput`,
+   * `TextArea` and other size-driven content keep their fixed width for now
+   * (tracked in CUI-36).
    */
   responsive?: boolean;
-  /**
-   * Below this width (px), horizontal field rows flip to a stacked column
-   * layout via a `@container` query. Vertical `FormGroup`s are left untouched.
-   */
-  flipAt?: number;
 };
 
 type PageFormProps = {
@@ -59,9 +56,22 @@ type PageFormProps = {
 } & FormProps;
 type TabFormProps = { layout: { kind: 'tab' } } & FormProps;
 
+// In a `responsive` Form a FormSection lays its FormGroups out as a two-column
+// CSS grid (label track + field track) and each FormGroup is a `subgrid` row, so
+// labels align per section from content alone — no measurement. Below STACK_BELOW
+// the grid collapses to a single column (fields stack under their labels) via a
+// `@container` query, so a field never shrinks small enough to truncate.
+// Both floors are a readability policy, not component-derived: fluid fields carry
+// `min-width: 0`, so there is no intrinsic minimum to read.
+// - field floor: the `1/2` Input size (10rem) — below this a field stacks.
+// - label floor: ~24ch — long labels wrap to about two lines before stacking.
+const FIELD_MIN_REM = 10;
+const LABEL_MIN_CH = 24;
+const STACK_BELOW = `calc(${LABEL_MIN_CH}ch + ${FIELD_MIN_REM}rem + ${spacing.r32})`;
+
 const StyledForm = styled.form<{
   $layout: PageFormProps['layout'] | TabFormProps['layout'];
-  $flipAt?: number;
+  $containerize?: boolean;
 }>`
   display: flex;
   flex-direction: column;
@@ -69,8 +79,8 @@ const StyledForm = styled.form<{
   height: 100%;
   background-color: ${(props) =>
     props.$layout.kind === 'page' && props.theme.backgroundLevel4};
-  ${({ $flipAt }) =>
-    $flipAt &&
+  ${({ $containerize }) =>
+    $containerize &&
     css`
       container-type: inline-size;
       container-name: responsive;
@@ -116,10 +126,10 @@ const ScrollArea = styled(BasicPageLayout)`
   overflow-y: auto;
 `;
 
+// Non-responsive layout: a flex row (horizontal) or column (vertical). The label
+// column width comes from measurement (see FormGroup / LabelContext).
 const FieldRow = styled.div<{
   $direction: 'vertical' | 'horizontal';
-  $responsive?: boolean;
-  $flipAt?: number;
 }>`
   display: flex;
   align-items: baseline;
@@ -133,45 +143,82 @@ const FieldRow = styled.div<{
           flex-direction: column;
           gap: ${spacing.r4};
         `}
-  ${({ $responsive }) =>
-    $responsive &&
-    css`
-      min-width: 0;
-    `}
-  ${({ $flipAt }) =>
-    $flipAt &&
-    css`
-      @container responsive (max-width: ${$flipAt}px) {
-        flex-direction: column;
-        align-items: stretch;
-        gap: ${spacing.r4};
-      }
-    `}
 `;
 
-const FieldLabelBox = styled.div<{ $width: string; $flipAt?: number }>`
+const FieldLabelBox = styled.div<{ $width: string }>`
   width: ${({ $width }) => $width};
   flex: none;
-  ${({ $flipAt }) =>
-    $flipAt &&
+  overflow-wrap: break-word;
+`;
+
+// Responsive layout: the FormSection grid. Every FormGroup subgrid row borrows
+// these two tracks, so labels align across the section with no measurement. The
+// label track hugs its content (or is frozen by `forceLabelWidth`); the field
+// track carries the field floor. Below STACK_BELOW the whole section stacks.
+const SectionGrid = styled.div<{ $labelTrack: string }>`
+  display: grid;
+  grid-template-columns:
+    ${({ $labelTrack }) => $labelTrack}
+    minmax(${FIELD_MIN_REM}rem, 1fr);
+  column-gap: ${spacing.r32};
+  row-gap: ${spacing.r12};
+
+  @container responsive (max-width: ${STACK_BELOW}) {
+    grid-template-columns: 1fr;
+    /* Stacked groups need more separation than side-by-side rows: each group is
+       now two lines (label over field), so widen the gap between groups. */
+    row-gap: ${spacing.r20};
+  }
+`;
+
+// A FormGroup as a subgrid row. Horizontal rows inherit the section's two tracks
+// and flip to a single column at STACK_BELOW; vertical rows are always a single
+// column (label stacked above its field).
+const FieldSubgridRow = styled.div<{
+  $direction: 'vertical' | 'horizontal';
+}>`
+  display: grid;
+  grid-column: 1 / -1;
+  row-gap: ${spacing.r4};
+  ${({ $direction }) =>
+    $direction === 'horizontal'
+      ? css`
+          grid-template-columns: subgrid;
+          align-items: baseline;
+
+          @container responsive (max-width: ${STACK_BELOW}) {
+            grid-template-columns: 1fr;
+            align-items: stretch;
+          }
+        `
+      : css`
+          grid-template-columns: 1fr;
+        `}
+`;
+
+const GridLabelCell = styled.div<{ $hasHelpTooltip: boolean }>`
+  min-width: 0;
+  overflow-wrap: break-word;
+  ${({ $hasHelpTooltip }) =>
+    $hasHelpTooltip &&
     css`
-      @container responsive (max-width: ${$flipAt}px) {
-        width: auto;
-        flex: initial;
-      }
+      /* The non-responsive column reserves 2rem beyond the label for the help
+         icon affordance; reserve the same here so the label column is identical
+         in both layouts. */
+      padding-right: ${spacing.r32};
     `}
 `;
 
 const LabelContext = createContext<{
   maxLabelWidth: number;
   setMaxLabelWidth: (setter: (value: number) => number) => void;
+  isLabelWidthFixed: boolean;
 } | null>(null);
 
 const RequireModeContext = createContext<'all' | 'partial'>('partial');
 
 const FormResponsiveContext = createContext<{
   responsive: boolean;
-  flipAt?: number;
 }>({ responsive: false });
 
 type ContentProps = {
@@ -210,14 +257,14 @@ const FormGroup = ({
     throw new Error('FormGroup cannot be used outside of FormSection');
   }
 
-  const { maxLabelWidth, setMaxLabelWidth } = ctxt;
+  const { maxLabelWidth, setMaxLabelWidth, isLabelWidthFixed } = ctxt;
   const requireMode = useContext(RequireModeContext);
-  const { responsive, flipAt } = useContext(FormResponsiveContext);
-  // The row→column flip only makes sense for horizontal rows; a vertical
-  // FormGroup is already stacked and must keep its label-column alignment.
-  const rowFlipAt = direction === 'horizontal' ? flipAt : undefined;
+  const { responsive } = useContext(FormResponsiveContext);
   const labelRef = useRef<HTMLLabelElement | null>(null);
   useEffect(() => {
+    // The responsive grid sizes the label column from content (no measurement),
+    // and a fixed (forced) label width never grows to the label either.
+    if (responsive || isLabelWidthFixed) return;
     if (labelRef.current) {
       const width = labelRef.current.getBoundingClientRect().width;
       setMaxLabelWidth((currentMaxLabelWidth) => {
@@ -228,7 +275,13 @@ const FormGroup = ({
         return currentMaxLabelWidth;
       });
     }
-  }, [labelRef, labelHelpTooltip, setMaxLabelWidth]);
+  }, [
+    labelRef,
+    labelHelpTooltip,
+    setMaxLabelWidth,
+    isLabelWidthFixed,
+    responsive,
+  ]);
 
   const value = {
     disabled: disabled || false,
@@ -236,64 +289,78 @@ const FormGroup = ({
     responsive,
   };
 
+  const labelContent = (
+    <label
+      htmlFor={id}
+      id={`${LABEL_PREFIX}${id}`}
+      ref={labelRef}
+      style={{ opacity: disabled ? 0.5 : 1 }}
+    >
+      <Text>
+        {label}
+        {requireMode !== 'all' && required && ' *'}
+        {requireMode === 'all' && !required && ' (optional)'}
+      </Text>
+      {labelHelpTooltip && (
+        <Box
+          display="inline-block"
+          marginLeft={spacing.r8}
+          style={{ whiteSpace: 'nowrap' }}
+        >
+          <IconHelp
+            tooltipMessage={labelHelpTooltip}
+            overlayStyle={maxWidthTooltip}
+          />
+        </Box>
+      )}
+    </label>
+  );
+
+  const fieldContent = (
+    <Stack
+      direction={helpErrorPosition === 'right' ? 'horizontal' : 'vertical'}
+      gap={helpErrorPosition === 'right' ? 'r8' : 'r4'}
+      style={responsive ? { minWidth: 0 } : undefined}
+    >
+      {content}
+      {error ? (
+        <HelperText color="statusCritical" id={`${DESCRIPTION_PREFIX}${id}`}>
+          {error}
+        </HelperText>
+      ) : help ? (
+        <div style={{ opacity: disabled ? 0.5 : 1 }}>
+          <HelperText color="textSecondary" id={`${DESCRIPTION_PREFIX}${id}`}>
+            {help}
+          </HelperText>
+        </div>
+      ) : (
+        <HelperText>&nbsp;</HelperText>
+      )}
+    </Stack>
+  );
+
+  if (responsive) {
+    return (
+      <FieldContext.Provider value={value}>
+        <FieldSubgridRow $direction={direction}>
+          <GridLabelCell $hasHelpTooltip={!!labelHelpTooltip}>
+            {labelContent}
+          </GridLabelCell>
+          {fieldContent}
+        </FieldSubgridRow>
+      </FieldContext.Provider>
+    );
+  }
+
   return (
     <FieldContext.Provider value={value}>
-      <FieldRow
-        $direction={direction}
-        $responsive={responsive}
-        $flipAt={rowFlipAt}
-      >
+      <FieldRow $direction={direction}>
         <FieldLabelBox
           $width={maxLabelWidth === 0 ? 'max-content' : `${maxLabelWidth}px`}
-          $flipAt={rowFlipAt}
         >
-          <label
-            htmlFor={id}
-            id={`${LABEL_PREFIX}${id}`}
-            ref={labelRef}
-            style={{ opacity: disabled ? 0.5 : 1 }}
-          >
-            <Text>
-              {label}
-              {requireMode !== 'all' && required && ' *'}
-              {requireMode === 'all' && !required && ' (optional)'}
-            </Text>
-            {labelHelpTooltip && (
-              <Box
-                display="inline-block"
-                marginLeft={spacing.r8}
-                style={{ whiteSpace: 'nowrap' }}
-              >
-                <IconHelp
-                  tooltipMessage={labelHelpTooltip}
-                  overlayStyle={maxWidthTooltip}
-                />
-              </Box>
-            )}
-          </label>
+          {labelContent}
         </FieldLabelBox>
-        <Stack
-          direction={helpErrorPosition === 'right' ? 'horizontal' : 'vertical'}
-          gap={helpErrorPosition === 'right' ? 'r8' : 'r4'}
-          style={responsive ? { minWidth: 0 } : undefined}
-        >
-          {content}
-          {error ? (
-            <HelperText color="statusCritical" id={`${DESCRIPTION_PREFIX}${id}`}>{error}</HelperText>
-          ) : help ? (
-            <div
-              style={{
-                opacity: disabled ? 0.5 : 1,
-              }}
-            >
-              <HelperText color="textSecondary" id={`${DESCRIPTION_PREFIX}${id}`}>{help}</HelperText>
-            </div>
-          ) : (
-            <HelperText>
-              &nbsp;
-            </HelperText>
-          )}
-        </Stack>
+        {fieldContent}
       </FieldRow>
     </FieldContext.Provider>
   );
@@ -312,16 +379,31 @@ const FormSection = ({
   forceLabelWidth,
   rightActions,
 }: FormSectionProps) => {
-  const [maxLabelWidth, setMaxLabelWidth] = useState<number>(
-    forceLabelWidth || 0,
-  );
+  // `forceLabelWidth` is a hard cap: when set, the label column stays exactly
+  // that wide and label measurement never grows it (long labels wrap), mirroring
+  // how `Input`'s `size` fixes the field width. When unset, the column auto-sizes
+  // to the widest measured label.
+  const isLabelWidthFixed = forceLabelWidth != null;
+  const [measuredLabelWidth, setMaxLabelWidth] = useState<number>(0);
+  const maxLabelWidth = isLabelWidthFixed
+    ? forceLabelWidth
+    : measuredLabelWidth;
+  const { responsive } = useContext(FormResponsiveContext);
   //If all the formgroup are not required, add `(optional)` next to form section title.
   const groupNotOptional = Children.toArray(children).find((child) =>
     isValidElement(child) ? child.props.required === true : false,
   );
 
+  // In responsive mode the label column is a grid track, sized from content or
+  // frozen by `forceLabelWidth` (the hard cap).
+  const labelTrack = isLabelWidthFixed
+    ? `${forceLabelWidth}px`
+    : 'minmax(min-content, max-content)';
+
   return (
-    <LabelContext.Provider value={{ maxLabelWidth, setMaxLabelWidth }}>
+    <LabelContext.Provider
+      value={{ maxLabelWidth, setMaxLabelWidth, isLabelWidthFixed }}
+    >
       <Stack direction="vertical" gap="r12">
         {title && (
           <Wrap>
@@ -342,7 +424,11 @@ const FormSection = ({
             <div>{rightActions}</div>
           </Wrap>
         )}
-        {children}
+        {responsive ? (
+          <SectionGrid $labelTrack={labelTrack}>{children}</SectionGrid>
+        ) : (
+          children
+        )}
       </Stack>
     </LabelContext.Provider>
   );
@@ -354,7 +440,7 @@ const PageForm = forwardRef<HTMLFormElement, PageFormProps>(
     ref,
   ) => {
     const requireMode = useContext(RequireModeContext);
-    const { flipAt } = useContext(FormResponsiveContext);
+    const { responsive } = useContext(FormResponsiveContext);
     return (
       <ScrollbarWrapper>
         <StyledForm
@@ -362,7 +448,7 @@ const PageForm = forwardRef<HTMLFormElement, PageFormProps>(
           noValidate
           ref={ref}
           $layout={layout}
-          $flipAt={flipAt}
+          $containerize={responsive}
         >
           <FixedHeader $layoutKind="page">
             <PaddedForHeaderAndFooterContent>
@@ -424,8 +510,11 @@ const PageForm = forwardRef<HTMLFormElement, PageFormProps>(
 );
 
 const TabForm = forwardRef<HTMLFormElement, TabFormProps>(
-  ({ layout, leftActions, rightActions, children, banner, ...formProps }, ref) => {
-    const { flipAt } = useContext(FormResponsiveContext);
+  (
+    { layout, leftActions, rightActions, children, banner, ...formProps },
+    ref,
+  ) => {
+    const { responsive } = useContext(FormResponsiveContext);
     return (
       <ScrollbarWrapper>
         <StyledForm
@@ -433,7 +522,7 @@ const TabForm = forwardRef<HTMLFormElement, TabFormProps>(
           noValidate
           ref={ref}
           $layout={layout}
-          $flipAt={flipAt}
+          $containerize={responsive}
         >
           <FixedHeader $layoutKind="tab">
             <Wrap>
@@ -457,12 +546,10 @@ const TabForm = forwardRef<HTMLFormElement, TabFormProps>(
 );
 
 const Form = forwardRef<HTMLFormElement, TabFormProps | PageFormProps>(
-  ({ layout, requireMode, responsive, flipAt, ...formProps }, ref) => {
+  ({ layout, requireMode, responsive, ...formProps }, ref) => {
     return (
       <RequireModeContext.Provider value={requireMode || 'partial'}>
-        <FormResponsiveContext.Provider
-          value={{ responsive: !!responsive, flipAt }}
-        >
+        <FormResponsiveContext.Provider value={{ responsive: !!responsive }}>
           {layout.kind === 'page' ? (
             <PageForm layout={layout} {...formProps} ref={ref}></PageForm>
           ) : (

--- a/src/lib/components/form/Form.component.tsx
+++ b/src/lib/components/form/Form.component.tsx
@@ -110,11 +110,17 @@ const FieldRow = styled.div<{
   $flipAt?: number;
 }>`
   display: flex;
-  flex-direction: ${({ $direction }) =>
-    $direction === 'horizontal' ? 'row' : 'column'};
   align-items: baseline;
-  gap: ${({ $direction }) =>
-    $direction === 'horizontal' ? spacing.r32 : spacing.r4};
+  ${({ $direction }) =>
+    $direction === 'horizontal'
+      ? css`
+          flex-direction: row;
+          gap: ${spacing.r32};
+        `
+      : css`
+          flex-direction: column;
+          gap: ${spacing.r4};
+        `}
   ${({ $responsive }) =>
     $responsive &&
     css`

--- a/src/lib/components/form/Form.component.tsx
+++ b/src/lib/components/form/Form.component.tsx
@@ -11,7 +11,7 @@ import {
   useRef,
   useState,
 } from 'react';
-import styled from 'styled-components';
+import styled, { css } from 'styled-components';
 import { spacing, Stack, Wrap } from '../../spacing';
 import { convertRemToPixels } from '../../utils';
 import { Box } from '../box/Box';
@@ -33,6 +33,8 @@ type FormProps = Omit<
   leftActions?: ReactNode;
   rightActions?: ReactNode;
   banner?: ReactNode;
+  responsive?: boolean;
+  flipAt?: number;
 };
 
 type PageFormProps = {
@@ -47,6 +49,7 @@ type TabFormProps = { layout: { kind: 'tab' } } & FormProps;
 
 const StyledForm = styled.form<{
   $layout: PageFormProps['layout'] | TabFormProps['layout'];
+  $flipAt?: number;
 }>`
   display: flex;
   flex-direction: column;
@@ -54,6 +57,12 @@ const StyledForm = styled.form<{
   height: 100%;
   background-color: ${(props) =>
     props.$layout.kind === 'page' && props.theme.backgroundLevel4};
+  ${({ $flipAt }) =>
+    $flipAt &&
+    css`
+      container-type: inline-size;
+      container-name: responsive;
+    `}
 `;
 
 const BasicPageLayout = styled.div<{ $layoutKind: 'page' | 'tab' }>`
@@ -102,6 +111,11 @@ const LabelContext = createContext<{
 
 const RequireModeContext = createContext<'all' | 'partial'>('partial');
 
+const FormResponsiveContext = createContext<{
+  responsive: boolean;
+  flipAt?: number;
+}>({ responsive: false });
+
 type ContentProps = {
   helper: string;
   error: string;
@@ -140,6 +154,7 @@ const FormGroup = ({
 
   const { maxLabelWidth, setMaxLabelWidth } = ctxt;
   const requireMode = useContext(RequireModeContext);
+  const { responsive, flipAt } = useContext(FormResponsiveContext);
   const labelRef = useRef<HTMLLabelElement | null>(null);
   useEffect(() => {
     if (labelRef.current) {
@@ -157,6 +172,7 @@ const FormGroup = ({
   const value = {
     disabled: disabled || false,
     error: error || undefined,
+    responsive,
   };
 
   return (
@@ -279,9 +295,16 @@ const PageForm = forwardRef<HTMLFormElement, PageFormProps>(
     ref,
   ) => {
     const requireMode = useContext(RequireModeContext);
+    const { flipAt } = useContext(FormResponsiveContext);
     return (
       <ScrollbarWrapper>
-        <StyledForm {...formProps} noValidate ref={ref} $layout={layout}>
+        <StyledForm
+          {...formProps}
+          noValidate
+          ref={ref}
+          $layout={layout}
+          $flipAt={flipAt}
+        >
           <FixedHeader $layoutKind="page">
             <PaddedForHeaderAndFooterContent>
               <Wrap>
@@ -343,9 +366,16 @@ const PageForm = forwardRef<HTMLFormElement, PageFormProps>(
 
 const TabForm = forwardRef<HTMLFormElement, TabFormProps>(
   ({ layout, leftActions, rightActions, children, banner, ...formProps }, ref) => {
+    const { flipAt } = useContext(FormResponsiveContext);
     return (
       <ScrollbarWrapper>
-        <StyledForm {...formProps} noValidate ref={ref} $layout={layout}>
+        <StyledForm
+          {...formProps}
+          noValidate
+          ref={ref}
+          $layout={layout}
+          $flipAt={flipAt}
+        >
           <FixedHeader $layoutKind="tab">
             <Wrap>
               <div>{leftActions}</div>
@@ -368,14 +398,18 @@ const TabForm = forwardRef<HTMLFormElement, TabFormProps>(
 );
 
 const Form = forwardRef<HTMLFormElement, TabFormProps | PageFormProps>(
-  ({ layout, requireMode, ...formProps }, ref) => {
+  ({ layout, requireMode, responsive, flipAt, ...formProps }, ref) => {
     return (
       <RequireModeContext.Provider value={requireMode || 'partial'}>
-        {layout.kind === 'page' ? (
-          <PageForm layout={layout} {...formProps} ref={ref}></PageForm>
-        ) : (
-          <TabForm layout={layout} {...formProps} ref={ref}></TabForm>
-        )}
+        <FormResponsiveContext.Provider
+          value={{ responsive: !!responsive, flipAt }}
+        >
+          {layout.kind === 'page' ? (
+            <PageForm layout={layout} {...formProps} ref={ref}></PageForm>
+          ) : (
+            <TabForm layout={layout} {...formProps} ref={ref}></TabForm>
+          )}
+        </FormResponsiveContext.Provider>
       </RequireModeContext.Provider>
     );
   },
@@ -385,6 +419,7 @@ type FieldState = {
   error?: string;
   disabled?: boolean;
   required?: boolean;
+  responsive?: boolean;
 };
 const FieldContext = createContext<null | FieldState>(null);
 

--- a/src/lib/components/form/Form.component.tsx
+++ b/src/lib/components/form/Form.component.tsx
@@ -122,65 +122,122 @@ const ScrollArea = styled(BasicPageLayout)`
   overflow-y: auto;
 `;
 
-// A FormSection is always a two-column CSS grid (label track + field track), and
-// each FormGroup is a `subgrid` row — so labels align across the section from
-// content alone, no measurement in either mode. The two modes differ only in the
-// field track and whether the section can flip:
-//   - responsive: field track is fluid (minmax(10rem, 1fr)) and the section flips
-//     to a single stacked column below STACK_BELOW via an `@container` query.
-//   - non-responsive: field track hugs its content (max-content) and never flips.
-const SectionGrid = styled.div<{ $labelTrack: string; $responsive: boolean }>`
-  display: grid;
-  column-gap: ${spacing.r32};
-  row-gap: ${spacing.r12};
-  ${({ $labelTrack, $responsive }) =>
-    $responsive
-      ? css`
-          grid-template-columns: ${$labelTrack} minmax(
-              ${FIELD_MIN_REM}rem,
-              1fr
-            );
-
-          @container responsive (max-width: ${STACK_BELOW}) {
-            grid-template-columns: 1fr;
-            /* Stacked groups need more separation than side-by-side rows: each
-               group is now two lines (label over field), so widen the gap. */
-            row-gap: ${spacing.r20};
-          }
-        `
-      : css`
-          grid-template-columns: ${$labelTrack} max-content;
-        `}
-`;
-
-// A FormGroup as a subgrid row. Horizontal rows inherit the section's two tracks
-// (and, when responsive, flip to a single column at STACK_BELOW); vertical rows
-// are always a single column (label stacked above its field).
-const FieldSubgridRow = styled.div<{
-  $direction: 'vertical' | 'horizontal';
+// A FormSection lays its FormGroups out so labels align across the section from
+// content alone — no JS measurement. It picks one of two mechanisms based on
+// whether the label column is a fixed width (`forceLabelWidth`):
+//   - fixed label width: the section is a plain vertical stack and each FormGroup
+//     row is a *self-sufficient* two-column grid (see FieldSubgridRow). Every row
+//     uses the same fixed label track, so labels align — and because a row needs
+//     no parent grid, it keeps its layout even when nested inside another element
+//     (a div/Stack/Accordion).
+//   - auto label width: the section is a two-column grid and each FormGroup row is
+//     a `subgrid` row, so the auto-sized label column is shared across rows. This
+//     requires each row to be a direct grid item.
+// Either way, non-FormGroup children (an InfoMessage, a Banner) stack full-width.
+// `responsive` makes the field track fluid (minmax(10rem, 1fr)) and lets each row
+// flip to a stacked single column below STACK_BELOW via an `@container` query.
+const SectionGrid = styled.div<{
+  $labelTrack: string;
   $responsive: boolean;
+  $fixedLabel: boolean;
 }>`
-  display: grid;
-  grid-column: 1 / -1;
-  row-gap: ${spacing.r4};
-  ${({ $direction, $responsive }) =>
-    $direction === 'horizontal'
+  ${({ $labelTrack, $responsive, $fixedLabel }) =>
+    $fixedLabel
       ? css`
-          grid-template-columns: subgrid;
-          align-items: baseline;
+          display: flex;
+          flex-direction: column;
+          gap: ${spacing.r12};
           ${
             $responsive &&
             css`
               @container responsive (max-width: ${STACK_BELOW}) {
-                grid-template-columns: 1fr;
-                align-items: stretch;
+                gap: ${spacing.r20};
               }
             `
           }
         `
       : css`
-          grid-template-columns: 1fr;
+          display: grid;
+          column-gap: ${spacing.r32};
+          row-gap: ${spacing.r12};
+          /* The field track fills the remaining width (its floor keeps fields from
+             shrinking below content — 10rem when responsive, their own size when
+             not) so the grid reaches the container edge. That is what lets a
+             full-width child actually span it — with a content-sized track the
+             grid would stop at its content and a 1 / -1 span with it. */
+          grid-template-columns:
+            ${$labelTrack}
+            ${
+              $responsive
+                ? `minmax(${FIELD_MIN_REM}rem, 1fr)`
+                : 'minmax(max-content, 1fr)'
+            };
+          /* Non-FormGroup children (InfoMessage, Banner, …) span the full width
+             instead of being auto-placed into the label column. */
+          & > * {
+            grid-column: 1 / -1;
+          }
+          ${
+            $responsive &&
+            css`
+              @container responsive (max-width: ${STACK_BELOW}) {
+                grid-template-columns: 1fr;
+                /* Stacked groups need more separation than side-by-side rows: each
+                 group is now two lines (label over field), so widen the gap. */
+                row-gap: ${spacing.r20};
+              }
+            `
+          }
         `}
+`;
+
+// A FormGroup row. A horizontal row lays label + field on one line; a vertical row
+// stacks them. How a horizontal row gets its two columns depends on the label
+// width:
+//   - fixed (`forceLabelWidth`): the row is a *self-sufficient* two-column grid, so
+//     it keeps its layout anywhere in the DOM — including nested inside a div,
+//     Stack or Accordion — and all rows align because they share $labelTrack.
+//   - auto: the row is a `subgrid` of the SectionGrid so the auto-sized label
+//     column is shared across rows. NOTE: `subgrid` only works when this row is a
+//     *direct grid item* of a SectionGrid. A FormGroup nested inside another
+//     element breaks that chain and the row loses its columns — either set
+//     `forceLabelWidth` on the section, or wrap the nested groups in their own
+//     FormSection.
+const FieldSubgridRow = styled.div<{
+  $direction: 'vertical' | 'horizontal';
+  $responsive: boolean;
+  $labelTrack: string;
+  $fixedLabel: boolean;
+}>`
+  display: grid;
+  grid-column: 1 / -1;
+  row-gap: ${spacing.r4};
+  ${({ $direction, $responsive, $labelTrack, $fixedLabel }) => {
+    if ($direction === 'vertical') {
+      return css`
+        grid-template-columns: 1fr;
+      `;
+    }
+    const fieldTrack = $responsive
+      ? `minmax(${FIELD_MIN_REM}rem, 1fr)`
+      : 'max-content';
+    return css`
+      column-gap: ${spacing.r32};
+      align-items: baseline;
+      grid-template-columns: ${
+        $fixedLabel ? `${$labelTrack} ${fieldTrack}` : 'subgrid'
+      };
+      ${
+        $responsive &&
+        css`
+          @container responsive (max-width: ${STACK_BELOW}) {
+            grid-template-columns: 1fr;
+            align-items: stretch;
+          }
+        `
+      }
+    `;
+  }}
 `;
 
 const GridLabelCell = styled.div<{ $hasHelpTooltip: boolean }>`
@@ -195,9 +252,13 @@ const GridLabelCell = styled.div<{ $hasHelpTooltip: boolean }>`
     `}
 `;
 
-// Presence marker so a FormGroup can assert it is rendered inside a FormSection
-// (its `subgrid` row is meaningless without the section grid as its parent).
-const FormSectionContext = createContext<boolean>(false);
+// Carries the section's label-column config down to each FormGroup so a row can
+// build its own layout. Null outside a FormSection — a FormGroup then throws.
+type SectionLabelConfig = {
+  labelTrack: string;
+  fixedLabel: boolean;
+};
+const FormSectionContext = createContext<SectionLabelConfig | null>(null);
 
 const RequireModeContext = createContext<'all' | 'partial'>('partial');
 
@@ -235,10 +296,10 @@ const FormGroup = ({
   helpErrorPosition = 'right',
   disabled,
 }: FormGroupProps) => {
-  const insideSection = useContext(FormSectionContext);
+  const sectionLabel = useContext(FormSectionContext);
   const requireMode = useContext(RequireModeContext);
   const { responsive } = useContext(FormResponsiveContext);
-  if (!insideSection) {
+  if (!sectionLabel) {
     throw new Error('FormGroup cannot be used outside of FormSection');
   }
 
@@ -299,7 +360,12 @@ const FormGroup = ({
 
   return (
     <FieldContext.Provider value={value}>
-      <FieldSubgridRow $direction={direction} $responsive={responsive}>
+      <FieldSubgridRow
+        $direction={direction}
+        $responsive={responsive}
+        $labelTrack={sectionLabel.labelTrack}
+        $fixedLabel={sectionLabel.fixedLabel}
+      >
         <GridLabelCell $hasHelpTooltip={!!labelHelpTooltip}>
           {labelContent}
         </GridLabelCell>
@@ -312,6 +378,11 @@ const FormGroup = ({
 type FormSectionProps = {
   children: ReactElement<FormGroupProps> | ReactElement<FormGroupProps>[];
   title?: { name: string; icon?: IconName; helpTooltip?: string };
+  /**
+   * Freezes the label column to exactly this pixel width — a hard cap: labels
+   * wider than it wrap rather than widening the column. When unset, the column
+   * auto-sizes to the widest label in the section.
+   */
   forceLabelWidth?: number;
   rightActions?: ReactNode;
 };
@@ -328,21 +399,23 @@ const FormSection = ({
     isValidElement(child) ? child.props.required === true : false,
   );
 
-  // The label column is a grid track. `forceLabelWidth` is a hard cap that freezes
-  // it (long labels then wrap, mirroring how `Input`'s `size` fixes the field
-  // width). Otherwise it auto-sizes to the widest label from content — the grid
-  // aligns labels across the section, so no measurement is needed. Responsive
-  // lets the track shrink to its longest word (min-content) before the section
-  // flips; non-responsive hugs the widest label (max-content).
-  const labelTrack =
-    forceLabelWidth != null
-      ? `${forceLabelWidth}px`
-      : responsive
-        ? 'minmax(min-content, max-content)'
-        : 'max-content';
+  // The label column. `forceLabelWidth` is a hard cap that freezes it to an exact
+  // pixel width (long labels then wrap, mirroring how `Input`'s `size` fixes the
+  // field width); it also makes every FormGroup row self-sufficient, so nesting a
+  // group inside another element no longer breaks its layout. When unset, the
+  // column auto-sizes to the widest label from content, shared across rows via
+  // `subgrid` — no measurement. Responsive lets the track shrink to its longest
+  // word (min-content) before the section flips; non-responsive hugs it
+  // (max-content).
+  const fixedLabel = forceLabelWidth != null;
+  const labelTrack = fixedLabel
+    ? `${forceLabelWidth}px`
+    : responsive
+      ? 'minmax(min-content, max-content)'
+      : 'max-content';
 
   return (
-    <FormSectionContext.Provider value={true}>
+    <FormSectionContext.Provider value={{ labelTrack, fixedLabel }}>
       <Stack direction="vertical" gap="r12">
         {title && (
           <Wrap>
@@ -363,7 +436,11 @@ const FormSection = ({
             <div>{rightActions}</div>
           </Wrap>
         )}
-        <SectionGrid $labelTrack={labelTrack} $responsive={responsive}>
+        <SectionGrid
+          $labelTrack={labelTrack}
+          $responsive={responsive}
+          $fixedLabel={fixedLabel}
+        >
           {children}
         </SectionGrid>
       </Stack>

--- a/src/lib/components/form/Form.component.tsx
+++ b/src/lib/components/form/Form.component.tsx
@@ -33,7 +33,19 @@ type FormProps = Omit<
   leftActions?: ReactNode;
   rightActions?: ReactNode;
   banner?: ReactNode;
+  /**
+   * Makes contained fields fluid: their `size`-derived width becomes a
+   * preferred width that shrinks to fit the column (capped at `max-width: 100%`)
+   * instead of overflowing. Note: only `Input` currently honors this — `Select`,
+   * `SearchInput`, `TextArea` and other size-driven field content keep their
+   * fixed width for now (tracked in CUI-36). Flex ancestors between the Form and
+   * the field must allow shrinking (`min-width: 0`) for this to take effect.
+   */
   responsive?: boolean;
+  /**
+   * Below this width (px), horizontal field rows flip to a stacked column
+   * layout via a `@container` query. Vertical `FormGroup`s are left untouched.
+   */
   flipAt?: number;
 };
 
@@ -201,6 +213,9 @@ const FormGroup = ({
   const { maxLabelWidth, setMaxLabelWidth } = ctxt;
   const requireMode = useContext(RequireModeContext);
   const { responsive, flipAt } = useContext(FormResponsiveContext);
+  // The row→column flip only makes sense for horizontal rows; a vertical
+  // FormGroup is already stacked and must keep its label-column alignment.
+  const rowFlipAt = direction === 'horizontal' ? flipAt : undefined;
   const labelRef = useRef<HTMLLabelElement | null>(null);
   useEffect(() => {
     if (labelRef.current) {
@@ -223,10 +238,14 @@ const FormGroup = ({
 
   return (
     <FieldContext.Provider value={value}>
-      <FieldRow $direction={direction} $responsive={responsive} $flipAt={flipAt}>
+      <FieldRow
+        $direction={direction}
+        $responsive={responsive}
+        $flipAt={rowFlipAt}
+      >
         <FieldLabelBox
           $width={maxLabelWidth === 0 ? 'max-content' : `${maxLabelWidth}px`}
-          $flipAt={flipAt}
+          $flipAt={rowFlipAt}
         >
           <label
             htmlFor={id}

--- a/src/lib/components/form/Form.component.tsx
+++ b/src/lib/components/form/Form.component.tsx
@@ -7,13 +7,9 @@ import {
   ReactElement,
   ReactNode,
   useContext,
-  useEffect,
-  useRef,
-  useState,
 } from 'react';
 import styled, { css } from 'styled-components';
 import { spacing, Stack, Wrap } from '../../spacing';
-import { convertRemToPixels } from '../../utils';
 import { Box } from '../box/Box';
 import { Icon, IconName } from '../icon/Icon.component';
 import { IconHelp } from '../iconhelper/IconHelper';
@@ -126,69 +122,60 @@ const ScrollArea = styled(BasicPageLayout)`
   overflow-y: auto;
 `;
 
-// Non-responsive layout: a flex row (horizontal) or column (vertical). The label
-// column width comes from measurement (see FormGroup / LabelContext).
-const FieldRow = styled.div<{
-  $direction: 'vertical' | 'horizontal';
-}>`
-  display: flex;
-  align-items: baseline;
-  ${({ $direction }) =>
-    $direction === 'horizontal'
+// A FormSection is always a two-column CSS grid (label track + field track), and
+// each FormGroup is a `subgrid` row — so labels align across the section from
+// content alone, no measurement in either mode. The two modes differ only in the
+// field track and whether the section can flip:
+//   - responsive: field track is fluid (minmax(10rem, 1fr)) and the section flips
+//     to a single stacked column below STACK_BELOW via an `@container` query.
+//   - non-responsive: field track hugs its content (max-content) and never flips.
+const SectionGrid = styled.div<{ $labelTrack: string; $responsive: boolean }>`
+  display: grid;
+  column-gap: ${spacing.r32};
+  row-gap: ${spacing.r12};
+  ${({ $labelTrack, $responsive }) =>
+    $responsive
       ? css`
-          flex-direction: row;
-          gap: ${spacing.r32};
+          grid-template-columns: ${$labelTrack} minmax(
+              ${FIELD_MIN_REM}rem,
+              1fr
+            );
+
+          @container responsive (max-width: ${STACK_BELOW}) {
+            grid-template-columns: 1fr;
+            /* Stacked groups need more separation than side-by-side rows: each
+               group is now two lines (label over field), so widen the gap. */
+            row-gap: ${spacing.r20};
+          }
         `
       : css`
-          flex-direction: column;
-          gap: ${spacing.r4};
+          grid-template-columns: ${$labelTrack} max-content;
         `}
 `;
 
-const FieldLabelBox = styled.div<{ $width: string }>`
-  width: ${({ $width }) => $width};
-  flex: none;
-  overflow-wrap: break-word;
-`;
-
-// Responsive layout: the FormSection grid. Every FormGroup subgrid row borrows
-// these two tracks, so labels align across the section with no measurement. The
-// label track hugs its content (or is frozen by `forceLabelWidth`); the field
-// track carries the field floor. Below STACK_BELOW the whole section stacks.
-const SectionGrid = styled.div<{ $labelTrack: string }>`
-  display: grid;
-  grid-template-columns:
-    ${({ $labelTrack }) => $labelTrack}
-    minmax(${FIELD_MIN_REM}rem, 1fr);
-  column-gap: ${spacing.r32};
-  row-gap: ${spacing.r12};
-
-  @container responsive (max-width: ${STACK_BELOW}) {
-    grid-template-columns: 1fr;
-    /* Stacked groups need more separation than side-by-side rows: each group is
-       now two lines (label over field), so widen the gap between groups. */
-    row-gap: ${spacing.r20};
-  }
-`;
-
 // A FormGroup as a subgrid row. Horizontal rows inherit the section's two tracks
-// and flip to a single column at STACK_BELOW; vertical rows are always a single
-// column (label stacked above its field).
+// (and, when responsive, flip to a single column at STACK_BELOW); vertical rows
+// are always a single column (label stacked above its field).
 const FieldSubgridRow = styled.div<{
   $direction: 'vertical' | 'horizontal';
+  $responsive: boolean;
 }>`
   display: grid;
   grid-column: 1 / -1;
   row-gap: ${spacing.r4};
-  ${({ $direction }) =>
+  ${({ $direction, $responsive }) =>
     $direction === 'horizontal'
       ? css`
           grid-template-columns: subgrid;
           align-items: baseline;
-
-          @container responsive (max-width: ${STACK_BELOW}) {
-            grid-template-columns: 1fr;
-            align-items: stretch;
+          ${
+            $responsive &&
+            css`
+              @container responsive (max-width: ${STACK_BELOW}) {
+                grid-template-columns: 1fr;
+                align-items: stretch;
+              }
+            `
           }
         `
       : css`
@@ -198,7 +185,6 @@ const FieldSubgridRow = styled.div<{
 
 const GridLabelCell = styled.div<{ $hasHelpTooltip: boolean }>`
   min-width: 0;
-  overflow-wrap: break-word;
   ${({ $hasHelpTooltip }) =>
     $hasHelpTooltip &&
     css`
@@ -209,11 +195,9 @@ const GridLabelCell = styled.div<{ $hasHelpTooltip: boolean }>`
     `}
 `;
 
-const LabelContext = createContext<{
-  maxLabelWidth: number;
-  setMaxLabelWidth: (setter: (value: number) => number) => void;
-  isLabelWidthFixed: boolean;
-} | null>(null);
+// Presence marker so a FormGroup can assert it is rendered inside a FormSection
+// (its `subgrid` row is meaningless without the section grid as its parent).
+const FormSectionContext = createContext<boolean>(false);
 
 const RequireModeContext = createContext<'all' | 'partial'>('partial');
 
@@ -251,37 +235,12 @@ const FormGroup = ({
   helpErrorPosition = 'right',
   disabled,
 }: FormGroupProps) => {
-  const ctxt = useContext(LabelContext);
-  if (!ctxt) {
-    //intentionaly breaking rules of hooks here
-    throw new Error('FormGroup cannot be used outside of FormSection');
-  }
-
-  const { maxLabelWidth, setMaxLabelWidth, isLabelWidthFixed } = ctxt;
+  const insideSection = useContext(FormSectionContext);
   const requireMode = useContext(RequireModeContext);
   const { responsive } = useContext(FormResponsiveContext);
-  const labelRef = useRef<HTMLLabelElement | null>(null);
-  useEffect(() => {
-    // The responsive grid sizes the label column from content (no measurement),
-    // and a fixed (forced) label width never grows to the label either.
-    if (responsive || isLabelWidthFixed) return;
-    if (labelRef.current) {
-      const width = labelRef.current.getBoundingClientRect().width;
-      setMaxLabelWidth((currentMaxLabelWidth) => {
-        const additionalWdth = labelHelpTooltip ? convertRemToPixels(2) : 0;
-        if (width + additionalWdth > currentMaxLabelWidth) {
-          return width + additionalWdth;
-        }
-        return currentMaxLabelWidth;
-      });
-    }
-  }, [
-    labelRef,
-    labelHelpTooltip,
-    setMaxLabelWidth,
-    isLabelWidthFixed,
-    responsive,
-  ]);
+  if (!insideSection) {
+    throw new Error('FormGroup cannot be used outside of FormSection');
+  }
 
   const value = {
     disabled: disabled || false,
@@ -293,7 +252,6 @@ const FormGroup = ({
     <label
       htmlFor={id}
       id={`${LABEL_PREFIX}${id}`}
-      ref={labelRef}
       style={{ opacity: disabled ? 0.5 : 1 }}
     >
       <Text>
@@ -339,29 +297,14 @@ const FormGroup = ({
     </Stack>
   );
 
-  if (responsive) {
-    return (
-      <FieldContext.Provider value={value}>
-        <FieldSubgridRow $direction={direction}>
-          <GridLabelCell $hasHelpTooltip={!!labelHelpTooltip}>
-            {labelContent}
-          </GridLabelCell>
-          {fieldContent}
-        </FieldSubgridRow>
-      </FieldContext.Provider>
-    );
-  }
-
   return (
     <FieldContext.Provider value={value}>
-      <FieldRow $direction={direction}>
-        <FieldLabelBox
-          $width={maxLabelWidth === 0 ? 'max-content' : `${maxLabelWidth}px`}
-        >
+      <FieldSubgridRow $direction={direction} $responsive={responsive}>
+        <GridLabelCell $hasHelpTooltip={!!labelHelpTooltip}>
           {labelContent}
-        </FieldLabelBox>
+        </GridLabelCell>
         {fieldContent}
-      </FieldRow>
+      </FieldSubgridRow>
     </FieldContext.Provider>
   );
 };
@@ -379,31 +322,27 @@ const FormSection = ({
   forceLabelWidth,
   rightActions,
 }: FormSectionProps) => {
-  // `forceLabelWidth` is a hard cap: when set, the label column stays exactly
-  // that wide and label measurement never grows it (long labels wrap), mirroring
-  // how `Input`'s `size` fixes the field width. When unset, the column auto-sizes
-  // to the widest measured label.
-  const isLabelWidthFixed = forceLabelWidth != null;
-  const [measuredLabelWidth, setMaxLabelWidth] = useState<number>(0);
-  const maxLabelWidth = isLabelWidthFixed
-    ? forceLabelWidth
-    : measuredLabelWidth;
   const { responsive } = useContext(FormResponsiveContext);
   //If all the formgroup are not required, add `(optional)` next to form section title.
   const groupNotOptional = Children.toArray(children).find((child) =>
     isValidElement(child) ? child.props.required === true : false,
   );
 
-  // In responsive mode the label column is a grid track, sized from content or
-  // frozen by `forceLabelWidth` (the hard cap).
-  const labelTrack = isLabelWidthFixed
-    ? `${forceLabelWidth}px`
-    : 'minmax(min-content, max-content)';
+  // The label column is a grid track. `forceLabelWidth` is a hard cap that freezes
+  // it (long labels then wrap, mirroring how `Input`'s `size` fixes the field
+  // width). Otherwise it auto-sizes to the widest label from content — the grid
+  // aligns labels across the section, so no measurement is needed. Responsive
+  // lets the track shrink to its longest word (min-content) before the section
+  // flips; non-responsive hugs the widest label (max-content).
+  const labelTrack =
+    forceLabelWidth != null
+      ? `${forceLabelWidth}px`
+      : responsive
+        ? 'minmax(min-content, max-content)'
+        : 'max-content';
 
   return (
-    <LabelContext.Provider
-      value={{ maxLabelWidth, setMaxLabelWidth, isLabelWidthFixed }}
-    >
+    <FormSectionContext.Provider value={true}>
       <Stack direction="vertical" gap="r12">
         {title && (
           <Wrap>
@@ -424,13 +363,11 @@ const FormSection = ({
             <div>{rightActions}</div>
           </Wrap>
         )}
-        {responsive ? (
-          <SectionGrid $labelTrack={labelTrack}>{children}</SectionGrid>
-        ) : (
-          children
-        )}
+        <SectionGrid $labelTrack={labelTrack} $responsive={responsive}>
+          {children}
+        </SectionGrid>
       </Stack>
-    </LabelContext.Provider>
+    </FormSectionContext.Provider>
   );
 };
 

--- a/src/lib/components/form/Form.test.tsx
+++ b/src/lib/components/form/Form.test.tsx
@@ -30,4 +30,32 @@ describe('Form', () => {
 
     expect(onSubmit).toHaveBeenCalled();
   });
+
+  it('still submits and keeps fields usable when responsive and flipAt are enabled', async () => {
+    const onSubmit = jest.fn((e) => e.preventDefault());
+    render(
+      <Form
+        layout={{ kind: 'tab' }}
+        responsive
+        flipAt={480}
+        onSubmit={onSubmit}
+        rightActions={<button type="submit">Submit</button>}
+      >
+        <FormSection>
+          <FormGroup
+            id="name-field"
+            label="Name"
+            content={<input type="text" id="name-field" />}
+          />
+        </FormSection>
+      </Form>,
+    );
+
+    const input = screen.getByRole('textbox');
+    await act(() => userEvent.type(input, 'hello'));
+    expect(input).toHaveValue('hello');
+
+    await act(() => userEvent.click(screen.getByText('Submit')));
+    expect(onSubmit).toHaveBeenCalled();
+  });
 });

--- a/src/lib/components/form/Form.test.tsx
+++ b/src/lib/components/form/Form.test.tsx
@@ -10,9 +10,7 @@ describe('Form', () => {
       <Form
         layout={{ kind: 'page', title: 'Test Form' }}
         onSubmit={onSubmit}
-        rightActions={
-          <button type="submit">Submit</button>
-        }
+        rightActions={<button type="submit">Submit</button>}
       >
         <FormSection>
           <FormGroup
@@ -31,13 +29,12 @@ describe('Form', () => {
     expect(onSubmit).toHaveBeenCalled();
   });
 
-  it('still submits and keeps fields usable when responsive and flipAt are enabled', async () => {
+  it('still submits and keeps fields usable when responsive is enabled', async () => {
     const onSubmit = jest.fn((e) => e.preventDefault());
     render(
       <Form
         layout={{ kind: 'tab' }}
         responsive
-        flipAt={480}
         onSubmit={onSubmit}
         rightActions={<button type="submit">Submit</button>}
       >
@@ -59,9 +56,9 @@ describe('Form', () => {
     expect(onSubmit).toHaveBeenCalled();
   });
 
-  it('keeps the labelled field visible and usable with responsive shrink and flipAt', async () => {
+  it('keeps the labelled field visible and usable with responsive shrink', async () => {
     render(
-      <Form layout={{ kind: 'tab' }} responsive flipAt={400}>
+      <Form layout={{ kind: 'tab' }} responsive>
         <FormSection>
           <FormGroup
             id="email-field"

--- a/src/lib/components/form/Form.test.tsx
+++ b/src/lib/components/form/Form.test.tsx
@@ -58,4 +58,22 @@ describe('Form', () => {
     await act(() => userEvent.click(screen.getByText('Submit')));
     expect(onSubmit).toHaveBeenCalled();
   });
+
+  it('keeps the labelled field visible and usable with responsive shrink and flipAt', async () => {
+    render(
+      <Form layout={{ kind: 'tab' }} responsive flipAt={400}>
+        <FormSection>
+          <FormGroup
+            id="email-field"
+            label="Email"
+            content={<input type="text" id="email-field" />}
+          />
+        </FormSection>
+      </Form>,
+    );
+    expect(screen.getByText('Email')).toBeVisible();
+    const input = screen.getByRole('textbox');
+    await act(() => userEvent.type(input, 'x@y.z'));
+    expect(input).toHaveValue('x@y.z');
+  });
 });

--- a/src/lib/components/inputv2/inputv2.test.tsx
+++ b/src/lib/components/inputv2/inputv2.test.tsx
@@ -1,0 +1,16 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { getWrapper } from '../../testUtils';
+import { Input } from './inputv2';
+
+const { Wrapper } = getWrapper();
+
+describe('Input fluid', () => {
+  it('remains visible and editable when fluid is enabled', async () => {
+    render(<Input id="q" fluid aria-label="Search" />, { wrapper: Wrapper });
+    const input = screen.getByRole('textbox', { name: 'Search' });
+    expect(input).toBeVisible();
+    await userEvent.type(input, 'abc');
+    expect(input).toHaveValue('abc');
+  });
+});

--- a/src/lib/components/inputv2/inputv2.tsx
+++ b/src/lib/components/inputv2/inputv2.tsx
@@ -75,9 +75,16 @@ const InputBorder = styled.div<{
   $disabled: boolean;
   $hasError: boolean;
   $width: string;
+  $fluid: boolean;
 }>`
   box-sizing: border-box;
   width: ${(props) => props.$width};
+  ${(props) =>
+    props.$fluid &&
+    css`
+      max-width: 100%;
+      min-width: 0;
+    `}
   height: ${spacing.r32};
   border: ${spacing.r1} solid
     ${(props) =>
@@ -109,6 +116,7 @@ export type InputProps = {
   rightIconColor?: keyof CoreUITheme;
   size?: InputSize;
   noPlaceholderPrefix?: boolean;
+  fluid?: boolean;
 } & Omit<InputHTMLAttributes<HTMLInputElement>, 'size'>;
 
 export const Input = forwardRef<HTMLInputElement, InputProps>(
@@ -124,6 +132,7 @@ export const Input = forwardRef<HTMLInputElement, InputProps>(
       placeholder,
       size,
       noPlaceholderPrefix,
+      fluid,
       ...inputProps
     },
     ref,
@@ -132,7 +141,9 @@ export const Input = forwardRef<HTMLInputElement, InputProps>(
       isContextAvailable,
       disabled: disabledFromFieldContext,
       error: errorFromFieldContext,
+      responsive: responsiveFromFieldContext,
     } = useFieldContext();
+    const isFluid = !!(fluid || responsiveFromFieldContext);
     placeholder = placeholder
       ? noPlaceholderPrefix
         ? placeholder
@@ -144,6 +155,7 @@ export const Input = forwardRef<HTMLInputElement, InputProps>(
         $disabled={!!(disabled || disabledFromFieldContext)}
         $hasError={!!(error || errorFromFieldContext)}
         $width={convertSizeToRem(size)}
+        $fluid={isFluid}
       >
         <InputContainer
           $isContextAvailable={isContextAvailable}

--- a/stories/form.guideline.mdx
+++ b/stories/form.guideline.mdx
@@ -18,17 +18,18 @@ error text, and a shared actions bar. Fields are grouped with `FormSection` and
 ## Responsive forms
 
 Set `responsive` on the `Form` to make it adapt to the width it is given. It is
-**opt-in and non-breaking**: without the prop the Form keeps its current
-fixed-width, measurement-based layout unchanged.
+**opt-in**: without the prop the Form keeps its fixed-width layout, with fields at
+their `size`-derived widths and no flipping.
 
 `responsive` does two things:
 
 1. **Fluid fields** — a field's `size`-derived width becomes a _preferred_ width
    that shrinks to fit its column (capped at `max-width: 100%`) instead of
    overflowing.
-2. **Auto-flipping layout** — each `FormSection` becomes a two-column grid (a
-   label track and a field track). When the section gets too narrow it flips to a
-   single stacked column, with each field dropping under its own label.
+2. **Auto-flipping layout** — the field track becomes fluid and, when a section
+   gets too narrow, it flips to a single stacked column with each field dropping
+   under its own label. (A section is always laid out on CSS grid; `responsive`
+   only changes the field track and enables the flip.)
 
 <Canvas of={FormStories.ResponsiveForm} />
 
@@ -59,11 +60,38 @@ on the space it actually has — no viewport media queries, no JS resize listene
 
 ### Alignment is per `FormSection`
 
-Labels align within a section, not across the whole Form, because each
-`FormSection` is its own grid scope (its `FormGroup`s are `subgrid` rows). This is
-deliberate: it means a section can be wrapped — e.g. an `Accordion` containing its
-own `FormSection` — without breaking the alignment of the sections around it. Do
-**not** expect labels in one section to line up with labels in another.
+Labels align within a section, not across the whole Form — each `FormSection`
+sizes its own label column. Do **not** expect labels in one section to line up
+with labels in another. This is deliberate: a section can be wrapped (e.g. an
+`Accordion` holding its own `FormSection`) without disturbing the sections around
+it.
+
+### Nesting and non-field content
+
+How a section aligns its labels — and how tolerant it is of nesting — depends on
+whether you set `forceLabelWidth`:
+
+- **With `forceLabelWidth`** (a fixed pixel label column) each `FormGroup` row is
+  self-contained, so you can nest groups inside a wrapper — a `div`, a `Stack`, an
+  `Accordion` — and they stay aligned. This is the robust choice for forms with
+  collapsible or grouped fields.
+- **Without `forceLabelWidth`** the label column auto-sizes to the widest label,
+  shared across rows via CSS `subgrid` — which requires each `FormGroup` to be a
+  **direct child** of the `FormSection`. A group nested inside another element
+  loses its row layout and stacks. Either set `forceLabelWidth`, or give the
+  nested groups their own `FormSection`.
+
+Either way, non-`FormGroup` content dropped straight into a section (a `Banner`,
+an `InfoMessage`, explanatory `Text`) spans the full section width — place it
+freely.
+
+### Freezing the label column
+
+`FormSection`'s `forceLabelWidth` pins the label column to an exact pixel width.
+It is a **hard cap**: a label wider than it wraps rather than widening the column
+(mirroring how an `Input`'s `size` fixes the field width). Beyond fixing the
+width, it also makes the section's rows nesting-robust (see above). Leave it unset
+to let the column auto-size to the widest label.
 
 ### Per-field direction still wins
 

--- a/stories/form.guideline.mdx
+++ b/stories/form.guideline.mdx
@@ -1,0 +1,79 @@
+import { Meta, Canvas } from '@storybook/addon-docs/blocks';
+
+import * as FormStories from './form.stories';
+
+<Meta name="Guideline" of={FormStories} />
+
+<style>{`
+  .sbdocs-content h2 { margin-top: 5rem; }
+  .sbdocs-content h3 { margin-top: 3rem; }
+`}</style>
+
+# Form
+
+`Form` lays out a titled set of fields with consistent label placement, help and
+error text, and a shared actions bar. Fields are grouped with `FormSection` and
+`FormGroup`.
+
+## Responsive forms
+
+Set `responsive` on the `Form` to make it adapt to the width it is given. It is
+**opt-in and non-breaking**: without the prop the Form keeps its current
+fixed-width, measurement-based layout unchanged.
+
+`responsive` does two things:
+
+1. **Fluid fields** — a field's `size`-derived width becomes a _preferred_ width
+   that shrinks to fit its column (capped at `max-width: 100%`) instead of
+   overflowing.
+2. **Auto-flipping layout** — each `FormSection` becomes a two-column grid (a
+   label track and a field track). When the section gets too narrow it flips to a
+   single stacked column, with each field dropping under its own label.
+
+<Canvas of={FormStories.ResponsiveForm} />
+
+Drag the right edge of the framed area in the story above to watch the whole
+section flip between the row and stacked layouts.
+
+### There is no breakpoint prop
+
+The flip is **content-derived, not a magic number you pass in**. A section stacks
+once it can no longer give its columns a readable minimum:
+
+- **field floor — 10rem** (the `1/2` Input size). Below this a field would be too
+  narrow to read, so the section stacks instead of shrinking further.
+- **label floor — ~24ch.** Long labels wrap to about two lines before the section
+  stacks.
+
+Concretely the section stacks below `calc(24ch + 10rem + 2rem)` (label floor +
+field floor + the column gap). These are a readability policy, not a per-field
+measurement — fluid fields carry `min-width: 0`, so there is no intrinsic minimum
+to read off the DOM.
+
+### It responds to its container, not the viewport
+
+A `responsive` Form establishes a CSS containment context
+(`container-type: inline-size`) and its `@container` queries key off **its own
+width**. Put the Form in a narrow panel, drawer, or split view and it flips based
+on the space it actually has — no viewport media queries, no JS resize listeners.
+
+### Alignment is per `FormSection`
+
+Labels align within a section, not across the whole Form, because each
+`FormSection` is its own grid scope (its `FormGroup`s are `subgrid` rows). This is
+deliberate: it means a section can be wrapped — e.g. an `Accordion` containing its
+own `FormSection` — without breaking the alignment of the sections around it. Do
+**not** expect labels in one section to line up with labels in another.
+
+### Per-field direction still wins
+
+`FormGroup`'s `direction` is still honored inside a responsive Form. A
+`horizontal` group participates in the row/stack flip; a `vertical` group is
+always stacked (label above field) at every width.
+
+### Current limitation
+
+Only `Input` honors the fluid width today. `Select`, `SearchInput`, `TextArea`
+and other size-driven content still render at their fixed `size` width inside a
+responsive Form (tracked in **CUI-36**). Prefer `Input`-based fields when building
+a form that needs to shrink cleanly, until the other inputs opt in.

--- a/stories/form.stories.tsx
+++ b/stories/form.stories.tsx
@@ -6,11 +6,16 @@ import {
   FormGroup,
   FormSection,
 } from '../src/lib/components/form/Form.component';
+import { Checkbox } from '../src/lib/components/checkbox/Checkbox.component';
+import { ConstrainedText } from '../src/lib/components/constrainedtext/Constrainedtext.component';
 import { Icon } from '../src/lib/components/icon/Icon.component';
 import { Input } from '../src/lib/components/inputv2/inputv2';
+import { RadioGroup } from '../src/lib/components/radio/RadioGroup.component';
 import { Select } from '../src/lib/components/selectv2/Selectv2.component';
 import { Text } from '../src/lib/components/text/Text.component';
+import { TextArea } from '../src/lib/components/textarea/TextArea.component';
 import { Toggle } from '../src/lib/components/toggle/Toggle.component';
+import { Tooltip } from '../src/lib/components/tooltip/Tooltip.component';
 import { Stack } from '../src/lib/spacing';
 import { iconArgType } from './controls';
 import { Accordion } from '../src/lib/next';
@@ -50,6 +55,11 @@ export default {
     subTitle: {
       control: 'text',
       if: { arg: 'kind', eq: 'page' },
+    },
+    responsive: {
+      control: 'boolean',
+      description:
+        'Makes contained fields fluid and lays each FormSection out as a grid that auto-flips to a stacked column on narrow widths. Only `Input` honors the fluid width today.',
     },
   },
 };
@@ -224,6 +234,178 @@ export const PageForm = {
   },
   args: {
     requireMode: 'partial',
+  },
+};
+
+export const ResponsiveForm = {
+  render: ({ requireMode, responsive }) => {
+    const [analytics, setAnalytics] = useState(true);
+    const [versioning, setVersioning] = useState(false);
+    const [lockMode, setLockMode] = useState('governance');
+
+    return (
+      <div
+        style={{
+          resize: 'horizontal',
+          overflow: 'auto',
+          minWidth: '18rem',
+          maxWidth: '100%',
+          border: '1px dashed #666',
+          height: '40rem',
+        }}
+      >
+        <Form
+          layout={{ kind: 'tab' }}
+          requireMode={requireMode}
+          responsive={responsive}
+          rightActions={
+            <Stack gap={'r16'}>
+              <Button variant="outline" label="Cancel" />
+              <Button
+                variant="primary"
+                label="Save"
+                icon={<Icon name="Save" />}
+              />
+            </Stack>
+          }
+        >
+          <FormSection
+            title={{
+              name: 'Mixed field types',
+              helpTooltip: 'One of every common input, in horizontal rows',
+              icon: 'Node-backend',
+            }}
+            forceLabelWidth={200} // force the label column to 200px wide
+          >
+            <FormGroup
+              direction="horizontal"
+              label="Bucket name"
+              id="bucket-name"
+              labelHelpTooltip="The name of the bucket"
+              content={<Input id="bucket-name" />}
+              help="Optional helper text"
+              required
+            />
+            <FormGroup
+              direction="horizontal"
+              label="Analytics"
+              id="analytics"
+              content={
+                <Checkbox
+                  id="analytics"
+                  label="Enable usage analytics"
+                  checked={analytics}
+                  onChange={() => setAnalytics(!analytics)}
+                />
+              }
+              error="Analytics must be enabled while the trial is active."
+              helpErrorPosition="right"
+              required={false}
+            />
+            <FormGroup
+              direction="horizontal"
+              label="Object Lock Mode"
+              id="lock-mode"
+              labelHelpTooltip="S3 Object Lock Retention"
+              content={
+                <RadioGroup
+                  name="lock-mode"
+                  aria-label="Object Lock Mode"
+                  value={lockMode}
+                  onChange={setLockMode}
+                  options={[
+                    { value: 'governance', label: 'Governance' },
+                    { value: 'compliance', label: 'Compliance' },
+                  ]}
+                />
+              }
+              required
+            />
+            <FormGroup
+              direction="horizontal"
+              label="Versioning"
+              id="versioning"
+              content={
+                <Toggle
+                  name="versioning"
+                  toggle={versioning}
+                  onChange={() => setVersioning(!versioning)}
+                />
+              }
+              required={false}
+            />
+            <FormGroup
+              direction="horizontal"
+              label="Description"
+              id="description"
+              content={
+                <TextArea
+                  id="description"
+                  placeholder="Describe this bucket for other operators"
+                />
+              }
+              help="Shown in the destination console."
+              required={false}
+            />
+          </FormSection>
+
+          <FormSection
+            title={{
+              name: 'Read-only details',
+              helpTooltip:
+                'Text-only fields that display a value, not an input',
+              icon: 'Info-circle',
+            }}
+          >
+            <FormGroup
+              direction="horizontal"
+              label="User Type"
+              id="userType"
+              content={
+                <Text>
+                  <Stack>
+                    <Tooltip overlay={'Remote User'}>
+                      <Icon name="Simple-user" ariaLabel="Remote User" />
+                    </Tooltip>
+                    Remote
+                  </Stack>
+                </Text>
+              }
+              required={false}
+            />
+            <FormGroup
+              direction="horizontal"
+              label="Username"
+              id="username"
+              content={
+                <div style={{ overflow: 'hidden', width: '20.5rem' }}>
+                  <ConstrainedText
+                    text={
+                      <Text>
+                        a-very-long-username-that-will-be-clamped-across-two-lines-when-it-does-not-fit
+                      </Text>
+                    }
+                    lineClamp={2}
+                  />
+                </div>
+              }
+              required={false}
+            />
+            <FormGroup
+              direction="horizontal"
+              label="Created on"
+              id="createdOn"
+              content={<Text>2026-07-17 10:24 UTC</Text>}
+              required={false}
+            />
+          </FormSection>
+        </Form>
+      </div>
+    );
+  },
+  args: {
+    requireMode: 'partial',
+    responsive: true,
   },
 };
 

--- a/stories/form.stories.tsx
+++ b/stories/form.stories.tsx
@@ -442,6 +442,7 @@ export const ResponsiveSizedInputs = {
             direction="horizontal"
             label="Default (size 1)"
             id="w-default"
+            labelHelpTooltip="The help icon reserves ~2rem in the label column"
             content={<Input id="w-default" placeholder="20.5rem" />}
           />
           <FormGroup
@@ -517,6 +518,7 @@ export const ResponsiveWidthlessFields = {
               direction="horizontal"
               label="Tier"
               id="nw-radio"
+              labelHelpTooltip="Determines the feature set available"
               content={
                 <RadioGroup
                   name="nw-radio"
@@ -614,6 +616,70 @@ export const ResponsiveMixedFields = {
     );
   },
   args: { requireMode: 'partial', responsive: true },
+};
+
+// Case 4 — edge cases the layout must survive: a non-FormGroup child dropped
+// straight into a section (a Banner), and a FormGroup nested inside a plain
+// wrapper div. Two sections show the difference the label width makes:
+//   - Fixed label (`forceLabelWidth`): rows are self-sufficient, so the nested
+//     group stays aligned with its siblings; the Banner spans the full width.
+//   - Auto label (no `forceLabelWidth`): rows align via subgrid; the Banner still
+//     spans full width, but the *nested* group can no longer share the section's
+//     columns and drops to a stacked layout — the documented residual. Wrap it in
+//     its own FormSection (or set forceLabelWidth) to keep it aligned.
+export const NestingAndNonFieldContent = {
+  render: ({ requireMode, responsive }) => (
+    <ResizeFrame>
+      <Form
+        layout={{ kind: 'tab' }}
+        requireMode={requireMode}
+        responsive={responsive}
+      >
+        <FormSection
+          title={{ name: 'Fixed label width' }}
+          forceLabelWidth={180}
+        >
+          <FormGroup
+            direction="horizontal"
+            label="Direct child"
+            id="fx-direct"
+            content={<Input id="fx-direct" size="1/2" />}
+          />
+          <Banner variant="base" icon={<Icon name="Info-circle" />}>
+            A non-FormGroup child (this Banner) spans the full section width.
+          </Banner>
+          <div>
+            <FormGroup
+              direction="horizontal"
+              label="Nested in a div"
+              id="fx-nested"
+              content={<Input id="fx-nested" size="1/2" />}
+            />
+          </div>
+        </FormSection>
+        <FormSection title={{ name: 'Auto label width' }}>
+          <FormGroup
+            direction="horizontal"
+            label="Direct child"
+            id="au-direct"
+            content={<Input id="au-direct" size="1/2" />}
+          />
+          <Banner variant="base" icon={<Icon name="Info-circle" />}>
+            A non-FormGroup child (this Banner) spans the full section width.
+          </Banner>
+          <div>
+            <FormGroup
+              direction="horizontal"
+              label="Nested in a div (stacks)"
+              id="au-nested"
+              content={<Input id="au-nested" size="1/2" />}
+            />
+          </div>
+        </FormSection>
+      </Form>
+    </ResizeFrame>
+  ),
+  args: { requireMode: 'partial', responsive: false },
 };
 
 export const AllRequiredPageForm = {
@@ -749,8 +815,8 @@ export const FormWithAccordion = {
               required={false}
             ></FormGroup>
           </FormSection>
-          <FormSection>
-            <Accordion title="Advanced Settings" id="advanced-settings">
+          <Accordion title="Advanced Settings" id="advanced-settings">
+            <FormSection>
               <FormGroup
                 direction="vertical"
                 label="Object Lock Mode"
@@ -809,8 +875,8 @@ export const FormWithAccordion = {
                   </Select>
                 }
               />
-            </Accordion>
-          </FormSection>
+            </FormSection>
+          </Accordion>
         </Form>
       </>
     );

--- a/stories/form.stories.tsx
+++ b/stories/form.stories.tsx
@@ -409,6 +409,213 @@ export const ResponsiveForm = {
   },
 };
 
+// Drag the frame's right edge to narrow the Form. Toggle the `responsive` control
+// to compare the two layout modes on the same fields.
+const ResizeFrame = ({ children }: { children: React.ReactNode }) => (
+  <div
+    style={{
+      resize: 'horizontal',
+      overflow: 'auto',
+      minWidth: '16rem',
+      maxWidth: '100%',
+      border: '1px dashed #666',
+      height: '26rem',
+    }}
+  >
+    {children}
+  </div>
+);
+
+// Case 1 — every field is an `Input`, so each carries a `size`-derived width.
+// Responsive: they shrink to fit the column as you narrow the frame, and their
+// left edges stay aligned. Non-responsive: they keep their fixed width.
+export const ResponsiveSizedInputs = {
+  render: ({ requireMode, responsive }) => (
+    <ResizeFrame>
+      <Form
+        layout={{ kind: 'tab' }}
+        requireMode={requireMode}
+        responsive={responsive}
+      >
+        <FormSection title={{ name: 'Sized inputs', icon: 'Node-backend' }}>
+          <FormGroup
+            direction="horizontal"
+            label="Default (size 1)"
+            id="w-default"
+            content={<Input id="w-default" placeholder="20.5rem" />}
+          />
+          <FormGroup
+            direction="horizontal"
+            label="Two thirds"
+            id="w-23"
+            content={<Input id="w-23" size="2/3" placeholder="14rem" />}
+          />
+          <FormGroup
+            direction="horizontal"
+            label="Half"
+            id="w-12"
+            content={<Input id="w-12" size="1/2" placeholder="10rem" />}
+          />
+          <FormGroup
+            direction="horizontal"
+            label="One third"
+            id="w-13"
+            content={<Input id="w-13" size="1/3" placeholder="6rem" />}
+          />
+        </FormSection>
+      </Form>
+    </ResizeFrame>
+  ),
+  args: { requireMode: 'partial', responsive: true },
+};
+
+// Case 2 — none of these fields set a width (checkbox, toggle, radios, read-only
+// text). They can never overflow: the field column just reserves its floor and
+// the control sits at the start. Use this to sanity-check that a Form built
+// without `Input` behaves in both modes.
+export const ResponsiveWidthlessFields = {
+  render: ({ requireMode, responsive }) => {
+    const [subscribe, setSubscribe] = useState(true);
+    const [active, setActive] = useState(false);
+    const [tier, setTier] = useState('standard');
+    return (
+      <ResizeFrame>
+        <Form
+          layout={{ kind: 'tab' }}
+          requireMode={requireMode}
+          responsive={responsive}
+        >
+          <FormSection
+            title={{ name: 'Width-less fields', icon: 'Info-circle' }}
+          >
+            <FormGroup
+              direction="horizontal"
+              label="Notifications"
+              id="nw-check"
+              content={
+                <Checkbox
+                  id="nw-check"
+                  label="Email me updates"
+                  checked={subscribe}
+                  onChange={() => setSubscribe(!subscribe)}
+                />
+              }
+            />
+            <FormGroup
+              direction="horizontal"
+              label="Active"
+              id="nw-toggle"
+              content={
+                <Toggle
+                  name="nw-toggle"
+                  toggle={active}
+                  onChange={() => setActive(!active)}
+                />
+              }
+            />
+            <FormGroup
+              direction="horizontal"
+              label="Tier"
+              id="nw-radio"
+              content={
+                <RadioGroup
+                  name="nw-radio"
+                  aria-label="Tier"
+                  value={tier}
+                  onChange={setTier}
+                  options={[
+                    { value: 'standard', label: 'Standard' },
+                    { value: 'premium', label: 'Premium' },
+                  ]}
+                />
+              }
+            />
+            <FormGroup
+              direction="horizontal"
+              label="Created on"
+              id="nw-text"
+              content={<Text>2026-07-22 09:14 UTC</Text>}
+            />
+          </FormSection>
+        </Form>
+      </ResizeFrame>
+    );
+  },
+  args: { requireMode: 'partial', responsive: true },
+};
+
+// Case 3 — a mix. `Input` opts into fluid and shrinks; `Select` and a `TextArea`
+// with no explicit width (browser-default size) do NOT yet, so they keep their
+// width and overflow a narrow column in responsive mode (tracked in CUI-36).
+// Narrow the frame to see which fields shrink and which spill.
+export const ResponsiveMixedFields = {
+  render: ({ requireMode, responsive }) => {
+    const [region, setRegion] = useState('');
+    return (
+      <ResizeFrame>
+        <Form
+          layout={{ kind: 'tab' }}
+          requireMode={requireMode}
+          responsive={responsive}
+        >
+          <FormSection title={{ name: 'Mixed widths', icon: 'Node-backend' }}>
+            <FormGroup
+              direction="horizontal"
+              label="Bucket name"
+              id="mx-input"
+              content={<Input id="mx-input" />}
+              help="Input — fluid, shrinks to fit"
+            />
+            <FormGroup
+              direction="horizontal"
+              label="Region"
+              id="mx-select"
+              content={
+                <Select
+                  id="mx-select"
+                  placeholder="Choose a region"
+                  value={region}
+                  onChange={setRegion}
+                >
+                  <Select.Option value="us-east">US East</Select.Option>
+                  <Select.Option value="eu-west">EU West</Select.Option>
+                </Select>
+              }
+              help="Select — fixed width, overflows (CUI-36)"
+            />
+            <FormGroup
+              direction="horizontal"
+              label="Description"
+              id="mx-textarea"
+              content={
+                <TextArea
+                  id="mx-textarea"
+                  placeholder="No width set → browser default"
+                />
+              }
+              help="TextArea — browser-default width, overflows (CUI-36)"
+            />
+            <FormGroup
+              direction="horizontal"
+              label="Confirm"
+              id="mx-check"
+              content={
+                <Checkbox
+                  id="mx-check"
+                  label="I understand"
+                  checked
+                  onChange={() => undefined}
+                />
+              }
+            />
+          </FormSection>
+        </Form>
+      </ResizeFrame>
+    );
+  },
+  args: { requireMode: 'partial', responsive: true },
+};
+
 export const AllRequiredPageForm = {
   ...PageForm,
   args: {


### PR DESCRIPTION
**TL;DR** — Adds an opt-in `responsive` prop to `Form` (and `fluid` to `Input`) so a form adapts in place to the width it's given — fields shrink to fit and the layout auto-flips to stacked when too narrow. Reworks `FormSection` layout to be **`forceLabelWidth`-driven** (self-contained rows when set, auto-sized `subgrid` when unset) and drops the old JS label-measurement.

## Context

Forms in narrow panels/drawers either overflow or need a separate mobile layout. [CUI-32](https://scality.atlassian.net/browse/CUI-32) asked for a form that adapts to its container. Opt-in and non-breaking: without `responsive`, existing forms render as before (see the behavior-change note below for the caveats).

## Approach

**Layout is `forceLabelWidth`-driven, not always `subgrid`.** How a `FormSection` aligns its labels — and how tolerant it is of nesting — depends on whether `forceLabelWidth` is set. This is the core of the design and the reason the old JS label-measurement is gone:

| | engine | label alignment | nesting |
|---|---|---|---|
| **`forceLabelWidth` set** (fixed px) | each `FormGroup` is a **self-contained** 2-col grid (`<px> <field>`), rows stacked in a flex column | shared fixed px | **robust** — a group inside a `div` / `Stack` / `Accordion` stays aligned; each row carries its own column definition |
| **`forceLabelWidth` unset** (auto) | section is a grid, each `FormGroup` a `subgrid` row | auto-sized to widest label, shared via `subgrid` | requires **direct child** (a `subgrid` constraint) — a nested group loses the row and stacks under its label |

The auto (unset) branch adds two grid rules so a section is well-behaved beyond plain `FormGroup`s:
- field track is `minmax(max-content, 1fr)` (not bare `max-content`), so the grid **fills its container** instead of hugging content — otherwise a `grid-column: 1 / -1` child only spans to the last content-sized line, not the edge.
- `& > * { grid-column: 1 / -1 }`, so non-`FormGroup` children dropped into a section (a `Banner`, `InfoMessage`, explanatory `Text`) span the **full section width** in both modes.

**`responsive` is orthogonal** — it doesn't change which strategy above is used, only the field track and whether a section can flip:

| | field track | flip |
|---|---|---|
| **non-responsive** | `max-content` (auto) / field size (fixed) — hugs content | none |
| **responsive** | `minmax(10rem, 1fr)` — fluid | `@container` below `calc(24ch + 10rem + 2rem)` |

**The flip is content-derived — there is no breakpoint prop.** A section stacks once it can no longer give its columns a readable minimum: field floor **10rem** (the `1/2` Input size), label floor **~24ch**. It keys off the Form's *own* width via `container-type: inline-size`, not the viewport.

**Behavior change on the stable (non-responsive) path — what to verify.** Moving non-responsive forms onto the grid engine has visible consequences. All are believed visually equivalent for typical forms, but they touch *every* existing form:
- **Fields share one column** (auto branch, sized to the widest field) instead of each hugging its own content. Identical for all-`Input` forms; width-less content now sits in the shared column.
- `forceLabelWidth` is now a **hard cap** (a label wider than it wraps), where before it was a floor the measurement could grow past.
- A **vertical** `FormGroup` renders a full-row-width stacked label (was constrained to the measured label column).
- An **auto-label section (`forceLabelWidth` unset) with a `FormGroup` nested inside a wrapper** stacks that group instead of aligning it (the `subgrid` direct-child constraint). Setting `forceLabelWidth` on the section fixes it. See *Known limitations*.

**Only `Input` is fluid today.** What happens to a non-`Input` field in a `responsive` Form depends on its own width:

| field content | in a `responsive` Form |
|---|---|
| `Input` (fluid) | shrinks to fit, floored at 10rem |
| checkbox / toggle / radios / read-only `Text` (no width) | safe — never overflows; occupies the field column |
| `Select` / `SearchInput` / `TextArea` (fixed or browser-default width) | keeps its width and **overflows** a narrow column — tracked in **CUI-36** |

## Screenshots

**`responsive` in action** — as the frame narrows, the whole section flips from label-beside-field rows to a stacked single column. No breakpoint prop; the flip is content-derived (`ResponsiveForm` story).

<table>
<tr><th>Wide — label beside field</th><th>Narrow — flipped to stacked</th></tr>
<tr>
<td valign="top"><img src="https://github.com/user-attachments/assets/2faa9319-ec7a-467e-9664-5fc79d71f469" alt="Responsive form at a wide width: each label sits to the left of its field"></td>
<td valign="top"><img src="https://github.com/user-attachments/assets/dad1fe70-4fd1-4466-aa85-aa6059272814" alt="Responsive form at a narrow width: each field has dropped below its label"></td>
</tr>
</table>

**Nesting &amp; non-field content** (`NestingAndNonFieldContent` story) — with `forceLabelWidth` (top section) a `FormGroup` nested inside a `div` stays aligned with the direct-child rows; without it (bottom section) the nested group stacks under its label. A `Banner` dropped straight into a section spans the full width either way.

![Two form sections: the fixed-label section keeps a div-nested field aligned in the label column, the auto-label section stacks the nested field; a Banner spans the full section width in both](https://github.com/user-attachments/assets/1503d836-1a94-42e5-ac6c-1bf2bff886b5)
## 🔧 Usage

Opt in once on the `Form` (every contained `Input` becomes fluid and the section auto-flips):

```tsx
<Form responsive>                                            // ←
  <FormSection>
    <FormGroup id="name" label="Name" content={<Input id="name" size="1/2" />} />
  </FormSection>
</Form>
```

…or make a single `Input` fluid on its own, no `Form` needed:

```tsx
<Input id="q" fluid aria-label="Search" />                   // ←
```

Nesting `FormGroup`s inside a wrapper (`div` / `Stack` / `Accordion`)? Set `forceLabelWidth` on the section so rows stay aligned:

```tsx
<FormSection forceLabelWidth={180}>                          // ←
  <Stack direction="vertical">
    <FormGroup id="a" label="Name" content={<Input id="a" />} />
    <FormGroup id="b" label="Description" content={<Input id="b" />} />
  </Stack>
</FormSection>
```

> Flex ancestors between the Form and the field must allow shrinking (`min-width: 0`) for `responsive` to take effect — documented on the prop.

## Review focus

- 🟡 `form/Form.component.tsx › SectionGrid / FieldSubgridRow / FormGroup` — the layout engine now branches on `forceLabelWidth` (self-contained rows vs. `subgrid`) **and** on `responsive`. Confirm existing non-responsive forms are visually unchanged (the behavior notes above).
- 🟡 `form/Form.component.tsx › FormSection labelTrack` — `forceLabelWidth` became a hard cap; scan for consumers that relied on the label column growing past it.
- ⚪ `form/Form.component.tsx › SectionGrid auto branch` — `minmax(max-content, 1fr)` field track + `& > * { grid-column: 1 / -1 }` so the grid fills its container and non-`FormGroup` children span full width.
- ⚪ `inputv2/inputv2.tsx › InputBorder $fluid` — the `max-width: 100%; min-width: 0` opt-in, driven by `fluid` or the Form's `responsive` via `useFieldContext`.

## How to test

- **Storybook** → **Templates/Form** → `ResponsiveForm` (drag the frame's right edge to watch the row/stacked flip) and `NestingAndNonFieldContent` (a fixed-label section keeps a nested group aligned; an auto-label section stacks it; a `Banner` spans full width in both). Sanity-check `PageForm` / `FormWithAccordion` look unchanged.
- **Jest** — `npx jest src/lib/components/form src/lib/components/inputv2` (fields stay visible/typeable and the Form still submits when `responsive`/`fluid` are set).

## Known limitations

- **`responsive` makes only `Input` fluid.** `Select`, `SearchInput`, `TextArea` (and a horizontal `RadioGroup`) keep their width and overflow a shrinking column — tracked in **CUI-36**. `TextArea` with no `width` prop falls back to the browser default (~20rem), so it overflows too.
- **Auto-label sections with nested groups.** A `FormGroup` nested inside a wrapper under a `FormSection` that has **no** `forceLabelWidth` will stack instead of aligning (the `subgrid` direct-child constraint). Fix: add `forceLabelWidth` to the section. This surfaces in two consumer sections when they next bump `@scality/core-ui`, both a one-line fix: data-browser `BucketNotificationFormPage.tsx` ("Filters" section) and metalk8s `CreateVolume.tsx`. Not a regression until those repos bump.

## References

- **[CUI-32](https://scality.atlassian.net/browse/CUI-32)** — responsive/fluid Form (this PR), incl. the "flex ancestors need `min-width: 0`" rule.
- **[CUI-36](https://scality.atlassian.net/browse/CUI-36)** — follow-up: extend the fluid treatment to `Select` / `SearchInput` / `TextArea` / horizontal `RadioGroup`.

[CUI-32]: https://scality.atlassian.net/browse/CUI-32?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ