### PR TITLE
bugfix(icon): keep IconWrapper circular under flex pressure (CUI-39)

### DIFF
--- a/src/lib/components/icon/Icon.component.tsx
+++ b/src/lib/components/icon/Icon.component.tsx
@@ -159,6 +159,9 @@ export const IconWrapper = styled.div<{ $size: SizeProp }>`
   justify-content: center;
   align-items: center;
   border-radius: 100%;
+  // The width/height above are a fixed square; without this a flex parent under
+  // pressure shrinks the width only, deforming the bordered circle into an ellipse.
+  flex-shrink: 0;
 `;
 
 function NonWrappedIcon({

--- a/stories/icon.stories.tsx
+++ b/stories/icon.stories.tsx
@@ -125,6 +125,31 @@ export const Statuses = {
   },
 };
 
+export const StaysCircularUnderFlexPressure = {
+  name: 'Wrapped icon stays circular when squeezed',
+  render: () => (
+    <div
+      style={{
+        display: 'flex',
+        alignItems: 'center',
+        gap: '0.5rem',
+        resize: 'horizontal',
+        overflow: 'auto',
+        width: '400px',
+        minWidth: '120px',
+        padding: '0.5rem',
+        border: '1px dashed grey',
+      }}
+    >
+      <Icon name="Account" size="2x" color="infoPrimary" withWrapper />
+      <span>
+        Drag the handle to squeeze this row — the bordered circle must not
+        flatten into an ellipse.
+      </span>
+    </div>
+  ),
+};
+
 export const AllIcons = {
   render: () => (
     <table>


### PR DESCRIPTION
**TL;DR** — A wrapped `Icon` no longer squashes into an ellipse when its flex container runs out of room.

### Context / Why

`IconWrapper` sets a fixed rem square per size with a 1px border and no `flex-shrink`, so as a flex item under pressure the browser shrinks its width only and the bordered circle deforms. Visible on the ARTESCA certificates page header below ~700px. [CUI-39](https://scality.atlassian.net/browse/CUI-39)

### 🧩 Approach

`flex-shrink: 0` on `IconWrapper`. Verified in a real browser with a control, squeezing the container from 400px to 150px:

| `IconWrapper` | at 400px | squeezed to 150px | circular? |
| --- | --- | --- | --- |
| `flex-shrink: 0` (this PR) | 60.78 × 60.78 | 60.78 × 60.78 | ✅ |
| `flex-shrink: 1` (before) | 60.78 × 60.78 | **38.73 × 60.78** | ❌ ellipse |

The fix only *prevents* shrinking, so nothing that rendered correctly before can change — an already-square wrapper stays exactly as it was.

### 📷 Screenshots

<!-- 📷 Before: Storybook › Components/Icon › Wrapped icon stays circular when squeezed — drag the resize handle to ~150px; the circle flattens -->
<!-- 📷 After:  same story and width — the circle holds its shape and the text wraps instead -->

### 🔍 Review focus

- ⚪ **Minor** — `src/lib/components/icon/Icon.component.tsx › IconWrapper` — one declaration. It can only stop the wrapper from shrinking below its fixed square; the trade-off is that a very narrow flex container now overflows rather than deforming the icon, which is the intended behaviour for a bordered circle.

### 🧪 How to test

1. `npm run storybook` → **Components/Icon › Wrapped icon stays circular when squeezed**.
2. Drag the dashed box's bottom-right handle to squeeze the row down to ~150px.
3. The bordered circle must keep its shape — the text next to it wraps or clips instead. Before this change it flattened into an ellipse.
4. Sanity check **Components/Icon › Size**: wrapped icons at rest are unchanged.

### 🚧 Follow-up

- After merge + npm release, bump `@scality/core-ui` in `artesca/@artesca/ui/package.json` directly (`@artesca/ui` is built in-repo — not `integrate-components`, not `solutions/*/variable.mk`), which unblocks the ARTESCA certificates responsive ticket.

### 🔗 References

- [CUI-39](https://scality.atlassian.net/browse/CUI-39) — IconWrapper distorts into an ellipse under flex pressure.
- [CUI-38](https://scality.atlassian.net/browse/CUI-38) — sibling core-ui change from the same ARTESCA responsive handoff (self-orienting `Stack` separator). Kept in a separate PR because it needs design sign-off; this one doesn't, so it can merge and release independently.

<details><summary>What changed</summary>

`src/lib/components/icon/Icon.component.tsx` — `flex-shrink: 0` on `IconWrapper`, with a comment recording why (the width/height above it are a fixed square).

`stories/icon.stories.tsx` — adds `StaysCircularUnderFlexPressure`, a resizable flex row so the regression is reproducible by hand.

No API surface change: no prop added, removed or retyped. `npx tsc --noEmit` clean; related Jest tests green (200 passed / 24 suites).

</details>


[CUI-39]: https://scality.atlassian.net/browse/CUI-39?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[CUI-39]: https://scality.atlassian.net/browse/CUI-39?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ