### PR TITLE
build(deps): move styled-components to peerDependencies (CUI-37)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -39,7 +39,6 @@
         "react-window": "^1.8.6",
         "recharts": "^3.0.2",
         "remark-gfm": "^4.0.1",
-        "styled-components": "^6.4.3",
         "styled-system": "^5.1.5",
         "uuid": "^14.0.0"
       },
@@ -81,11 +80,13 @@
         "rimraf": "^3.0.0",
         "source-map-explorer": "^2.0.1",
         "storybook": "10.4.6",
+        "styled-components": "^6.4.3",
         "typescript": "^5.3.2"
       },
       "peerDependencies": {
         "react": "^18.0.0 || ^19.0.0",
-        "react-dom": "^18.0.0 || ^19.0.0"
+        "react-dom": "^18.0.0 || ^19.0.0",
+        "styled-components": "^6.4.3"
       }
     },
     "node_modules/@adobe/css-tools": {
@@ -2592,6 +2593,7 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/@emotion/is-prop-valid/-/is-prop-valid-1.4.0.tgz",
       "integrity": "sha512-QgD4fyscGcbbKwJmqNvUMSE02OsHUa+lAWKdEUIJKgqe5IwRSKd7+KhibEWdaKwgjLj0DRSHA9biAIqGBk05lw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@emotion/memoize": "^0.9.0"
@@ -8626,6 +8628,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/camelize/-/camelize-1.0.1.tgz",
       "integrity": "sha512-dU+Tx2fsypxTgtLoE36npi3UqcjSSMNYfkqgmoEhtZrraP5VWq0K7FkWVTYa8eMPtnU/G2txVsfdCJTn9uzpuQ==",
+      "dev": true,
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -9168,6 +9171,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/css-color-keywords/-/css-color-keywords-1.0.0.tgz",
       "integrity": "sha512-FyyrDHZKEjXDpNJYvVsV960FiqQyXc/LlYmsxl2BcdMb2WPx0OGRVgTg55rPSyLSNMqP52R9r8geSp7apN3Ofg==",
+      "dev": true,
       "license": "ISC",
       "engines": {
         "node": ">=4"
@@ -9243,6 +9247,7 @@
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/css-to-react-native/-/css-to-react-native-3.2.0.tgz",
       "integrity": "sha512-e8RKaLXMOFii+02mOlqwjbD00KSEKqblnpO9e++1aXS1fPQOpS1YoqdVHBqPjHNoxeF2mimzVqawm2KCbEdtHQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "camelize": "^1.0.0",
@@ -17703,6 +17708,7 @@
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz",
       "integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/prelude-ls": {
@@ -19843,9 +19849,10 @@
       "license": "MIT"
     },
     "node_modules/styled-components": {
-      "version": "6.4.3",
-      "resolved": "https://registry.npmjs.org/styled-components/-/styled-components-6.4.3.tgz",
-      "integrity": "sha512-wYXrhu+JmDjZ1Tv7O0OopGTfztbzun43Pjjhh2H+xc0h5A09dwpZ5FJbrifJDcL8g5TA9btpWOX2+iSRuJTExw==",
+      "version": "6.4.4",
+      "resolved": "https://registry.npmjs.org/styled-components/-/styled-components-6.4.4.tgz",
+      "integrity": "sha512-tJk5CmKUPMDoTsZQ8m0hHInBk9HFKUPSusqmbBuefDX+yUbMBWea2Ob/wdXFyHW8XZqXkprJscysAdKeGWNqlA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@emotion/is-prop-valid": "1.4.0",
@@ -19878,12 +19885,6 @@
         }
       }
     },
-    "node_modules/styled-components/node_modules/stylis": {
-      "version": "4.3.6",
-      "resolved": "https://registry.npmjs.org/stylis/-/stylis-4.3.6.tgz",
-      "integrity": "sha512-yQ3rwFWRfwNUY7H5vpU0wfdkNSnvnJinhF9830Swlaxl03zsOjCfmX0ugac+3LtK0lYSgwL/KXc8oYL3mG4YFQ==",
-      "license": "MIT"
-    },
     "node_modules/styled-system": {
       "version": "5.1.5",
       "resolved": "https://registry.npmjs.org/styled-system/-/styled-system-5.1.5.tgz",
@@ -19904,6 +19905,13 @@
         "@styled-system/variant": "^5.1.5",
         "object-assign": "^4.1.1"
       }
+    },
+    "node_modules/stylis": {
+      "version": "4.3.6",
+      "resolved": "https://registry.npmjs.org/stylis/-/stylis-4.3.6.tgz",
+      "integrity": "sha512-yQ3rwFWRfwNUY7H5vpU0wfdkNSnvnJinhF9830Swlaxl03zsOjCfmX0ugac+3LtK0lYSgwL/KXc8oYL3mG4YFQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/supports-color": {
       "version": "7.2.0",

--- a/package.json
+++ b/package.json
@@ -23,7 +23,8 @@
   "sideEffects": false,
   "peerDependencies": {
     "react": "^18.0.0 || ^19.0.0",
-    "react-dom": "^18.0.0 || ^19.0.0"
+    "react-dom": "^18.0.0 || ^19.0.0",
+    "styled-components": "^6.4.3"
   },
   "scripts": {
     "analyze": "source-map-explorer 'dist/*.js'",
@@ -82,6 +83,7 @@
     "rimraf": "^3.0.0",
     "source-map-explorer": "^2.0.1",
     "storybook": "10.4.6",
+    "styled-components": "^6.4.3",
     "typescript": "^5.3.2"
   },
   "husky": {
@@ -120,7 +122,6 @@
     "react-window": "^1.8.6",
     "recharts": "^3.0.2",
     "remark-gfm": "^4.0.1",
-    "styled-components": "^6.4.3",
     "styled-system": "^5.1.5",
     "uuid": "^14.0.0"
   },


### PR DESCRIPTION
## What

Move `styled-components` from `dependencies` to `peerDependencies` (matching `react`/`react-dom`), and add it to `devDependencies` so core-ui's own build/test/Storybook still resolve it.

## Why

As a regular `dependency`, npm was free to install a **nested** `node_modules/@scality/core-ui/node_modules/styled-components` in workspace consumers. That second instance yields two `ThemeProvider` contexts, so `useTheme()` returns `undefined` at test/build time — this broke identity-ui's Jest run (140 failures from `Checkbox`/theme consumers).

Making it a peer guarantees a single hoisted instance provided by the consumer, exactly as `react` already works.

### No Module Federation impact
The MF singleton version is negotiated from each consumer's rspack `shared` config (`requiredVersion: deps['styled-components']`, read from the consumer's own package.json), **independent** of core-ui's dependency classification. Runtime behavior is unchanged; this only affects install/build/test-time npm resolution.

### Why the devDependencies entry is required
Peer deps of the root package are not auto-installed for the package's own dev build. `react` survives peer-only here only because Storybook/testing-library pull it in transitively — nothing pulls `styled-components`, so `tsc` fails without the explicit devDep. Verified: peer-only → build fails across ~40 files; with devDep → clean.

## Verification

- **core-ui**: `npm run build` clean, `npm test` → 43 suites / 428 tests pass.
- **Pilots repointed at this branch** (fresh `--legacy-peer-deps` install, cache-clean) — all confirm a single deduped `styled-components@6.4.4`, no nested copy:
  - shell-ui: 92/92 pass
  - metalk8s ui: 220 pass / 2 skip / 3 todo
  - identity-ui: 248 pass (2 pre-existing `GroupsTab` form-logic failures, unrelated — this commit changes only package metadata, not compiled code)

🤖 Generated with [Claude Code](https://claude.com/claude-code)