### PR TITLE
improvement(spacing): let Stack flip direction from CSS via stackBelow (CUI-38)

### DIFF
--- a/src/lib/spacing.tsx
+++ b/src/lib/spacing.tsx
@@ -1,5 +1,5 @@
 import { Children, HTMLAttributes, HTMLProps, ReactNode } from 'react';
-import styled from 'styled-components';
+import styled, { css } from 'styled-components';
 import { Box, BoxComponentProps } from './components/box/Box';
 
 export const spacing = {
@@ -33,39 +33,89 @@ export const spacing = {
   f40: '40px',
 };
 
-const HSeparator = styled.div`
-  background: ${(props) => props.theme.border};
+// The two separator treatments. A row Stack draws a full-height rule between
+// its children; a column Stack draws a short dash. They are different shapes,
+// not one shape on two axes, so a single element cannot serve both by CSS alone
+// — which is why `stackBelow` below restyles the element rather than relying on
+// the flip.
+const ruleSeparator = css`
   width: 1px;
   align-self: stretch;
   flex-shrink: 0;
-  margin: ${spacing.r12} 0px;
+  margin: ${spacing.r12} 0;
 `;
 
-const VSeparator = styled.div`
-  height: 1px;
+const dashSeparator = css`
   width: ${spacing.r24};
-  background: ${(props) => props.theme.border};
+  height: 1px;
+  align-self: auto;
+  margin: 0;
 `;
 
-const Separator = ({ type }: { type?: 'vertical' | 'horizontal' }) => {
-  return (
-    <>
-      {type === 'horizontal' && <HSeparator>&nbsp;</HSeparator>}
-      {type === 'vertical' && <VSeparator>&nbsp;</VSeparator>}
-    </>
-  );
-};
+// One element for both directions. `Stack` used to pick between two components
+// at render time, which meant a CSS direction change left the separators
+// pointing the wrong way — CSS can restyle an element but cannot swap which one
+// React rendered.
+const Separator = styled.div<{
+  $direction: 'vertical' | 'horizontal';
+  $stackBelow?: number;
+}>`
+  background: ${(props) => props.theme.border};
+  ${(props) =>
+    props.$direction === 'horizontal' ? ruleSeparator : dashSeparator}
+
+  ${(props) =>
+    props.$direction === 'horizontal' &&
+    props.$stackBelow !== undefined &&
+    css`
+      @container responsive (max-width: ${props.$stackBelow}px) {
+        ${dashSeparator}
+      }
+    `}
+`;
+
+// Layout lives here rather than on `Box`'s props so the container query below
+// isn't fighting styled-system output for specificity.
+const StackBox = styled(Box)<{
+  $direction: 'vertical' | 'horizontal';
+  $stackBelow?: number;
+}>`
+  display: flex;
+  flex-direction: ${(props) =>
+    props.$direction === 'horizontal' ? 'row' : 'column'};
+  align-items: ${(props) =>
+    props.$direction === 'horizontal' ? 'center' : 'normal'};
+
+  ${(props) =>
+    props.$direction === 'horizontal' &&
+    props.$stackBelow !== undefined &&
+    css`
+      @container responsive (max-width: ${props.$stackBelow}px) {
+        flex-direction: column;
+        align-items: normal;
+      }
+    `}
+`;
 
 export const Stack = ({
   gap,
   direction,
   withSeparators,
+  stackBelow,
   children,
   ...rest
 }: {
   gap?: keyof typeof spacing;
   direction?: 'vertical' | 'horizontal';
   withSeparators?: boolean;
+  /**
+   * Below this container width (px) a horizontal Stack becomes vertical, and
+   * its separators become the vertical treatment along with it. Requires an
+   * ancestor that establishes the `responsive` container — `<Box container>`.
+   * Without one the query never matches and the Stack stays horizontal.
+   * Ignored when `direction="vertical"`.
+   */
+  stackBelow?: number;
   children: ReactNode[];
   container?: boolean;
 } & HTMLAttributes<HTMLDivElement>) => {
@@ -75,10 +125,9 @@ export const Stack = ({
   const numberOfChildren = Children.count(children);
 
   return (
-    <Box
-      display={'flex'}
-      flexDirection={direction === 'horizontal' ? 'row' : 'column'}
-      alignItems={direction === 'horizontal' ? 'center' : 'normal'}
+    <StackBox
+      $direction={direction}
+      $stackBelow={stackBelow}
       gap={spacing[gap]}
       {...rest}
     >
@@ -87,12 +136,12 @@ export const Stack = ({
           <>
             {node}
             {withSeparators && nodeIndex + 1 !== numberOfChildren && (
-              <Separator type={direction} />
+              <Separator $direction={direction} $stackBelow={stackBelow} />
             )}
           </>
         );
       })}
-    </Box>
+    </StackBox>
   );
 };
 

--- a/stories/spacing.stories.tsx
+++ b/stories/spacing.stories.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { useTheme } from 'styled-components';
+import styled, { useTheme } from 'styled-components';
 import { Icon } from '../src/lib/components/icon/Icon.component';
 import {
   EmphaseText,
@@ -111,6 +111,64 @@ export const StackStory = {
       </>
     );
   },
+};
+
+// `stackBelow` queries the `responsive` container, so an ancestor has to
+// establish one. `<Box container>` does this in app code.
+const ResizableContainer = styled.div`
+  container-type: inline-size;
+  container-name: responsive;
+  resize: horizontal;
+  overflow: auto;
+  min-width: 240px;
+  max-width: 100%;
+  width: 700px;
+  background: ${(props) => props.theme.backgroundLevel2};
+  padding: ${spacing.r16};
+`;
+
+export const StackBelowStory = {
+  name: 'stackBelow — direction follows the container width',
+  render: ({}) => (
+    <>
+      <h2>Drag the bottom-right handle below 500px</h2>
+      <SecondaryText>
+        One prop. The Stack flips from row to column in CSS only — no re-render
+        — and the separators switch from the row treatment (a full-height rule)
+        to the column treatment (a short dash) along with it.
+      </SecondaryText>
+      <ResizableContainer>
+        <Stack withSeparators gap="r24" stackBelow={500}>
+          <Stack gap="r16">
+            <Icon name="Account" size="2x" color="infoPrimary" withWrapper />
+            <Stack direction="vertical" gap="r4">
+              <LargerText>12</LargerText>
+              <SmallerSecondaryText>Accounts</SmallerSecondaryText>
+            </Stack>
+          </Stack>
+          <Stack gap="r16">
+            <Icon name="Bucket" size="2x" color="infoPrimary" withWrapper />
+            <Stack direction="vertical" gap="r4">
+              <LargerText>148</LargerText>
+              <SmallerSecondaryText>Buckets</SmallerSecondaryText>
+            </Stack>
+          </Stack>
+          <Stack gap="r16">
+            <Icon
+              name="Node-backend"
+              size="2x"
+              color="infoPrimary"
+              withWrapper
+            />
+            <Stack direction="vertical" gap="r4">
+              <LargerText>3</LargerText>
+              <SmallerSecondaryText>Endpoints</SmallerSecondaryText>
+            </Stack>
+          </Stack>
+        </Stack>
+      </ResizableContainer>
+    </>
+  ),
 };
 
 export const WrapStory = {


### PR DESCRIPTION
**TL;DR** — `Stack` gains `stackBelow={px}`: below that container width a horizontal Stack becomes vertical, and its separators switch to the vertical treatment along with it. Nothing renders differently today — the prop is opt-in.

### Context / Why

`Stack` picks its separator element from the `direction` **prop, at render time**. A CSS `flex-direction` flip — which is how container-query-driven responsive layouts work — leaves the separators pointing the wrong way. A consuming application hits this the moment it needs a row of columns to collapse into a stack as its container narrows — the row cannot flip, so the content clips silently instead. [CUI-38](https://scality.atlassian.net/browse/CUI-38)

### 🧩 Approach

**This PR replaces an earlier revision that made the row separator self-orienting.** That version used `flex-basis` for the main axis and `align-self` for the cross axis, so a CSS flip turned the rule into a **full-width** one. Design rejected it: a column `Stack` must keep its short dash. The two treatments are different *shapes*, not one shape on two axes — and CSS cannot query a parent's `flex-direction` — so the component has to emit the query itself.

Both treatments now live in one element as two `css` blocks, and `Stack` gains `stackBelow`:

```jsx
const Separator = styled.div`
  background: ${(props) => props.theme.border};
  ${(props) => (props.$direction === 'horizontal' ? ruleSeparator : dashSeparator)}

  ${(props) => props.$stackBelow !== undefined && css`
    @container responsive (max-width: ${props.$stackBelow}px) {
      ${dashSeparator}                 // ←
    }
  `}
`;
```

One element is what makes this possible at all: CSS can restyle an element, but it cannot swap **which** element React rendered.

**This follows a convention the library already has** — a numeric breakpoint the component turns into an `@container responsive` query:

| Component | Prop / constant | Below the width |
| --- | --- | --- |
| `Button` | `iconOnly={number}` | label collapses to icon + tooltip |
| `Form` | `STACK_BELOW` | label/field flip to a stacked column |
| `Stack` | **`stackBelow={number}`** *(new)* | direction flips to vertical |

Without an ancestor establishing that container (`<Box container>`), the query never matches and the `Stack` stays horizontal — the same graceful no-op as `iconOnly`.

**Layout moved off `Box`'s styled-system props onto a `styled(Box)` wrapper** so the container query doesn't have to out-specify them. This is what removes the `&&` specificity hack a consumer previously needed.

#### Verified no-op in both default directions

Rendered the old and new `Stack` side by side with `ServerStyleSheet`, then diffed the **computed declarations per element** (not the raw stylesheet, which differs only in class bookkeeping and rule splitting):

| Default direction | Container | Separator |
| --- | --- | --- |
| `horizontal` | identical (4 declarations) | identical (5 declarations) |
| `vertical` | identical (4 declarations) | `align-self: auto` and `margin: 0` added |

Those two additions are the CSS **initial** values for a flex item, so the computed style is unchanged. They exist only so the shared `dashSeparator` block resets what `ruleSeparator` sets when the container query swaps treatments.

**The `&nbsp;` text nodes are dropped from both separators.** Each treatment sets explicit dimensions, so neither depends on content for its size.

**Why the vertical dash had to stay** — beyond design's ruling, a full-width rule in a page `Form` duplicates the header's own `border-bottom: 1px solid theme.border` (`Form.component.tsx:102`): same weight, same colour, near-same width, so a section separator becomes indistinguishable from the form title's rule.

### 📷 Screenshots

<!-- 📷 Before: Storybook › Components/Styling/Spacing Utils › stackBelow — direction follows the container width, on development/1.0 (story does not exist yet; capture Stack Story › Banner example instead to show the unchanged row treatment) -->
<!-- 📷 After: same story on this branch, container dragged below 500px — the stack is a column and the separators are short dashes, not full-width rules -->

### 🔧 Usage

No existing `Stack` usage changes. What changes is how a consumer opts into a responsive direction — before, they hand-wrote the query and fought `Box` for specificity:

**Before** — what the earlier revision of this PR required:

```jsx
const ResponsiveStack = styled(Stack)`
  @container (max-width: 500px) {
    && {                          // ← doubles specificity to beat Box's flex-direction
      flex-direction: column;
      align-items: stretch;       // ← must be overridden too, separately
    }
  }
`;

<ResponsiveStack withSeparators gap="r24">…</ResponsiveStack>
```

**After** — from the story added in this PR:

```jsx
<Stack withSeparators gap="r24" stackBelow={500}>…</Stack>   // ←
```

Two notes for consumers:
- An ancestor must establish the `responsive` container — `<Box container>`. Without one the query never matches and the Stack stays horizontal.
- `stackBelow` is ignored when `direction="vertical"`. Flipping a vertical Stack to a row in CSS is still unsupported — pre-existing behaviour, unchanged here.

### 🔍 Review focus

- 🟡 **Moderate** — `src/lib/spacing.tsx › StackBox` — layout (`display`, `flex-direction`, `align-items`) moved off `Box`'s styled-system props onto a `styled(Box)` wrapper. This is the change most able to affect existing call sites: every `Stack` in every repo now gets its layout from a different class. The computed-declaration diff above is the evidence it's a no-op; `gap` still comes from `Box`, so the two classes now split what one used to emit.
- 🟡 **Moderate** — `src/lib/spacing.tsx › Separator` — `ruleSeparator`/`dashSeparator` must stay mutually resetting. `dashSeparator` restores `align-self` and `margin` precisely because `ruleSeparator` sets them; dropping either reset silently breaks the flipped state, and container queries don't evaluate in jsdom so no unit test will catch it.
- ⚪ **Minor** — `src/lib/spacing.tsx › Stack` — `stackBelow` is additive and `Separator` was never exported, so **no public API is removed**.

### 🧪 How to test

1. `npm run storybook` → **Components/Styling/Spacing Utils › stackBelow — direction follows the container width**.
2. Drag the container's bottom-right resize handle below 500px. The stack flips to a column and the separators become short dashes; drag back above 500px and they return to full-height rules. Nothing re-renders — only CSS changes.
3. Regression check on **Stack Story**: both the *Banner example* (horizontal) and the *Vertical divided example* must be pixel-identical to `development/1.0`.
4. Same for the vertical production sites under **Templates/Form** (`page-form`, `tab-form`, `form-with-accordion`) — section separators should be unchanged short dashes, still clearly subordinate to the form title's rule.

### 🚧 Follow-up

- Downstream pickup is a normal `@scality/core-ui` version bump once this is released; the integration details live in the consuming application's own ticket.
- The consumer layout that prompted design's ruling on the dash should be reviewed with them in its narrow state before the downstream change merges.
- A vertical `Stack` still can't be flipped to a row in CSS. No consumer needs it today. Not yet ticketed.
- `Wrap` is deliberately untouched — it does not wrap despite its name, deferred pending a usage audit. Not yet ticketed.

### 🔗 References

- [CUI-38](https://scality.atlassian.net/browse/CUI-38) — the ticket still describes the *self-orienting* approach, which design has since rejected. **It needs updating to match this PR.**
- [CUI-39](https://scality.atlassian.net/browse/CUI-39) / #1183 — sibling fix from the same responsive work (`IconWrapper` deforming into an ellipse), **merged**; released in 0.228.0.

<details><summary>What changed</summary>

`src/lib/spacing.tsx` — `HSeparator`/`VSeparator`/`Separator({ type })` collapse into one `Separator` styled component carrying both treatments as `ruleSeparator` and `dashSeparator` `css` blocks. A new `StackBox = styled(Box)` holds the layout so the container query doesn't fight styled-system for specificity. `Stack` gains `stackBelow?: number` and passes it, with `direction`, to both as transient props (verified not to reach the DOM).

`stories/spacing.stories.tsx` — replaces the earlier `ContainerQueryDirectionFlip` story with `StackBelowStory`, which uses the prop instead of a hand-written query. Its container sets `container-name: responsive` explicitly, documenting the requirement.

Deliberately not in this PR: `Wrap` (out of scope per CUI-38), any restyle of existing vertical separators, and any `Form` change.

`tsc --noEmit` clean, `npm run build` clean, `npm run lint` clean, suite green.

</details>


[CUI-38]: https://scality.atlassian.net/browse/CUI-38?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[CUI-38]: https://scality.atlassian.net/browse/CUI-38?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ