### PR TITLE
fix(select): repair Selectv2 menu styling dropped under styled-components v6

### DIFF
--- a/src/lib/components/selectv2/SelectStyle.ts
+++ b/src/lib/components/selectv2/SelectStyle.ts
@@ -152,14 +152,10 @@ const SelectStyle = styled(Select)`
     .sc-select__menu-list {
       padding: 0;
       overflow: hidden;
-      ${({ isDefault }) =>
-        isDefault
-          ? `
-        max-height: calc(${spacing.r32} * ${(props) =>
-              props.itemsPerScrollWindow} + ${spacing.r32} / 2);`
-          : `
-        max-height: calc(${spacing.r24} * ${(props) =>
-              props.itemsPerScrollWindow} + ${spacing.r24} / 2);`}
+      ${({ isDefault, itemsPerScrollWindow }) => {
+        const optionHeight = isDefault ? spacing.r32 : spacing.r24;
+        return `max-height: calc(${optionHeight} * ${itemsPerScrollWindow} + ${optionHeight} / 2);`;
+      }}
 
       .sc-select__menu-notice {
         color: ${({ isDefault }) =>
@@ -250,12 +246,12 @@ const SelectStyle = styled(Select)`
       ${({ isDefault }) =>
         isDefault &&
         `
-          div > .react-window-option:first-of-type > .sc-select__option {
+          div > .react-window-option:first-of-type > .sc-select__option,
           .sc-select__option:first-of-type {
             border-radius: ${spacing.r4} ${spacing.r4} 0 0;
           }
 
-          div > .react-window-option:last-of-type > .sc-select__option {
+          div > .react-window-option:last-of-type > .sc-select__option,
           .sc-select__option:last-of-type {
             border-bottom: ${spacing.r1} solid transparent;
             border-radius: 0 0 ${spacing.r4} ${spacing.r4};


### PR DESCRIPTION
**TL;DR** — The `Selectv2` dropdown menu rendered completely unstyled (white background, plain block-list options) after the styled-components v6 upgrade; this restores its styling with a two-line CSS fix, plus repairs a second latent `max-height` bug in the same block.

## Context

The v6 migration ([#1150](https://github.com/scality/core-ui/pull/1150)) is now on `development/1.0`. Two latent defects in `SelectStyle.ts` that styled-components **v5 silently tolerated** surfaced under v6 — the menu was the visible one, the `max-height` was riding along undetected.

## Approach

### 1. Malformed braces drop the whole menu block (the visible bug)

The `isDefault` option-rounding block opened two selectors with `{` but never closed them — 4 `{` against 2 `}`. styled-components **v6's template flattener discards the entire enclosing `.sc-select__menu` block** when the braces are unbalanced, *before* the CSS ever reaches stylis. So the menu lost its `background-color`, options fell back to `display: block`, and `.sc-tooltip { width: 100% }` was dropped. v5's stylis tolerated the same braces, which is why it only broke after the migration.

The fix joins each double-opened selector into a single comma selector:

**Before:**
```css
div > .react-window-option:first-of-type > .sc-select__option {   /* ← opens a block, never closed */
.sc-select__option:first-of-type {
  border-radius: 4px 4px 0 0;
}
```

**After:**
```css
div > .react-window-option:first-of-type > .sc-select__option,   /* ← one comma-joined selector */
.sc-select__option:first-of-type {
  border-radius: 4px 4px 0 0;
}
```

### 2. `max-height` calc never interpolated `itemsPerScrollWindow`

The `max-height` value nested an arrow function (`(props) => props.itemsPerScrollWindow`) *inside* a template string that was itself returned from an arrow — the inner arrow was never called, so it stringified into a garbage `calc()`. Destructuring `itemsPerScrollWindow` at the outer arrow fixes it. Independent of the brace bug; fixing it alone did **not** restore the menu.

## Screenshots

Default Select (`Components/Inputs/Select` → *Playground*), dropdown open, captured on port 3001 Storybook — the same code before and after the fix:

<img width="868" height="314" alt="select-menu-before-after" src="https://github.com/user-attachments/assets/63e0cc24-70da-4efb-bdea-770e51fae564" />

## Review focus

- 🟡 `SelectStyle.ts › .sc-select__menu isDefault option-rounding` — the brace repair. Low-risk CSS change, but it governs **every** Select's menu rendering, so worth confirming the dropdown looks right for both default and non-default (`isDefault={false}`) variants.
- ⚪ `SelectStyle.ts › .sc-select__menu-list max-height` — arrow destructuring; only affects the scroll-window height when `itemsPerScrollWindow` is set.

## How to test

1. `npm run storybook` → **Components/Inputs/Select**.
2. Open a default Select's dropdown: the menu should have the dark themed background, options laid out with `display: flex`, and rounded corners on the first/last option.
3. `npx jest src/lib/components/selectv2` — 23/23 pass.

## References

- [#1150](https://github.com/scality/core-ui/pull/1150) — `refactor(styled-components): migrate core-ui to styled-components v6` (ARTESCA-17817). The migration that surfaced both defects; v5 tolerated them.