### PR TITLE
improvement(responsive): Select fluid + width-less controls keep size (CUI-36)

### DIFF
--- a/src/lib/components/form/Form.component.tsx
+++ b/src/lib/components/form/Form.component.tsx
@@ -339,7 +339,20 @@ const FormGroup = ({
     <Stack
       direction={helpErrorPosition === 'right' ? 'horizontal' : 'vertical'}
       gap={helpErrorPosition === 'right' ? 'r8' : 'r4'}
-      style={responsive ? { minWidth: 0 } : undefined}
+      style={
+        responsive
+          ? {
+              minWidth: 0,
+              // Left-align rather than stretch, so a width-less control (a
+              // TextArea sized only by its `cols`) keeps its intrinsic size in
+              // the fluid `1fr` field column instead of growing to fill it.
+              // Input is unaffected — it caps itself via `max-width: 100%`.
+              ...(helpErrorPosition === 'right'
+                ? {}
+                : { alignItems: 'flex-start' }),
+            }
+          : undefined
+      }
     >
       {content}
       {error ? (

--- a/src/lib/components/form/Form.component.tsx
+++ b/src/lib/components/form/Form.component.tsx
@@ -391,9 +391,11 @@ type FormSectionProps = {
   children: ReactElement<FormGroupProps> | ReactElement<FormGroupProps>[];
   title?: { name: string; icon?: IconName; helpTooltip?: string };
   /**
-   * Freezes the label column to exactly this pixel width — a hard cap: labels
-   * wider than it wrap rather than widening the column. When unset, the column
-   * auto-sizes to the widest label in the section.
+   * Caps the label column at this pixel width: labels wider than it wrap rather
+   * than widening the column. In a `responsive` Form the column keeps this width
+   * while there is room but shrinks below it (down to the longest word) as the
+   * field track is squeezed, so rows stay aligned; otherwise it is pinned to this
+   * exact width. When unset, the column auto-sizes to the widest label.
    */
   forceLabelWidth?: number;
   rightActions?: ReactNode;
@@ -411,20 +413,19 @@ const FormSection = ({
     isValidElement(child) ? child.props.required === true : false,
   );
 
-  // The label column. `forceLabelWidth` is a hard cap that freezes it to an exact
-  // pixel width (long labels then wrap, mirroring how `Input`'s `size` fixes the
-  // field width); it also makes every FormGroup row self-sufficient, so nesting a
-  // group inside another element no longer breaks its layout. When unset, the
-  // column auto-sizes to the widest label from content, shared across rows via
-  // `subgrid` — no measurement. Responsive lets the track shrink to its longest
-  // word (min-content) before the section flips; non-responsive hugs it
-  // (max-content).
+  // The label column. `forceLabelWidth` sets the column's upper bound to an exact
+  // pixel width (labels wider than it wrap, mirroring how `Input`'s `size` fixes
+  // the field width); it also makes every FormGroup row self-sufficient, so nesting
+  // a group inside another element no longer breaks its layout. When unset, the
+  // column's cap is its widest label (`max-content`), shared across rows via
+  // `subgrid` — no measurement. Responsive then lets the column shrink from its
+  // longest word (`min-content`) up to that cap before the section flips;
+  // non-responsive pins it to the cap.
   const fixedLabel = forceLabelWidth != null;
-  const labelTrack = fixedLabel
-    ? `${forceLabelWidth}px`
-    : responsive
-      ? 'minmax(min-content, max-content)'
-      : 'max-content';
+  const labelWidthCap = fixedLabel ? `${forceLabelWidth}px` : 'max-content';
+  const labelTrack = responsive
+    ? `minmax(min-content, ${labelWidthCap})`
+    : labelWidthCap;
 
   return (
     <FormSectionContext.Provider value={{ labelTrack, fixedLabel }}>

--- a/src/lib/components/form/Form.component.tsx
+++ b/src/lib/components/form/Form.component.tsx
@@ -35,9 +35,8 @@ type FormProps = Omit<
    * overflowing. It also lays each `FormSection` out as a two-column grid that
    * auto-flips to a stacked single column on narrow widths — there is no
    * breakpoint prop; the flip point is derived from the layout (see below).
-   * Note: only `Input` currently honors the fluid width — `Select`, `SearchInput`,
-   * `TextArea` and other size-driven content keep their fixed width for now
-   * (tracked in CUI-36).
+   * Note: `Input` and `Select` currently honor the fluid width — `SearchInput`,
+   * `TextArea` and other size-driven content keep their fixed width for now.
    */
   responsive?: boolean;
 };

--- a/src/lib/components/selectv2/SelectStyle.ts
+++ b/src/lib/components/selectv2/SelectStyle.ts
@@ -8,6 +8,7 @@ const SelectStyle = styled(Select)`
   font-size: ${fontSize.base};
   box-sizing: border-box;
   width: ${({ width }) => width};
+  ${({ fluid }) => fluid && `max-width: 100%; min-width: 0;`}
   ${({ isDefault }) =>
     isDefault ? `height: ${spacing.r32}` : `height: ${spacing.r24}`};
 
@@ -122,7 +123,7 @@ const SelectStyle = styled(Select)`
   }
 
   .sc-select__menu {
-    width: ${({ width }) => width};
+    width: ${({ fluid, width }) => (fluid ? '100%' : width)};
     border: ${spacing.r1} solid
       ${({ isDefault }) =>
         getThemePropSelector(isDefault ? 'border' : 'selectedActive')};

--- a/src/lib/components/selectv2/Selectv2.component.tsx
+++ b/src/lib/components/selectv2/Selectv2.component.tsx
@@ -27,6 +27,7 @@ import { FixedSizeList, FixedSizeList as List } from 'react-window';
 import { convertRemToPixels } from '../../utils';
 import { spacing } from '../../spacing';
 import { convertSizeToRem } from '../inputv2/inputv2';
+import { useFieldContext } from '../form/Form.component';
 import { ConstrainedText } from '../constrainedtext/Constrainedtext.component';
 import ReactSelect from 'react-select/src/Select';
 
@@ -348,6 +349,9 @@ export type SelectProps = {
   variant?: 'default' | 'rounded';
   size?: '1' | '2/3' | '1/2' | '1/3';
   className?: string;
+  /** When true (or inside a responsive Form), the control fills its container
+   *  down to a min instead of staying fixed at its `size` width. */
+  fluid?: boolean;
   /** use menuPositon='fixed' inside modal to avoid display issue */
   menuPosition?: 'fixed' | 'absolute';
   /** number of items visible before the option list becomes scrollable
@@ -395,11 +399,14 @@ function SelectBox<
   size = '1',
   id,
   selectRef,
+  fluid,
   itemsPerScrollWindow = 4,
   ...rest
 }: SelectProps & {
   selectRef?: Ref<SelectRef<OptionType, IsMulti, GroupType>>;
 }) {
+  const { responsive: responsiveFromFieldContext } = useFieldContext();
+  const isFluid = !!(fluid || responsiveFromFieldContext);
   const [keyboardFocusEnabled, setKeyboardFocusEnabled] = useState(false);
   const [searchSelection, setSearchSelection] = useState('');
   const [searchValue, setSearchValue] = useState('');
@@ -571,6 +578,7 @@ function SelectBox<
               }
             }}
             width={convertSizeToRem(size)}
+            fluid={isFluid}
             {...rest}
           />
         )}
@@ -599,11 +607,14 @@ const SelectWithOptionContext = forwardRef<
     });
   }, []);
 
-  const contextValue = useMemo(() => ({
-    options, 
-    register, 
-    unregister
-  }), [options, register, unregister]);
+  const contextValue = useMemo(
+    () => ({
+      options,
+      register,
+      unregister,
+    }),
+    [options, register, unregister],
+  );
 
   return (
     <OptionContext.Provider value={contextValue}>


### PR DESCRIPTION
**TL;DR** — Extends the responsive Form treatment beyond `Input`: a `Select` now shrinks to fit its column (and auto-enables inside a `<Form responsive>`), and a width-less control such as a `TextArea` keeps its intrinsic size in the fluid column instead of being stretched to fill it.

## Context

[CUI-32](https://scality.atlassian.net/browse/CUI-32) made `Form`/`Input` responsive but, as documented there, only `Input` was fluid — `Select`, `SearchInput`, `TextArea` kept their width and overflowed a shrinking column. [CUI-36](https://scality.atlassian.net/browse/CUI-36) is the follow-up that closes that gap for the remaining inputs. This PR is rebased onto the merged CUI-32 grid layout (its earlier stacked-on-CUI-32 history was dropped in favor of the final merged version).

## Approach

**`Select` fluid (`selectv2`).** Add a `fluid` prop mirroring `Input`: the size-derived width becomes a *preferred* width (`max-width: 100%; min-width: 0`) that shrinks to fit its column instead of overflowing, and the menu widens to match. `fluid` turns on **automatically** when the Select sits inside a `<Form responsive>` (read from the FormGroup `FieldContext`), so a responsive Form makes its Selects shrink with no per-field prop. Opt-in and non-breaking outside a responsive Form.

**Width-less controls keep their size (`form`).** With `helpErrorPosition="bottom"` the field sits in a vertical Stack whose default `align-items: normal` (stretch) stretched a control sized only by its `cols` (a `TextArea`) to fill the fluid `1fr` column. The field content is now left-aligned in that case, so the control keeps its intrinsic size. `Input` is unaffected (`max-width: 100%`); the horizontal (help-on-right) and non-responsive layouts are untouched.

## Review focus

- 🟡 `selectv2/Selectv2.component.tsx` — `fluid` plumbing + auto-on via `useFieldContext`; confirm a Select outside a responsive Form is unchanged.
- ⚪ `selectv2/SelectStyle.ts` — `fluid` → `max-width: 100%; min-width: 0` and menu `width: 100%`.
- ⚪ `form/Form.component.tsx` — `align-items: flex-start` only in `responsive` + non-`right` help position.

## How to test

- **Storybook** → **Templates/Form** with `responsive` — a `Select` shrinks with the column; a `TextArea` stays at its `cols` size rather than stretching. Sanity-check a plain `Select` (no Form) looks unchanged.
- **Jest** — `npx jest src/lib/components/form src/lib/components/selectv2`

## References

- **[CUI-32](https://scality.atlassian.net/browse/CUI-32)** — responsive/fluid Form + Input (merged, the base for this work).
- **[CUI-36](https://scality.atlassian.net/browse/CUI-36)** — extend fluid to Select / SearchInput / TextArea / horizontal RadioGroup (this PR).


[CUI-32]: https://scality.atlassian.net/browse/CUI-32?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[CUI-36]: https://scality.atlassian.net/browse/CUI-36?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[CUI-32]: https://scality.atlassian.net/browse/CUI-32?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ