### PR TITLE
fix(Tablev2): reserve layout space for the sort caret

### DIFF
--- a/src/lib/components/tablev2/MultiSelectableContent.tsx
+++ b/src/lib/components/tablev2/MultiSelectableContent.tsx
@@ -8,6 +8,7 @@ import {
   TableBody,
   TableHeader,
   TableRowMultiSelectable,
+  HeaderContent,
 } from './Tablestyle';
 import {
   TableHeightKeyType,
@@ -270,7 +271,7 @@ export const MultiSelectableContent = <
                     }
                   }}
                 >
-                  <div>
+                  <HeaderContent $align={column?.cellStyle?.textAlign}>
                     {column.id === 'selection' ? (
                       <div
                         onClick={(event) => {
@@ -293,7 +294,7 @@ export const MultiSelectableContent = <
                       column.render('Header')
                     )}
                     <SortCaret column={column} />
-                  </div>
+                  </HeaderContent>
                 </TableHeader>
               );
             })}

--- a/src/lib/components/tablev2/SingleSelectableContent.tsx
+++ b/src/lib/components/tablev2/SingleSelectableContent.tsx
@@ -8,6 +8,7 @@ import {
   TableBody,
   TableHeader,
   SortCaret,
+  HeaderContent,
 } from './Tablestyle';
 import {
   TableHeightKeyType,
@@ -205,10 +206,10 @@ export function SingleSelectableContent<
                     }
                   }}
                 >
-                  <div>
+                  <HeaderContent $align={column.cellStyle?.textAlign}>
                     {column.render('Header')}
                     <SortCaret column={column} />
-                  </div>
+                  </HeaderContent>
                 </TableHeader>
               );
             })}

--- a/src/lib/components/tablev2/Tablestyle.tsx
+++ b/src/lib/components/tablev2/Tablestyle.tsx
@@ -1,4 +1,5 @@
 import styled, { css } from 'styled-components';
+import type { CSSProperties } from 'react';
 import {
   TableHeightKeyType,
   tableRowHeight,
@@ -12,11 +13,34 @@ import { spacing } from '../../spacing';
 const borderSize = '4px';
 export const SortIncentive = styled.span`
   position: absolute;
+  inset: 0;
   display: none;
+  align-items: center;
+  justify-content: center;
 `;
+// In-flow so it reserves its own width (never clipped/crowded on tight or
+// centered columns); the hover incentive stays absolute inside it so showing
+// it on hover causes no layout shift.
 export const SortCaretWrapper = styled.span`
-  padding-left: ${spacing.r4};
-  position: absolute;
+  position: relative;
+  display: inline-flex;
+  flex: none;
+  align-items: center;
+  justify-content: center;
+  min-width: ${spacing.r16};
+  margin-left: ${spacing.r4};
+`;
+export const HeaderContent = styled.div<{ $align?: CSSProperties['textAlign'] }>`
+  display: flex;
+  align-items: center;
+  width: 100%;
+  min-width: 0;
+  justify-content: ${(props) =>
+    props.$align === 'right' || props.$align === 'end'
+      ? 'flex-end'
+      : props.$align === 'center'
+        ? 'center'
+        : 'flex-start'};
 `;
 export const TableHeader = styled.div<{
   $headerHeight?: number | string;
@@ -32,7 +56,7 @@ export const TableHeader = styled.div<{
       : 'default'};
   &:hover {
     ${SortIncentive} {
-      display: block;
+      display: flex;
     }
   }
   &:focus-visible {


### PR DESCRIPTION
## TL;DR

The Tablev2 sort caret now reserves its own space in the header layout, so it no longer crowds or clips on centered/right-aligned or narrow columns — and consumers no longer need per-table `paddingRight` hacks to make room for it.

## Context

On a narrow, centered sortable column the caret sat outside the header's own layout: it was cramped against the column edge and could reach the next column's header label. Consumers were working around it per table with a manual `paddingRight`; this fixes the cause in core-ui.

## Approach

The caret was `position: absolute` and reserved **no** width, so `text-align` positioned the label as if the caret weren't there and the caret then spilled past the intended edge — clipped by `HeadRow { overflow: hidden }` on tight columns.

**Before:**
```tsx
export const SortCaretWrapper = styled.span`
  padding-left: ${spacing.r4};
  position: absolute;   // ← reserves no width → clips/crowds
`;
// header inner:
<div>
  {column.render('Header')}
  <SortCaret column={column} />
</div>
```

**After:**
```tsx
export const SortCaretWrapper = styled.span`
  position: relative;          // ← in-flow: reserves its own width
  display: inline-flex;
  min-width: ${spacing.r16};   // ← space held whether sorted or not (no shift when toggling sort)
  margin-left: ${spacing.r4};
`;
export const HeaderContent = styled.div<{ $align?: CSSProperties['textAlign'] }>`
  display: flex; align-items: center; width: 100%; min-width: 0;
  justify-content: ${(p) =>                         // ← alignment from the column's textAlign
    p.$align === 'right' || p.$align === 'end' ? 'flex-end'
    : p.$align === 'center' ? 'center' : 'flex-start'};
`;
// header inner:
<HeaderContent $align={column.cellStyle?.textAlign}>  // ←
  {column.render('Header')}
  <SortCaret column={column} />
</HeaderContent>
```

The label + caret are now in-flow siblings in a flex row aligned by the column's `textAlign`; the caret slot's `min-width` reserves space in both sorted and unsorted states (so toggling sort doesn't shift the header). The hover incentive stays `position: absolute` **inside** the reserved slot, so it still appears on hover with zero layout shift. Applied to both `SingleSelectableContent` and `MultiSelectableContent`.

## Screenshots

<img width="1701" height="642" alt="Before/after on a narrow centered sortable column: the sort caret no longer runs into the next column's header label" src="https://github.com/user-attachments/assets/940ed993-bc05-4799-9c28-8031b45befe6" />

A narrow, centered sortable column (`Health`) next to a left-aligned one, with any per-column `paddingRight` workaround removed so what's on show is core-ui's own behaviour. Measured on the sorted `Health` header at two column widths:

| `Health` column | Caret overhang past its own column | Gap to the next header's label |
| --- | --- | --- |
| 56 px (`maxWidth: 4rem`) | +14 px → **+3 px** | **0 px → 11 px** — the caret was touching the next header |
| 77 px (`maxWidth: 5.5rem`) | +3 px → **-7 px**, fully inside the column | 11 px → **21 px** — a `paddingRight` workaround is no longer needed |

At 56 px the header content (label + reserved slot) needs 59 px, so it still bleeds 3 px into the inter-column gap — a column that narrow is simply too small for "Health" plus a caret. The collision with the neighbouring label is gone either way.

## Review focus

- 🟡 `tablev2/Tablestyle.tsx › SortCaretWrapper, HeaderContent, SortIncentive` — the layout change: in-flow caret with reserved `min-width`, alignment via `$align`, incentive re-centered with `inset: 0` and `display: flex` on hover.
- ⚪ `tablev2/SingleSelectableContent.tsx` / `MultiSelectableContent.tsx` — inner header `<div>` → `HeaderContent` passing `column.cellStyle?.textAlign`.

## How to test

1. `npm run storybook` → a Table story with left/center/right-aligned sortable columns.
2. Sorted centered/right column: caret sits beside the label with room, not clipped.
3. Toggle sort on a column: the header does **not** shift horizontally.
4. Hover an unsorted column: the "Sort" incentive appears in the reserved slot without pushing the label.
5. Narrow column with a long header: the label truncates, the caret stays visible.

## Follow-up

Once released and bumped, consumers that added a per-column `paddingRight` purely to make room for the caret can drop it.

## References

- **ARTESCA-17384** — 4.2 visual inconsistencies; the crowded caret surfaced as part of that table cleanup.
