### PR TITLE
fix(accordion): let content overflow the box once open (ARTESCA-17819)

### DIFF
--- a/src/lib/components/accordion/Accordion.component.tsx
+++ b/src/lib/components/accordion/Accordion.component.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 
 import { spacing, Stack } from '../../spacing';
 import { Box } from '../box/Box';
@@ -50,8 +50,9 @@ const AccordionHeader = styled.button<{
 
 const AccordionContent = styled.div<{
   $isOpen: boolean;
+  $isExpanded: boolean;
 }>`
-  overflow: hidden;
+  overflow: ${(props) => (props.$isOpen && props.$isExpanded ? 'visible' : 'hidden')};
   opacity: ${(props) => (props.$isOpen ? 1 : 0)};
   transition:
     height 0.3s ease-in,
@@ -72,10 +73,17 @@ export const Accordion = ({
   isEmphazed = true,
 }: AccordionProps) => {
   const [isOpen, setIsOpen] = useState(open);
+  const [isExpanded, setIsExpanded] = useState(open);
 
   useMemo(() => {
     setIsOpen(open);
   }, [open]);
+
+  useEffect(() => {
+    if (!isOpen) {
+      setIsExpanded(false);
+    }
+  }, [isOpen]);
 
   const handleToggleContent = (
     e:
@@ -83,6 +91,18 @@ export const Accordion = ({
       | React.KeyboardEvent<HTMLButtonElement>,
   ) => {
     setIsOpen((prev) => !prev);
+  };
+
+  const handleTransitionEnd = (e: React.TransitionEvent<HTMLDivElement>) => {
+    // Only react to this element's own height transition finishing, not a
+    // height transition bubbling up from a descendant.
+    if (
+      e.target === e.currentTarget &&
+      e.propertyName === 'height' &&
+      isOpen
+    ) {
+      setIsExpanded(true);
+    }
   };
 
   return (
@@ -121,7 +141,9 @@ export const Accordion = ({
             element?.style.setProperty('height', '0px');
           }
         }}
+        onTransitionEnd={handleTransitionEnd}
         $isOpen={isOpen}
+        $isExpanded={isExpanded}
         id={id}
         aria-labelledby={`Accordion-header-${id}`}
         role="region"

--- a/stories/Accordion/accordion.stories.tsx
+++ b/stories/Accordion/accordion.stories.tsx
@@ -6,6 +6,7 @@ import {
   AccordionProps,
 } from '../../src/lib/components/accordion/Accordion.component';
 import { Button } from '../../src/lib/components/buttonv2/Buttonv2.component';
+import { Select } from '../../src/lib/components/selectv2/Selectv2.component';
 import { spacing, Stack } from '../../src/lib/spacing';
 import { Text } from '../../src/lib';
 
@@ -63,6 +64,28 @@ export const Stacked: AccordionStory = {
       <Accordion {...args} />
     </Stack>
   ),
+};
+
+export const WithSelectAtBottom: AccordionStory = {
+  render: (args) => (
+    <Accordion {...args} open>
+      <Stack direction="vertical" gap="r8">
+        <Text>
+          Open the Select below — its menu must overflow past the accordion
+          border and stay fully visible/scrollable (ARTESCA-17819).
+        </Text>
+        <Select id="membership-type" placeholder="Select a value...">
+          <Select.Option value="DN">DN</Select.Option>
+          <Select.Option value="UID">UID</Select.Option>
+          <Select.Option value="CN">CN</Select.Option>
+          <Select.Option value="SAM">sAMAccountName</Select.Option>
+        </Select>
+      </Stack>
+    </Accordion>
+  ),
+  args: {
+    title: 'Advanced Settings',
+  },
 };
 
 export const WithCustomStyle: AccordionStory = {


### PR DESCRIPTION
**TL;DR** — Content opened inside an `Accordion` (a `Select` menu, dropdown or tooltip) is no longer clipped by the box: once the accordion has finished opening, its content is allowed to overflow.

## Context

The Accordion animates with `overflow: hidden` so the height transition clips cleanly. But that also clips anything a child legitimately renders outside the box — most visibly a `Select`/dropdown menu opened near the bottom, which got cut off at the accordion border. [ARTESCA-17819](https://scality.atlassian.net/browse/ARTESCA-17819).

## Approach

Keep `overflow: hidden` **only while the open/collapse height transition runs** (so the animation still clips), then flip to `overflow: visible` once opening is done:

- an `isExpanded` state gates `overflow` and is set on the content's **own** height `transitionEnd` (guarded with `e.target === e.currentTarget` so a descendant's bubbled height transition doesn't flip it early);
- `isExpanded` initializes to `open`, so an **initially-open** accordion is visible from mount and never depends on a transition that wouldn't fire on first paint;
- closing resets `isExpanded`, so the collapse animation clips again.

## ⚠️ Merge note — reconcile with #1170

This PR and **#1170 (`fix(accordion): follow content height`)** both touch the Accordion's `overflow`/height handling but solve different bugs:

| | this PR | #1170 |
|---|---|---|
| menu/popover escapes the box when open | ✅ | ❌ |
| box resizes when content grows/shrinks after open | ❌ (locked height → content spills) | ✅ |

They're complementary — combined, the box follows its content height (nothing spills) **and** overflow is visible (popovers escape). Whoever merges second must integrate both mechanisms rather than let one overwrite the other.

## How to test

- **Storybook** → **Accordion** → `WithSelectAtBottom`: open the `Select` near the bottom; its menu overflows past the accordion border and stays fully visible/scrollable.
- **Jest** — `npx jest src/lib/components/accordion`


[ARTESCA-17819]: https://scality.atlassian.net/browse/ARTESCA-17819?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ