### PR TITLE
fix(accordion): grid-row open animation — no clipping on growth, popovers escape the box (ARTESCA-17819)

### DIFF
--- a/src/lib/components/accordion/Accordion.component.tsx
+++ b/src/lib/components/accordion/Accordion.component.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 
 import { spacing, Stack } from '../../spacing';
 import { Box } from '../box/Box';
@@ -65,10 +65,14 @@ const AccordionContent = styled.div<{
     visibility 0.3s;
 `;
 
-// Clips the content while the row collapses; min-height: 0 lets the grid track
-// shrink below the content's min-content height so it can reach 0.
-const ContentClip = styled.div`
-  overflow: hidden;
+// Clips the content while the row collapses (min-height: 0 lets the grid track
+// shrink to 0). Once open and fully expanded, overflow is released so a child
+// that renders outside the box — a Select menu, dropdown or tooltip — is not
+// clipped by the accordion border (ARTESCA-17819).
+const ContentClip = styled.div<{
+  $isExpanded: boolean;
+}>`
+  overflow: ${(props) => (props.$isExpanded ? 'visible' : 'hidden')};
   min-height: 0;
 `;
 
@@ -86,6 +90,9 @@ export const Accordion = ({
 }: AccordionProps) => {
   const [isOpen, setIsOpen] = useState(open);
   const [previousOpenProp, setPreviousOpenProp] = useState(open);
+  // Gates overflow: true only once the open animation has finished, so the
+  // box still clips while it animates but lets content escape once settled.
+  const [isExpanded, setIsExpanded] = useState(open);
 
   // Sync to the `open` prop when it changes, while still letting the header
   // toggle drive state in between (adjusting state during render, per React docs).
@@ -94,8 +101,28 @@ export const Accordion = ({
     setIsOpen(open);
   }
 
+  useEffect(() => {
+    // Re-clip as soon as the accordion starts closing so nothing spills during
+    // the collapse animation, and so the next open starts clipped again.
+    if (!isOpen) {
+      setIsExpanded(false);
+    }
+  }, [isOpen]);
+
   const handleToggleContent = () => {
     setIsOpen((prev) => !prev);
+  };
+
+  const handleTransitionEnd = (e: React.TransitionEvent<HTMLDivElement>) => {
+    // Only react to this element's own row transition finishing, not a
+    // transition bubbling up from a descendant.
+    if (
+      e.target === e.currentTarget &&
+      e.propertyName === 'grid-template-rows' &&
+      isOpen
+    ) {
+      setIsExpanded(true);
+    }
   };
 
   return (
@@ -125,11 +152,12 @@ export const Accordion = ({
 
       <AccordionContent
         $isOpen={isOpen}
+        onTransitionEnd={handleTransitionEnd}
         id={id}
         aria-labelledby={`Accordion-header-${id}`}
         role="region"
       >
-        <ContentClip>
+        <ContentClip $isExpanded={isOpen && isExpanded}>
           <Wrapper style={style}>{children}</Wrapper>
         </ContentClip>
       </AccordionContent>

--- a/src/lib/components/accordion/Accordion.component.tsx
+++ b/src/lib/components/accordion/Accordion.component.tsx
@@ -1,4 +1,4 @@
-import { useLayoutEffect, useMemo, useRef, useState } from 'react';
+import { useState } from 'react';
 
 import { spacing, Stack } from '../../spacing';
 import { Box } from '../box/Box';
@@ -48,17 +48,30 @@ const AccordionHeader = styled.button<{
   `}
 `;
 
+// Animate open/closed by transitioning a single grid row from 0fr to 1fr.
+// A 1fr track always resolves to the content's current height, so content that
+// grows or shrinks while open follows instantly and is never clipped — no
+// height measurement needed.
 const AccordionContent = styled.div<{
   $isOpen: boolean;
 }>`
-  overflow: hidden;
+  display: grid;
+  grid-template-rows: ${(props) => (props.$isOpen ? '1fr' : '0fr')};
   opacity: ${(props) => (props.$isOpen ? 1 : 0)};
+  visibility: ${(props) => (props.$isOpen ? 'visible' : 'hidden')};
   transition:
-    height 0.3s ease-in,
+    grid-template-rows 0.3s ease-in,
     opacity 0.3s ease-in,
     visibility 0.3s;
-  visibility: ${(props) => (props.$isOpen ? 'visible' : 'hidden')};
 `;
+
+// Clips the content while the row collapses; min-height: 0 lets the grid track
+// shrink below the content's min-content height so it can reach 0.
+const ContentClip = styled.div`
+  overflow: hidden;
+  min-height: 0;
+`;
+
 const Wrapper = styled.div`
   padding: ${spacing.r8} 0 ${spacing.r8} 0;
 `;
@@ -72,44 +85,16 @@ export const Accordion = ({
   isEmphazed = true,
 }: AccordionProps) => {
   const [isOpen, setIsOpen] = useState(open);
-  const contentRef = useRef<HTMLDivElement | null>(null);
-  const wrapperRef = useRef<HTMLDivElement | null>(null);
+  const [previousOpenProp, setPreviousOpenProp] = useState(open);
 
-  useMemo(() => {
+  // Sync to the `open` prop when it changes, while still letting the header
+  // toggle drive state in between (adjusting state during render, per React docs).
+  if (open !== previousOpenProp) {
+    setPreviousOpenProp(open);
     setIsOpen(open);
-  }, [open]);
+  }
 
-  useLayoutEffect(() => {
-    const content = contentRef.current;
-    if (!content) return;
-
-    const syncHeight = () => {
-      content.style.height =
-        isOpen && wrapperRef.current
-          ? `${wrapperRef.current.offsetHeight}px`
-          : '0px';
-    };
-    syncHeight();
-
-    // While open, follow the content height so it is never clipped when it grows
-    // or shrinks (e.g. a responsive Form flipping its fields to a stacked layout).
-    if (
-      !isOpen ||
-      typeof ResizeObserver === 'undefined' ||
-      !wrapperRef.current
-    ) {
-      return;
-    }
-    const observer = new ResizeObserver(syncHeight);
-    observer.observe(wrapperRef.current);
-    return () => observer.disconnect();
-  }, [isOpen, children]);
-
-  const handleToggleContent = (
-    e:
-      | React.MouseEvent<HTMLButtonElement>
-      | React.KeyboardEvent<HTMLButtonElement>,
-  ) => {
+  const handleToggleContent = () => {
     setIsOpen((prev) => !prev);
   };
 
@@ -123,9 +108,6 @@ export const Accordion = ({
           onClick={handleToggleContent}
           aria-controls={id}
           aria-expanded={isOpen}
-          onKeyDown={(e) =>
-            (e.key === 'Enter' || e.key === ' ') && handleToggleContent
-          }
         >
           <Stack direction="horizontal" gap="r8">
             <Icon
@@ -142,15 +124,14 @@ export const Accordion = ({
       </h3>
 
       <AccordionContent
-        ref={contentRef}
         $isOpen={isOpen}
         id={id}
         aria-labelledby={`Accordion-header-${id}`}
         role="region"
       >
-        <Wrapper ref={wrapperRef} style={style}>
-          {children}
-        </Wrapper>
+        <ContentClip>
+          <Wrapper style={style}>{children}</Wrapper>
+        </ContentClip>
       </AccordionContent>
     </AccordionContainer>
   );

--- a/src/lib/components/accordion/Accordion.component.tsx
+++ b/src/lib/components/accordion/Accordion.component.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useState } from 'react';
+import { useLayoutEffect, useMemo, useRef, useState } from 'react';
 
 import { spacing, Stack } from '../../spacing';
 import { Box } from '../box/Box';
@@ -72,10 +72,38 @@ export const Accordion = ({
   isEmphazed = true,
 }: AccordionProps) => {
   const [isOpen, setIsOpen] = useState(open);
+  const contentRef = useRef<HTMLDivElement | null>(null);
+  const wrapperRef = useRef<HTMLDivElement | null>(null);
 
   useMemo(() => {
     setIsOpen(open);
   }, [open]);
+
+  useLayoutEffect(() => {
+    const content = contentRef.current;
+    if (!content) return;
+
+    const syncHeight = () => {
+      content.style.height =
+        isOpen && wrapperRef.current
+          ? `${wrapperRef.current.offsetHeight}px`
+          : '0px';
+    };
+    syncHeight();
+
+    // While open, follow the content height so it is never clipped when it grows
+    // or shrinks (e.g. a responsive Form flipping its fields to a stacked layout).
+    if (
+      !isOpen ||
+      typeof ResizeObserver === 'undefined' ||
+      !wrapperRef.current
+    ) {
+      return;
+    }
+    const observer = new ResizeObserver(syncHeight);
+    observer.observe(wrapperRef.current);
+    return () => observer.disconnect();
+  }, [isOpen, children]);
 
   const handleToggleContent = (
     e:
@@ -114,19 +142,15 @@ export const Accordion = ({
       </h3>
 
       <AccordionContent
-        ref={(element) => {
-          if (isOpen) {
-            element?.style.setProperty('height', element.scrollHeight + 'px');
-          } else {
-            element?.style.setProperty('height', '0px');
-          }
-        }}
+        ref={contentRef}
         $isOpen={isOpen}
         id={id}
         aria-labelledby={`Accordion-header-${id}`}
         role="region"
       >
-        <Wrapper style={style}>{children}</Wrapper>
+        <Wrapper ref={wrapperRef} style={style}>
+          {children}
+        </Wrapper>
       </AccordionContent>
     </AccordionContainer>
   );

--- a/src/lib/components/accordion/Accordion.component.tsx
+++ b/src/lib/components/accordion/Accordion.component.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 
 import { spacing, Stack } from '../../spacing';
 import { Box } from '../box/Box';
@@ -109,21 +109,24 @@ export const Accordion = ({
     }
   }, [isOpen]);
 
-  const handleToggleContent = () => {
+  const handleToggleContent = useCallback(() => {
     setIsOpen((prev) => !prev);
-  };
+  }, []);
 
-  const handleTransitionEnd = (e: React.TransitionEvent<HTMLDivElement>) => {
-    // Only react to this element's own row transition finishing, not a
-    // transition bubbling up from a descendant.
-    if (
-      e.target === e.currentTarget &&
-      e.propertyName === 'grid-template-rows' &&
-      isOpen
-    ) {
-      setIsExpanded(true);
-    }
-  };
+  const handleTransitionEnd = useCallback(
+    (e: React.TransitionEvent<HTMLDivElement>) => {
+      // Only react to this element's own row transition finishing, not a
+      // transition bubbling up from a descendant.
+      if (
+        e.target === e.currentTarget &&
+        e.propertyName === 'grid-template-rows' &&
+        isOpen
+      ) {
+        setIsExpanded(true);
+      }
+    },
+    [isOpen],
+  );
 
   return (
     <AccordionContainer>

--- a/stories/Accordion/accordion.stories.tsx
+++ b/stories/Accordion/accordion.stories.tsx
@@ -6,6 +6,7 @@ import {
   AccordionProps,
 } from '../../src/lib/components/accordion/Accordion.component';
 import { Button } from '../../src/lib/components/buttonv2/Buttonv2.component';
+import { Select } from '../../src/lib/components/selectv2/Selectv2.component';
 import { spacing, Stack } from '../../src/lib/spacing';
 import { Text } from '../../src/lib';
 
@@ -63,6 +64,28 @@ export const Stacked: AccordionStory = {
       <Accordion {...args} />
     </Stack>
   ),
+};
+
+export const WithSelectAtBottom: AccordionStory = {
+  render: (args) => (
+    <Accordion {...args} open>
+      <Stack direction="vertical" gap="r8">
+        <Text>
+          Open the Select below — its menu must overflow past the accordion
+          border and stay fully visible/scrollable (ARTESCA-17819).
+        </Text>
+        <Select id="membership-type" placeholder="Select a value...">
+          <Select.Option value="DN">DN</Select.Option>
+          <Select.Option value="UID">UID</Select.Option>
+          <Select.Option value="CN">CN</Select.Option>
+          <Select.Option value="SAM">sAMAccountName</Select.Option>
+        </Select>
+      </Stack>
+    </Accordion>
+  ),
+  args: {
+    title: 'Advanced Settings',
+  },
 };
 
 export const WithCustomStyle: AccordionStory = {


### PR DESCRIPTION
**TL;DR** — Rewrites the `Accordion` open/collapse animation to a pure-CSS grid-row transition (`0fr → 1fr`) instead of a JS-measured pixel `height`. Content that grows or shrinks after opening is never clipped, and once open the box releases `overflow` so a `Select` menu, dropdown or tooltip can escape the border.

## Context

The Accordion animated open by transitioning an **explicit measured** pixel `height`, measured once at render time (`element.scrollHeight` in a ref callback). Two bugs fell out of that:

| Bug | Cause |
|---|---|
| Content that grows/shrinks after open is clipped | the measured height goes stale on any reflow that fires no React render — a container resize, a `@container` responsive flip |
| A `Select` menu / tooltip opened near the bottom is cut off at the border | `overflow: hidden` (needed to clip the height animation) also clips anything a child legitimately renders outside the box — [ARTESCA-17819] |

This PR absorbs and closes **#1171**, which fixed only the second bug.

## Approach

**Animate a grid row, not a pixel height.** A single-row grid transitioning `grid-template-rows` from `0fr` to `1fr`; a `1fr` track always resolves to the content's *current* height, so growth/shrink is followed instantly with no measurement.

Before:
```tsx
<AccordionContent
  ref={(el) => {                                                    // ←
    el?.style.setProperty('height', isOpen ? el.scrollHeight + 'px' : '0px');
  }}
  $isOpen={isOpen}
>
  <Wrapper>{children}</Wrapper>
</AccordionContent>
// AccordionContent styled: overflow: hidden; transition: height 0.3s;   // ←
```

After:
```tsx
<AccordionContent $isOpen={isOpen} onTransitionEnd={handleTransitionEnd}>
  <ContentClip $isExpanded={isOpen && isExpanded}>                  // ←
    <Wrapper>{children}</Wrapper>
  </ContentClip>
</AccordionContent>
// AccordionContent styled: display: grid; grid-template-rows: 0fr ↔ 1fr;  // ←
// ContentClip styled:      overflow: hidden → visible; min-height: 0;
```

No `ResizeObserver`, no `scrollHeight`, no refs — the whole measurement path is deleted. (Grid-row transitions need Chrome 107 / Firefox 66 / Safari 16, all 2022+.)

**Release overflow once settled (ARTESCA-17819).** The inner `ContentClip` keeps `overflow: hidden` while the row animates, then flips to `visible` once the open transition finishes — gated by an `isExpanded` state set on the element's **own** `grid-template-rows` `transitionEnd` (`e.target === e.currentTarget` so a descendant's bubbled transition can't flip it early), initialized to `open`, and reset on close so the collapse animation clips again.

## How to test

- **Storybook → Accordion → `WithSelectAtBottom`**: open the `Select` near the bottom; its menu overflows past the accordion border and stays fully visible/scrollable.
- Open an accordion whose content changes height *after* opening (e.g. a `responsive` Form that flips to a taller stacked layout as the frame narrows) — the box follows the content; nothing is clipped.
- **Jest** — `npx jest src/lib/components/accordion`

## References

- [ARTESCA-17819] — a `Select` menu opened inside an Accordion is clipped by the box border.
- Supersedes **#1171** (overflow-when-open); its fix is folded in here.

[ARTESCA-17819]: https://scality.atlassian.net/browse/ARTESCA-17819