### PR TITLE
fix(tablev2): keep the sort caret out of the header's intrinsic width

### DIFF
--- a/src/lib/components/tablev2/MultiSelectableContent.tsx
+++ b/src/lib/components/tablev2/MultiSelectableContent.tsx
@@ -5,6 +5,7 @@ import { useTableContext } from './Tablev2.component';
 import {
   HeadRow,
   SortCaret,
+  HeaderLabel,
   TableBody,
   TableHeader,
   TableRowMultiSelectable,
@@ -271,7 +272,10 @@ export const MultiSelectableContent = <
                     }
                   }}
                 >
-                  <HeaderContent $align={column?.cellStyle?.textAlign}>
+                  <HeaderContent
+                    $align={column?.cellStyle?.textAlign}
+                    $sortable={!column.disableSortBy}
+                  >
                     {column.id === 'selection' ? (
                       <div
                         onClick={(event) => {
@@ -291,7 +295,7 @@ export const MultiSelectableContent = <
                         {column.render('Header')}
                       </div>
                     ) : (
-                      column.render('Header')
+                      <HeaderLabel>{column.render('Header')}</HeaderLabel>
                     )}
                     <SortCaret column={column} />
                   </HeaderContent>

--- a/src/lib/components/tablev2/SingleSelectableContent.tsx
+++ b/src/lib/components/tablev2/SingleSelectableContent.tsx
@@ -9,6 +9,7 @@ import {
   TableHeader,
   SortCaret,
   HeaderContent,
+  HeaderLabel,
 } from './Tablestyle';
 import {
   TableHeightKeyType,
@@ -206,8 +207,11 @@ export function SingleSelectableContent<
                     }
                   }}
                 >
-                  <HeaderContent $align={column.cellStyle?.textAlign}>
-                    {column.render('Header')}
+                  <HeaderContent
+                    $align={column.cellStyle?.textAlign}
+                    $sortable={!column.disableSortBy}
+                  >
+                    <HeaderLabel>{column.render('Header')}</HeaderLabel>
                     <SortCaret column={column} />
                   </HeaderContent>
                 </TableHeader>

--- a/src/lib/components/tablev2/Tablestyle.tsx
+++ b/src/lib/components/tablev2/Tablestyle.tsx
@@ -11,6 +11,11 @@ import { FocusVisibleStyle } from '../buttonv2/Buttonv2.component';
 import { spacing } from '../../spacing';
 
 const borderSize = '4px';
+const caretGlyphSize = spacing.r16;
+const caretGutter = spacing.r4;
+// The room HeaderContent reserves so the glyph never overflows its header.
+const caretSpace = spacing.r20;
+
 export const SortIncentive = styled.span`
   position: absolute;
   inset: 0;
@@ -18,29 +23,94 @@ export const SortIncentive = styled.span`
   align-items: center;
   justify-content: center;
 `;
-// In-flow so it reserves its own width (never clipped/crowded on tight or
-// centered columns); the hover incentive stays absolute inside it so showing
-// it on hover causes no layout shift.
-export const SortCaretWrapper = styled.span`
-  position: relative;
+
+/** The painted glyph, out of flow inside the zero-width anchor below. */
+export const SortCaretGlyph = styled.span`
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  width: ${caretGlyphSize};
   display: inline-flex;
-  flex: none;
   align-items: center;
   justify-content: center;
-  min-width: ${spacing.r16};
-  margin-left: ${spacing.r4};
 `;
-export const HeaderContent = styled.div<{ $align?: CSSProperties['textAlign'] }>`
+
+/**
+ * A zero-width flex item. Being a real flex item is what keeps the glyph next to
+ * the label (and lets `order` move it to the label's other side) — anchoring it
+ * to `HeaderContent`'s edge instead would strand it at the far side of a wide
+ * column. Being zero-width is what keeps it out of the sizing equation: a caret
+ * with real width lifts every sortable header's min-content 20px above the
+ * matching body cell's, and the two rows then stop agreeing on column widths as
+ * soon as that floor binds. `HeaderContent` reserves the room with padding.
+ */
+export const SortCaretWrapper = styled.span`
+  position: relative;
+  flex: none;
+  width: 0;
+  align-self: stretch;
+`;
+
+/** Ellipsize rather than let a long header outgrow its column. */
+export const HeaderLabel = styled.span`
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+`;
+
+export const HeaderContent = styled.div<{
+  $align?: CSSProperties['textAlign'];
+  $sortable?: boolean;
+}>`
   display: flex;
   align-items: center;
+  box-sizing: border-box;
   width: 100%;
   min-width: 0;
-  justify-content: ${(props) =>
-    props.$align === 'right' || props.$align === 'end'
-      ? 'flex-end'
-      : props.$align === 'center'
-        ? 'center'
-        : 'flex-start'};
+
+  ${({ $align, $sortable }) => {
+    const isEnd = $align === 'right' || $align === 'end';
+    const isCenter = $align === 'center';
+    const justify = isEnd ? 'flex-end' : isCenter ? 'center' : 'flex-start';
+
+    if (!$sortable) {
+      return css`
+        justify-content: ${justify};
+      `;
+    }
+
+    // End-aligned columns are the one case where the caret goes on the label's
+    // start side: the label has to stay flush with the trailing edge or it no
+    // longer lines up with the values below it, which leaves no room after it.
+    if (isEnd) {
+      return css`
+        justify-content: flex-end;
+        padding-inline-start: ${caretSpace};
+        ${SortCaretWrapper} {
+          order: -1;
+        }
+        ${SortCaretGlyph} {
+          inset-inline-end: ${caretGutter};
+        }
+      `;
+    }
+
+    // Centred columns reserve both sides so the label stays centred.
+    return css`
+      justify-content: ${justify};
+      ${isCenter
+        ? css`
+            padding-inline: ${caretSpace};
+          `
+        : css`
+            padding-inline-end: ${caretSpace};
+          `}
+      ${SortCaretGlyph} {
+        inset-inline-start: ${caretGutter};
+      }
+    `;
+  }}
 `;
 export const TableHeader = styled.div<{
   $headerHeight?: number | string;
@@ -49,6 +119,8 @@ export const TableHeader = styled.div<{
   display: flex;
   flex-direction: column;
   justify-content: center;
+  /* The header must never be the reason a column is wider than its cells. */
+  min-width: 0;
   height: ${(props) => props.$headerHeight};
   cursor: ${(props) =>
     props.tabIndex !== undefined && props.tabIndex >= 0
@@ -187,17 +259,19 @@ export const SortCaret = <
 }) => {
   return !column.disableSortBy ? (
     <SortCaretWrapper>
-      {column.isSorted ? (
-        column.isSortedDesc ? (
-          <Icon name="Sort-down" />
+      <SortCaretGlyph>
+        {column.isSorted ? (
+          column.isSortedDesc ? (
+            <Icon name="Sort-down" />
+          ) : (
+            <Icon name="Sort-up" />
+          )
         ) : (
-          <Icon name="Sort-up" />
-        )
-      ) : (
-        <SortIncentive>
-          <Icon name="Sort" />
-        </SortIncentive>
-      )}
+          <SortIncentive>
+            <Icon name="Sort" />
+          </SortIncentive>
+        )}
+      </SortCaretGlyph>
     </SortCaretWrapper>
   ) : null;
 };

--- a/stories/tablev2.stories.tsx
+++ b/stories/tablev2.stories.tsx
@@ -936,3 +936,131 @@ export const ResponsiveColumnDropWithReveal = {
     </>
   ),
 };
+
+/**
+ * Guards the sort-caret header regression. Two independent defects:
+ *  - a sortable header's min-content is 20px above its body cell's, so the two
+ *    rows stop agreeing on column widths once that floor binds (Reproduction A);
+ *  - an end-aligned header label is pushed off the trailing edge by the caret
+ *    sitting after it (Reproduction B).
+ */
+type Reading = { label: string; mirror: string; value: string };
+
+const readingData: Reading[] = [
+  { label: '27', mirror: '27', value: '27' },
+  { label: '31', mirror: '31', value: '31' },
+];
+
+// Both columns carry the same flex and the same narrow body value; the only
+// difference is sortability. They must resolve to the same width.
+const readingColumns: Column<Reading>[] = [
+  {
+    Header: 'Temperature',
+    accessor: 'label',
+    cellStyle: { width: 'unset', flex: 1, textAlign: 'left' },
+  },
+  {
+    Header: 'Temperature',
+    accessor: 'mirror',
+    cellStyle: { width: 'unset', flex: 1, textAlign: 'left' },
+    disableSortBy: true,
+  },
+];
+
+type Certificate = {
+  name: string;
+  issuer: string;
+  status: string;
+  expireOn: string;
+};
+
+const certificateData: Certificate[] = [
+  {
+    name: 'artesca-ingress',
+    issuer: 'Scality Internal CA',
+    status: 'Valid',
+    expireOn: '2027-01-14',
+  },
+  {
+    name: 'shell-ui-oidc',
+    issuer: "Let's Encrypt X3",
+    status: 'Valid',
+    expireOn: '2026-11-02',
+  },
+];
+
+const certificateColumns: Column<Certificate>[] = [
+  {
+    Header: 'Name',
+    accessor: 'name',
+    cellStyle: { width: 'unset', flex: 1, textAlign: 'left' },
+  },
+  {
+    Header: 'Issuer',
+    accessor: 'issuer',
+    cellStyle: { width: 'unset', flex: 1, textAlign: 'left' },
+    disableSortBy: true,
+  },
+  {
+    Header: 'Status',
+    accessor: 'status',
+    cellStyle: { width: 'unset', flex: 0.75, textAlign: 'center' },
+  },
+  {
+    Header: 'Expire On',
+    accessor: 'expireOn',
+    cellStyle: {
+      width: 'unset',
+      flex: 0.75,
+      textAlign: 'right',
+      paddingRight: '36px',
+    },
+  },
+];
+
+export const SortCaretHeaderAlignment = {
+  render: () => (
+    <>
+      <Title>A — equal flex, sortable vs not, container too narrow for both headers</Title>
+      <div id="repro-a" style={{ height: '120px', width: '220px' }}>
+        <Table
+          columns={readingColumns}
+          data={readingData}
+          defaultSortingKey={'label'}
+        >
+          <Table.SingleSelectableContent
+            rowHeight="h32"
+            separationLineVariant="backgroundLevel3"
+          />
+        </Table>
+      </div>
+      <Title>B — end-aligned and centred sortable headers</Title>
+      <div id="repro-b" style={{ height: '140px' }}>
+        <Table
+          columns={certificateColumns}
+          data={certificateData}
+          defaultSortingKey={'expireOn'}
+        >
+          <Table.SingleSelectableContent
+            rowHeight="h40"
+            separationLineVariant="backgroundLevel3"
+          />
+        </Table>
+      </div>
+      <Title>C — multi selectable, same columns as B</Title>
+      <div id="repro-c" style={{ height: '160px' }}>
+        <Table
+          columns={certificateColumns}
+          data={certificateData}
+          defaultSortingKey={'status'}
+        >
+          <Table.MultiSelectableContent
+            rowHeight="h40"
+            separationLineVariant="backgroundLevel3"
+            onMultiSelectionChanged={action('selection changed')}
+          />
+        </Table>
+      </div>
+    </>
+  ),
+};


### PR DESCRIPTION
**TL;DR** — Sortable `Tablev2` headers have been 20px wider than they should be since 0.226.0, which knocks the header row out of alignment with the body rows below it. The sort caret no longer takes part in that width calculation.

### Context / Why

#1168 gave the sort caret a real, in-flow width so the hover-reveal caret would stop overlapping the header label. It fixed the overlap, but it also made every sortable header 20px wider at its narrowest — so header columns and body columns stop agreeing on widths, and right-aligned headers sit short of the values underneath them. Reported on the ARTESCA Certificates page, where the `Expire On` header visibly fails to line up with its dates.

### 🧩 Approach

The caret is still an in-flow flex item — it has to be, or it can't sit next to the label — but it is now **zero-width**, and `HeaderContent` reserves the room it needs with padding instead.

**Before** — `min-width: 16px` + `margin-left: 4px` means the caret contributes 20px to the header's `min-content`, which the body cell below it doesn't have:

```ts
export const SortCaretWrapper = styled.span`
  position: relative;
  display: inline-flex;
  flex: none;
  align-items: center;
  justify-content: center;
  min-width: ${spacing.r16};   // ←
  margin-left: ${spacing.r4};  // ←
`;
```

**After** — a zero-width anchor holding an out-of-flow glyph, so the caret contributes nothing to `min-content`:

```ts
export const SortCaretWrapper = styled.span`
  position: relative;
  flex: none;
  width: 0;              // ←
  align-self: stretch;
`;

export const SortCaretGlyph = styled.span`
  position: absolute;    // ←
  top: 0;
  bottom: 0;
  width: ${caretGlyphSize};
  display: inline-flex;
  align-items: center;
  justify-content: center;
`;
```

Which side `HeaderContent` reserves follows the column's alignment, because the label has to stay flush with whichever edge its values are flush with:

| `textAlign` | Padding reserved | Caret side |
| --- | --- | --- |
| `right` / `end` | `padding-inline-start` | Start of the label (`order: -1`) |
| `center` | `padding-inline` (both) | End of the label, label stays centred |
| default / `left` | `padding-inline-end` | End of the label |
| *(not sortable)* | none | — |

The caret-before-label case is the one that looks unusual, so worth noting it's the convention: MUI's `TableCell` sets `flex-direction: row-reverse` for `align: 'right'` **only** — no other alignment touches flex-direction — and `TableSortLabel` inherits it while rendering label-then-icon, with the same 4px gutter. Their [issue #21085](https://github.com/mui/material-ui/issues/21085) asking for an explicit position prop was closed *not planned*. We use `order: -1` rather than `row-reverse` because `HeaderContent` computes `justify-content` explicitly and `row-reverse` would invert what `flex-start`/`flex-end` mean.

Verified in Chrome at 1280×900 against a reverted baseline (jsdom doesn't lay out, so this can't be a Jest assertion):

| | Before | After |
| --- | --- | --- |
| Two identical-flex columns, one sortable one not, in a 220px container | header widths **97 / 91** — neither matches the 94px body cell | **94 / 94** — both match |
| Right-aligned sortable header, text right edge vs. the 1198px content edge | **1181** — 17px short | **1198** — flush |
| Caret glyph distance from the label | — | **3px**, inside the header, in every alignment |
| Hovering to reveal the caret | no layout shift | **no layout shift** — #1168's actual goal still holds |

Headers also get `min-width: 0` and an ellipsizing `HeaderLabel`, so a long header truncates rather than becoming the reason a column outgrows its cells.

**This does not fully fix the reported Certificates symptom.** Only ~17px of that ~160px gap was the caret. The rest is a separate, pre-existing defect: body cells ignore `textAlign` entirely, because the default string `Cell` wraps values in `ConstrainedText`, whose container is `display: -webkit-box` and doesn't honour `text-align`. That needs its own ticket and its own PR.

### 📷 Screenshots

<!-- 📷 Before: Storybook › Components/Data Display/Table › Sort Caret Header Alignment, reproduction A — the two 220px "Temperature" columns, showing the sortable header wider than the non-sortable one and both misaligned with the row below. Drag image here. -->
<!-- 📷 After: the same story section, both headers flush with their cells. Drag image here. -->

### 🔍 Review focus

- 🟡 **Moderate** — `src/lib/components/tablev2/Tablestyle.tsx › HeaderContent` — the alignment→padding mapping and the `order: -1` flip apply to every `Tablev2` header. Worth checking the centred case in particular: it reserves 20px on *both* sides unconditionally, which costs a centred sortable column 40px of label space whether or not it's currently sorted.
- 🟡 **Moderate** — `src/lib/components/tablev2/Tablestyle.tsx › HeaderLabel`, `TableHeader` — `min-width: 0` plus `text-overflow: ellipsis` is a behaviour change for callers who pass no new prop: a header that used to force its column wider now truncates instead. Intended, but it's the part most likely to surprise a consumer.
- ⚪ **Minor** — `src/lib/components/tablev2/MultiSelectableContent.tsx` — `HeaderLabel` is deliberately *not* applied to the `selection` branch, so the checkbox keeps its click-handling `div` without inheriting the ellipsis clipping.

### 🧪 How to test

1. `npm run storybook`, then open **Components / Data Display / Table → Sort Caret Header Alignment**.
2. Section **(A)**: the two `Temperature` columns are identically sized and differ only in `disableSortBy`. Both headers should be exactly as wide as, and start at the same x as, the cells beneath them. Before this change the sortable one was 6px wider.
3. Section **(B)**: the right-aligned `Expire On` header text should end flush with the column's right content edge, with the caret to its *left*. (The dates below it will still be left-aligned — that's the separate `ConstrainedText` defect above, not this change.) The centred `Status` header should stay centred.
4. Hover each sortable header — the caret appears and nothing shifts.
5. Section **(C)**: same columns through `MultiSelectableContent`. Note the checkbox column still causes a 12–16px header/body disagreement; that is pre-existing and unchanged by this PR.
6. Regression check on any existing table story (`Tablev2` → the standard examples) — headers should look untouched.

### 🔗 References

- [#1168](https://github.com/scality/core-ui/pull/1168) — *fix(Tablev2): reserve layout space for the sort caret*, the change this regression came from. Its goal (no layout shift on hover-reveal) is preserved.
- [mui/material-ui#21085](https://github.com/mui/material-ui/issues/21085) — MUI's request for an explicit sort-icon position prop, closed *not planned*; the precedent for deriving the caret side from the column alignment.

<details><summary>What changed</summary>

`Tablestyle.tsx` carries the fix: `SortCaretWrapper` becomes a zero-width anchor, the painted glyph moves into a new out-of-flow `SortCaretGlyph`, `HeaderContent` gains a `$sortable` flag and the alignment-driven padding, and a new `HeaderLabel` handles truncation.

`SingleSelectableContent.tsx` and `MultiSelectableContent.tsx` only pass `$sortable` and wrap the rendered header in `HeaderLabel`.

`stories/tablev2.stories.tsx` adds the repro story used for the measurements above. The container widths in it matter: at 400px the caret's 20px floor never binds, so a broken build measures as passing — section (A) uses 220px deliberately.

No public API change: no new props, no changed prop types or defaults.

</details>