### PR TITLE
feat(tablev2): allow opting out of the body scroll fade

### DIFF
--- a/src/lib/components/tablev2/TableCommon.tsx
+++ b/src/lib/components/tablev2/TableCommon.tsx
@@ -25,14 +25,19 @@ import useSyncedScroll from './useSyncedScroll';
 import { CSSProperties } from 'styled-components';
 import { UnsuccessfulResult } from '../UnsuccessfulResult.component';
 
-const SmoothScrollDiv = forwardRef<HTMLDivElement, any>((props, ref) => (
-  <div
-    ref={ref}
-    {...props}
-    style={{ ...props.style, scrollBehavior: 'smooth' }}
-    className={['scroll-fade', props.className].filter(Boolean).join(' ')}
-  />
-));
+const SmoothScrollDiv = forwardRef<HTMLDivElement, any>((props, ref) => {
+  const { scrollFade } = useTableContext();
+  return (
+    <div
+      ref={ref}
+      {...props}
+      style={{ ...props.style, scrollBehavior: 'smooth' }}
+      className={[scrollFade && 'scroll-fade', props.className]
+        .filter(Boolean)
+        .join(' ')}
+    />
+  );
+});
 
 type VirtualizedRowsType<
   DATA_ROW extends Record<string, unknown> = Record<string, unknown>,

--- a/src/lib/components/tablev2/Tablev2.component.tsx
+++ b/src/lib/components/tablev2/Tablev2.component.tsx
@@ -105,6 +105,14 @@ export type TableProps<
    * narrow viewports. Opt-in; defaults to `false` (no behaviour change).
    */
   revealDroppedColumns?: boolean;
+  /**
+   * When `true` (default), the virtualized body shows a bottom scroll fade that
+   * hints at more rows and auto-hides once the user reaches the end. Set to
+   * `false` to opt out when the fade is unnecessary or looks out of place
+   * (e.g. tables that never overflow, or those inside an already-faded
+   * container).
+   */
+  scrollFade?: boolean;
   //To call it from the Cell renderer to update the original data
 } & UpdateTableData<DATA_ROW>;
 
@@ -143,6 +151,8 @@ type TableContextType<
   hasScrollbar?: boolean;
   /** Ids of the columns currently hidden by the responsive `dropAt` effect. */
   droppedColumnIds: Set<string>;
+  /** Whether the virtualized body renders the bottom scroll fade. */
+  scrollFade: boolean;
 };
 const TableContext = createContext<TableContextType | null>(null);
 
@@ -219,6 +229,7 @@ function Table<
   status,
   entityName,
   revealDroppedColumns = false,
+  scrollFade = true,
 }: TableProps<DATA_ROW>) {
   sortTypes = {
     health: (row1, row2) => {
@@ -448,6 +459,7 @@ function Table<
     setHasScrollbar,
     hasScrollbar,
     droppedColumnIds,
+    scrollFade,
   };
   return (
     <TableContext.Provider


### PR DESCRIPTION
## TL;DR

Adds a `scrollFade` prop to `Table` so consumers can turn off the bottom scroll fade on the virtualized body. It defaults to `true`, so existing tables are unchanged — pass `scrollFade={false}` to opt out.

## Context

Since #1072 the virtualized table body has *always* applied the bottom `scroll-fade`. That fade is helpful when a table overflows, but looks out of place on tables that never overflow, or ones already sitting inside a faded/scrolling container — with no way to switch it off. This adds that escape hatch.

## Approach

The flag rides the existing `TableContext` (same path as `revealDroppedColumns`) down to `SmoothScrollDiv`, which is the `outerElementType` of the `react-window` list and the only place the `scroll-fade` class is attached. When `scrollFade` is `false` the class is simply omitted:

**Before** — `TableCommon.tsx › SmoothScrollDiv`
```tsx
className={['scroll-fade', props.className].filter(Boolean).join(' ')}   // ←
```

**After**
```tsx
const { scrollFade } = useTableContext();                                 // ←
// ...
className={[scrollFade && 'scroll-fade', props.className]                 // ←
  .filter(Boolean)
  .join(' ')}
```

The `.scroll-fade` CSS utility itself (in `ScrollbarWrapper`) is untouched — this only changes whether the table opts into it.

## 🔧 Usage

Opt out by passing `scrollFade={false}`; omit it (or pass `true`) to keep today's behaviour.

```tsx
<Table
  columns={columns}
  data={data}
  entityName={entityName}
  scrollFade={false}   // ← opt out of the bottom scroll fade
>
  <Table.SingleSelectableContent rowHeight="h40" /* … */ />
</Table>
```

## Review focus

- 🟡 `tablev2/Tablev2.component.tsx` — `scrollFade` added to `TableProps` (default `true`), to `TableContextType` (required), and into the context value. Confirm the default preserves current behaviour everywhere.
- ⚪ `tablev2/TableCommon.tsx › SmoothScrollDiv` — reads `scrollFade` from context and conditionally drops the class. No other consumer of the class.

## How to test

In Storybook (`npm run storybook`), open a **tablev2** story with enough rows to overflow:
1. Default render → bottom fade is present, auto-hiding once scrolled to the end (unchanged).
2. Add `scrollFade={false}` to the `<Table>` → fade is gone; scrolling behaviour otherwise identical.

## References

- #1072 — *Improvement/scroll fade table*: auto-applied the fade to every tablev2 body (the behaviour this PR makes opt-out-able).
- #1071 — added the general-purpose `.scroll-fade` utility on `ScrollbarWrapper` (unchanged here).
- #1075 — prevented the fade from masking the border/scrollbar.