### PR TITLE
bugfix(className): keep the sc-* hook class when a consumer styles a component (CUI-42)

### DIFF
--- a/src/lib/components/breadcrumb/Breadcrumb.component.tsx
+++ b/src/lib/components/breadcrumb/Breadcrumb.component.tsx
@@ -5,8 +5,11 @@ import { fontSize } from '../../style/theme';
 import { Icon } from '../icon/Icon.component';
 type Props = {
   paths: Array<JSX.Element>;
+  className?: string;
 };
-const BreadcrumbContainer = styled.ol`
+const BreadcrumbContainer = styled.ol.withConfig({
+  componentId: 'sc-breadcrumb',
+})`
   display: flex;
   list-style-type: none;
   padding-left: 0;
@@ -91,11 +94,7 @@ const Breadcrumb = ({ paths = [], ...rest }: Props) => {
       );
     })
     .reduce(withBreadcrumbSeparator(lastIndex), []);
-  return (
-    <BreadcrumbContainer className="sc-breadcrumb" {...rest}>
-      {breadcrumbItems}
-    </BreadcrumbContainer>
-  );
+  return <BreadcrumbContainer {...rest}>{breadcrumbItems}</BreadcrumbContainer>;
 };
 
 export { Breadcrumb };

--- a/src/lib/components/buttongroup/ButtonGroup.component.tsx
+++ b/src/lib/components/buttongroup/ButtonGroup.component.tsx
@@ -31,7 +31,9 @@ export type ButtonGroupProps = Omit<
   children: ReactNode;
 };
 
-const ButtonGroupContainer = styled.div<{ $orientation: Orientation }>`
+const ButtonGroupContainer = styled.div.withConfig({
+  componentId: 'sc-button-group',
+})<{ $orientation: Orientation }>`
   display: inline-flex;
   flex-direction: ${(props) =>
     props.$orientation === 'vertical' ? 'column' : 'row'};
@@ -144,12 +146,7 @@ function ButtonGroup({
     : children;
 
   return (
-    <ButtonGroupContainer
-      className="sc-button-group"
-      role="group"
-      $orientation={orientation}
-      {...rest}
-    >
+    <ButtonGroupContainer role="group" $orientation={orientation} {...rest}>
       {items}
     </ButtonGroupContainer>
   );

--- a/src/lib/components/buttonv2/Buttonv2.component.tsx
+++ b/src/lib/components/buttonv2/Buttonv2.component.tsx
@@ -58,7 +58,9 @@ type ButtonStyledTransientProps = {
   $icon?: React.ReactNode;
   $label?: React.ReactNode;
 };
-export const ButtonStyled = styled.button<ButtonStyledTransientProps>`
+export const ButtonStyled = styled.button.withConfig({
+  componentId: 'sc-button',
+})<ButtonStyledTransientProps>`
   -webkit-appearance: none;
   -moz-appearance: none;
   appearance: none;
@@ -373,7 +375,6 @@ function Button({
       overlayStyle={tooltip?.overlayStyle}
     >
       <ButtonStyled
-        className="sc-button"
         $variant={variant}
         disabled={isLoading || disabled}
         $label={label}

--- a/src/lib/components/circularprogressbar/CircularProgressBar.component.style.ts
+++ b/src/lib/components/circularprogressbar/CircularProgressBar.component.style.ts
@@ -2,7 +2,9 @@ import styled from 'styled-components';
 import { spacing } from '../../spacing';
 import { getThemePropSelector } from '../../utils';
 import { EmphaseText } from '../text/Text.component';
-export const CircularProgressBarContainer = styled.div`
+export const CircularProgressBarContainer = styled.div.withConfig({
+  componentId: 'sc-circularprogressbar',
+})`
   display: inline-block;
   color: ${getThemePropSelector('textPrimary')};
 `;

--- a/src/lib/components/circularprogressbar/CircularProgressBar.component.tsx
+++ b/src/lib/components/circularprogressbar/CircularProgressBar.component.tsx
@@ -13,6 +13,7 @@ type Props = {
   color?: string;
   backgroundColor?: string;
   children?: JSX.Element;
+  className?: string;
 };
 
 /**
@@ -52,7 +53,7 @@ function CircularProgressBar({
   const svgSize = centerPointCoordinate * 2;
   const CIRCUMFERENCE = Math.PI * (radius * 2);
   return (
-    <CircularProgressBarContainer className="sc-circularprogressbar" {...rest}>
+    <CircularProgressBarContainer {...rest}>
       {title && <Title>{title}</Title>}
 
       <svg width={svgSize} height={svgSize}>

--- a/src/lib/components/dropdown/Dropdown.component.tsx
+++ b/src/lib/components/dropdown/Dropdown.component.tsx
@@ -32,8 +32,11 @@ type Props = {
    * case. Overrides the label reference the underlying select would set.
    */
   'aria-label'?: string;
+  className?: string;
 };
-const DropdownStyled = styled.div`
+const DropdownStyled = styled.div.withConfig({
+  componentId: 'sc-dropdown',
+})`
   position: relative;
   user-select: none;
   cursor: pointer;
@@ -271,11 +274,7 @@ function Dropdown({
   const { getReferenceProps, getFloatingProps } = useInteractions();
 
   return (
-    <DropdownStyled
-      className="sc-dropdown"
-      {...rest}
-      ref={refs.setReference}
-    >
+    <DropdownStyled {...rest} ref={refs.setReference}>
       <TriggerStyled
         $variant={variant}
         $size={size}

--- a/src/lib/components/error-pages/ErrorPage401.component.tsx
+++ b/src/lib/components/error-pages/ErrorPage401.component.tsx
@@ -1,5 +1,5 @@
 import {
-  ErrorPageContainer,
+  ErrorPage401Container,
   Row,
   Title,
   Description,
@@ -28,6 +28,7 @@ type Props = {
   supportLink?: string;
   locale?: string;
   onReturnHomeClick?: (event: React.MouseEvent<HTMLButtonElement>) => void;
+  className?: string;
 };
 
 function ErrorPage401({
@@ -40,7 +41,7 @@ function ErrorPage401({
   // Ensure the locale formatting is consistent
   locale = locale.toLowerCase();
   return (
-    <ErrorPageContainer className="sc-error-page401" {...rest}>
+    <ErrorPage401Container {...rest}>
       <Row>
         <Icon name="Exclamation-circle" size="2x" color="statusWarning" />
         <Title>{translations[locale].unexpected_error}</Title>
@@ -69,7 +70,7 @@ function ErrorPage401({
           onClick={onReturnHomeClick}
         />
       )}
-    </ErrorPageContainer>
+    </ErrorPage401Container>
   );
 }
 

--- a/src/lib/components/error-pages/ErrorPage404.component.tsx
+++ b/src/lib/components/error-pages/ErrorPage404.component.tsx
@@ -1,5 +1,5 @@
 import {
-  ErrorPageContainer,
+  ErrorPage404Container,
   Row,
   Title,
   Description,
@@ -27,6 +27,7 @@ const translations = {
 type Props = {
   locale?: string;
   onReturnHomeClick?: (event: React.MouseEvent<HTMLButtonElement>) => void;
+  className?: string;
 };
 
 function ErrorPage404({ locale = 'en', onReturnHomeClick, ...rest }: Props) {
@@ -34,7 +35,7 @@ function ErrorPage404({ locale = 'en', onReturnHomeClick, ...rest }: Props) {
   // Ensure the locale formatting is consistent
   locale = locale.toLowerCase();
   return (
-    <ErrorPageContainer className="sc-error-page404" {...rest}>
+    <ErrorPage404Container {...rest}>
       <Row>
         <Icon name="Exclamation-circle" size="2x" color="statusWarning" />
         <Title>{translations[locale].not_exist}</Title>
@@ -56,7 +57,7 @@ function ErrorPage404({ locale = 'en', onReturnHomeClick, ...rest }: Props) {
           onClick={onReturnHomeClick}
         />
       )}
-    </ErrorPageContainer>
+    </ErrorPage404Container>
   );
 }
 

--- a/src/lib/components/error-pages/ErrorPage500.component.tsx
+++ b/src/lib/components/error-pages/ErrorPage500.component.tsx
@@ -1,5 +1,5 @@
 import {
-  ErrorPageContainer,
+  ErrorPage500Container,
   Row,
   Title,
   Description,
@@ -34,6 +34,7 @@ type Props = {
   locale?: string;
   onReturnHomeClick?: (event: React.MouseEvent<HTMLButtonElement>) => void;
   errorMessage?: { en: string; fr: string };
+  className?: string;
 };
 
 function ErrorPage500({
@@ -47,7 +48,7 @@ function ErrorPage500({
   // Ensure the locale formatting is consistent
   locale = locale.toLowerCase();
   return (
-    <ErrorPageContainer className="sc-error-page500" {...rest}>
+    <ErrorPage500Container {...rest}>
       <Row>
         <Icon name="Exclamation-circle" size="2x" color="statusWarning" />
         <Title>{translations[locale].unexpected_error}</Title>
@@ -80,7 +81,7 @@ function ErrorPage500({
           onClick={onReturnHomeClick}
         />
       )}
-    </ErrorPageContainer>
+    </ErrorPage500Container>
   );
 }
 

--- a/src/lib/components/error-pages/ErrorPageAuth.component.tsx
+++ b/src/lib/components/error-pages/ErrorPageAuth.component.tsx
@@ -1,6 +1,6 @@
 import { Icon } from '../icon/Icon.component';
 import {
-  ErrorPageContainer,
+  ErrorPageAuthContainer,
   Row,
   Title,
   Description,
@@ -27,6 +27,7 @@ const translations = {
 type Props = {
   supportLink?: string;
   locale?: string;
+  className?: string;
 };
 
 function ErrorPageAuth({
@@ -38,7 +39,7 @@ function ErrorPageAuth({
   // Ensure the locale formatting is consistent
   locale = locale.toLowerCase();
   return (
-    <ErrorPageContainer className="sc-error-pageauth" {...rest}>
+    <ErrorPageAuthContainer {...rest}>
       <Row>
         <Icon name="Info-circle" size="2x" color="textPrimary" />
         <Title>{translations[locale].unexpected_error}</Title>
@@ -62,7 +63,7 @@ function ErrorPageAuth({
           )}
         </Description>
       </Row>
-    </ErrorPageContainer>
+    </ErrorPageAuthContainer>
   );
 }
 

--- a/src/lib/components/error-pages/ErrorPageStyle.ts
+++ b/src/lib/components/error-pages/ErrorPageStyle.ts
@@ -9,6 +9,19 @@ export const ErrorPageContainer = styled.div`
   align-items: center;
   height: 100%;
 `;
+
+export const ErrorPage401Container = styled(ErrorPageContainer).withConfig({
+  componentId: 'sc-error-page401',
+})``;
+export const ErrorPage404Container = styled(ErrorPageContainer).withConfig({
+  componentId: 'sc-error-page404',
+})``;
+export const ErrorPage500Container = styled(ErrorPageContainer).withConfig({
+  componentId: 'sc-error-page500',
+})``;
+export const ErrorPageAuthContainer = styled(ErrorPageContainer).withConfig({
+  componentId: 'sc-error-pageauth',
+})``;
 export const Title = styled.h2`
   color: ${getThemePropSelector('textPrimary')};
   margin: 0;

--- a/src/lib/components/lateralnavbarlayout/LateralNavbarLayout.component.tsx
+++ b/src/lib/components/lateralnavbarlayout/LateralNavbarLayout.component.tsx
@@ -6,8 +6,11 @@ import { getThemePropSelector } from '../../utils';
 type Props = {
   sidebar: SidebarProps;
   children: JSX.Element;
+  className?: string;
 };
-const LateralNavbarLayoutContainer = styled.div`
+const LateralNavbarLayoutContainer = styled.div.withConfig({
+  componentId: 'sc-lateralnavbarlayout',
+})`
   display: flex;
   flex-direction: column;
   height: 100vh;
@@ -25,7 +28,7 @@ const MainContent = styled.div`
 
 function LateralNavbarLayout({ children, sidebar, ...rest }: Props) {
   return (
-    <LateralNavbarLayoutContainer className="sc-lateralnavbarlayout" {...rest}>
+    <LateralNavbarLayoutContainer {...rest}>
       <ContentContainer>
         {sidebar && <Sidebar {...sidebar} />}
         <MainContent className="main">{children}</MainContent>

--- a/src/lib/components/layout/Layout.component.tsx
+++ b/src/lib/components/layout/Layout.component.tsx
@@ -10,8 +10,11 @@ type Props = {
   sidebar?: SidebarProps;
   navbarElement?: JSX.Element;
   children: JSX.Element;
+  className?: string;
 };
-const LayoutContainer = styled.div`
+const LayoutContainer = styled.div.withConfig({
+  componentId: 'sc-layout',
+})`
   display: flex;
   flex-direction: column;
   height: 100%;
@@ -28,7 +31,7 @@ const MainContent = styled.div`
 
 function Layout({ children, sidebar, navbar, navbarElement, ...rest }: Props) {
   return (
-    <LayoutContainer className="sc-layout" {...rest}>
+    <LayoutContainer {...rest}>
       {navbar && <Navbar {...navbar} />}
       {!navbar &&
         navbarElement !== undefined &&

--- a/src/lib/components/loader/Loader.component.tsx
+++ b/src/lib/components/loader/Loader.component.tsx
@@ -9,8 +9,11 @@ type Props = {
   color?: string;
   children?: JSX.Element;
   centered?: boolean;
+  className?: string;
 };
-const LoaderContainer = styled.div<{
+const LoaderContainer = styled.div.withConfig({
+  componentId: 'sc-loader',
+})<{
   $size: keyof typeof SIZE;
   $color?: string;
   $centered?: boolean;
@@ -54,13 +57,7 @@ function Loader({
   ...rest
 }: Props) {
   return (
-    <LoaderContainer
-      $size={size}
-      $color={color}
-      $centered={centered}
-      className="sc-loader"
-      {...rest}
-    >
+    <LoaderContainer $size={size} $color={color} $centered={centered} {...rest}>
       <LoaderTextDiv>
         <LoaderIcon />
         {children && <LoaderText> {children}</LoaderText>}

--- a/src/lib/components/modal/Modal.component.tsx
+++ b/src/lib/components/modal/Modal.component.tsx
@@ -61,6 +61,7 @@ type CommonProps = {
    * content that needs more horizontal space.
    */
   wide?: boolean;
+  className?: string;
 };
 
 type WithLegacyFooter = {
@@ -103,7 +104,9 @@ type AlertDialogProps = CommonProps &
 
 type Props = DialogProps | AlertDialogProps;
 
-const ModalContainer = styled.div`
+const ModalContainer = styled.div.withConfig({
+  componentId: 'sc-modal',
+})`
   position: fixed;
   top: 0;
   left: 0;
@@ -241,7 +244,6 @@ const Modal = ({
   return isOpen
     ? createPortal(
       <ModalContainer
-        className="sc-modal"
         role={role}
         aria-modal="true"
         aria-labelledby={labelId}

--- a/src/lib/components/modal/Modal.test.tsx
+++ b/src/lib/components/modal/Modal.test.tsx
@@ -1,5 +1,6 @@
 import '@testing-library/jest-dom';
 import { render, screen } from '@testing-library/react';
+import styled from 'styled-components';
 import { getWrapper } from '../../testUtils';
 import { Modal } from './Modal.component';
 
@@ -65,5 +66,29 @@ describe('Modal stacking order', () => {
     expect(bodyIndexOf('first mounted')).toBeGreaterThan(
       bodyIndexOf('second mounted'),
     );
+  });
+});
+
+describe('Modal hook class', () => {
+  const { Wrapper } = getWrapper();
+
+  it('keeps the sc-modal hook class when wrapped in styled()', () => {
+    const WideModal = styled(Modal)`
+      width: 80vw;
+    `;
+    render(
+      <Wrapper>
+        <WideModal isOpen title="Styled" footer={null}>
+          <p>Content</p>
+        </WideModal>
+      </Wrapper>,
+    );
+
+    const dialog = screen.getByRole('dialog');
+    expect(dialog).toHaveClass('sc-modal');
+    // the styled() wrapper's generated class must survive alongside it
+    expect(
+      Array.from(dialog.classList).filter((c) => c !== 'sc-modal').length,
+    ).toBeGreaterThan(0);
   });
 });

--- a/src/lib/components/navbar/Navbar.component.tsx
+++ b/src/lib/components/navbar/Navbar.component.tsx
@@ -26,7 +26,10 @@ import {
   navbarItemWidth,
   zIndex,
 } from '../../style/theme';
-import { getContrastText, getThemePropSelector } from '../../utils';
+import {
+  getContrastText,
+  getThemePropSelector,
+} from '../../utils';
 import { Dropdown, type Item } from '../dropdown/Dropdown.component';
 import { Icon } from '../icon/Icon.component';
 import { Button, FocusVisibleStyle, type Props as ButtonProps } from '../buttonv2/Buttonv2.component';
@@ -191,11 +194,14 @@ export type Props = {
    * Defaults to {@link NAVBAR_COLLAPSE_BREAKPOINT_PX}.
    */
   condenseActionsBreakpoint?: number;
+  className?: string;
 };
 const getNavbarTextColor = (props) =>
   getContrastText(props.theme.navbarBackground, props.theme.textPrimary, props.theme.textReverse) ?? props.theme.textPrimary;
 
-const NavbarContainer = styled.div`
+const NavbarContainer = styled.div.withConfig({
+  componentId: 'sc-navbar',
+})`
   height: ${navbarHeight};
   display: flex;
   justify-content: space-between;
@@ -682,7 +688,10 @@ function NavBar({
   );
 
   return (
-    <NavbarContainer className="sc-navbar" ref={ref} {...rest}>
+    <NavbarContainer
+      ref={ref}
+      {...rest}
+    >
       <NavbarMenu>
         {onToggleClick && (
           <NavbarMenuItem onClick={onToggleClick}>

--- a/src/lib/components/notifications/Notification.component.tsx
+++ b/src/lib/components/notifications/Notification.component.tsx
@@ -19,8 +19,11 @@ export type Props = {
   variant?: Variant;
   dismissAfter?: number;
   onDismiss?: (arg0: string) => void;
+  className?: string;
 };
-const NotificationContainer = styled.div<{ $variant?: Variant }>`
+const NotificationContainer = styled.div.withConfig({
+  componentId: 'sc-notification',
+})<{ $variant?: Variant }>`
   position: relative;
   padding: ${spacing.r16};
   margin-top: ${spacing.r16};
@@ -135,7 +138,6 @@ function Notification({
 
   return (
     <NotificationContainer
-      className="sc-notification"
       $variant={variant}
       onMouseEnter={clearTimer}
       onMouseLeave={resumeTimer}

--- a/src/lib/components/notifications/Notifications.component.tsx
+++ b/src/lib/components/notifications/Notifications.component.tsx
@@ -18,8 +18,11 @@ type Props = {
   position?: Position;
   notifications: Array<NotificationProps>;
   onDismiss: (arg0: string) => void;
+  className?: string;
 };
-const NotificationsContainer = styled.div<{ $position?: Position }>`
+const NotificationsContainer = styled.div.withConfig({
+  componentId: 'sc-notifications',
+})<{ $position?: Position }>`
   position: fixed;
   z-index: ${zIndex.notification};
   margin: ${spacing.r24};
@@ -52,10 +55,14 @@ const NotificationsContainer = styled.div<{ $position?: Position }>`
   }};
 `;
 
-function Notifications({ position, notifications, onDismiss, ...rest }: Props) {
+function Notifications({
+  position,
+  notifications,
+  onDismiss,
+  ...rest
+}: Props) {
   return (
     <NotificationsContainer
-      className="sc-notifications"
       $position={position}
       {...rest}
     >

--- a/src/lib/components/progressbar/ProgressBar.component.tsx
+++ b/src/lib/components/progressbar/ProgressBar.component.tsx
@@ -17,8 +17,11 @@ export type ProgressBarProps = {
   // The animation to full the progress bar
   isAnimation?: boolean;
   height?: React.CSSProperties['height'];
+  className?: string;
 };
-const Container = styled.div``;
+const Container = styled.div.withConfig({
+  componentId: 'sc-progressbar',
+})``;
 const ProgressBarContainer = styled.div<{
   $backgroundColor: string;
   $size: keyof typeof fontSize | 'custom';
@@ -166,7 +169,9 @@ function ProgressBar({
     backgroundColor = theme.backgroundLevel2;
   }
   return (
-    <Container className="sc-progressbar" {...rest}>
+    <Container
+      {...rest}
+    >
       {(topLeftLabel || topRightLabel) && (
         <TopLabelsContainer>
           {topLeftLabel && (

--- a/src/lib/components/searchinput/SearchInput.component.tsx
+++ b/src/lib/components/searchinput/SearchInput.component.tsx
@@ -17,8 +17,11 @@ export type Props = {
   autoComplete?: 'on' | 'off';
   searchIcon?: IconName;
   searchIconColor?: keyof CoreUITheme;
+  className?: string;
 };
-const SearchInputContainer = styled.div<{
+const SearchInputContainer = styled.div.withConfig({
+  componentId: 'sc-searchinput',
+})<{
   $disabled?: boolean;
 }>`
   position: relative;
@@ -103,11 +106,7 @@ const SearchInput = forwardRef(
     };
 
     return (
-      <SearchInputContainer
-        className="sc-searchinput"
-        $disabled={disabled}
-        {...rest}
-      >
+      <SearchInputContainer $disabled={disabled} {...rest}>
         <Input
           autoComplete={autoComplete}
           min={'1'}

--- a/src/lib/components/sidebar/Sidebar.component.tsx
+++ b/src/lib/components/sidebar/Sidebar.component.tsx
@@ -16,6 +16,7 @@ type Item = {
   onClick: (arg0: any) => void;
   active?: boolean;
   icon?: JSX.Element;
+  className?: string;
 };
 type Items = Array<Item>;
 export type Props = {
@@ -23,6 +24,7 @@ export type Props = {
   actions: Items;
   hoverable?: boolean;
   onToggleClick?: () => void;
+  className?: string;
 };
 export type WrapperProps = {
   $expanded?: boolean;
@@ -72,7 +74,9 @@ const Wrapper = styled.div<WrapperProps>`
     }
   }}
 `;
-const SidebarContainer = styled.div<WrapperProps>`
+const SidebarContainer = styled.div.withConfig({
+  componentId: 'sc-sidebar',
+})<WrapperProps>`
   ${(props) => {
     const { backgroundLevel1 } = props.theme;
     return css`
@@ -110,7 +114,9 @@ const SidebarContainer = styled.div<WrapperProps>`
     padding: 0px;
   }
 `;
-const SidebarItem = styled.div<{ $active?: boolean }>`
+const SidebarItem = styled.div.withConfig({
+  componentId: 'sc-sidebar-item',
+})<{ $active?: boolean }>`
   position: relative;
   display: flex;
   align-items: center;
@@ -184,7 +190,6 @@ function Sidebar({
     >
       <SidebarContainer
         $expanded={expanded}
-        className="sc-sidebar"
         $hoverable={hoverable}
         $hovered={hovered}
         {...rest}
@@ -197,7 +202,7 @@ function Sidebar({
                 setHovered(false);
                 onToggleClick();
               }}
-              tooltip={{overlay: "Toggle sidebar"}}
+              tooltip={{ overlay: 'Toggle sidebar' }}
             />
           </MenuItemIcon>
         )}
@@ -205,7 +210,6 @@ function Sidebar({
           ({ active, label, onClick, icon = null, ...actionRest }, index) => {
             return (
               <SidebarItem
-                className="sc-sidebar-item"
                 key={index}
                 $active={active}
                 title={label}

--- a/src/lib/components/steppers/Steppers.component.tsx
+++ b/src/lib/components/steppers/Steppers.component.tsx
@@ -17,8 +17,11 @@ type StepProps = {
 type Props = {
   steps: Array<StepProps>;
   activeStep: number;
+  className?: string;
 };
-const SteppersContainer = styled.div`
+const SteppersContainer = styled.div.withConfig({
+  componentId: 'sc-steppers',
+})`
   padding-top: 4rem;
   padding-left: 2rem;
 `;
@@ -147,7 +150,7 @@ function Step(props: StepProps) {
 
 function Steppers({ steps, activeStep, ...rest }: Props) {
   return (
-    <SteppersContainer className="sc-steppers" {...rest}>
+    <SteppersContainer {...rest}>
       {steps.map(({ title, content, ...stepRest }, index) => (
         <Step
           key={index}

--- a/src/lib/components/textarea/TextArea.component.tsx
+++ b/src/lib/components/textarea/TextArea.component.tsx
@@ -24,7 +24,9 @@ type Props = TextareaHTMLAttributes<HTMLTextAreaElement> & {
 };
 type RefType = HTMLTextAreaElement | null;
 
-const TextAreaContainer = styled.textarea<{
+const TextAreaContainer = styled.textarea.withConfig({
+  componentId: 'sc-textarea',
+})<{
   $variant: TextAreaVariant;
   $width?: CSSProperties['width'];
   $height?: CSSProperties['height'];
@@ -146,7 +148,6 @@ function TextAreaElement(
   if (width || height) {
     return (
       <TextAreaContainer
-        className="sc-textarea"
         $width={width}
         $height={height}
         $variant={variant}
@@ -162,7 +163,6 @@ function TextAreaElement(
 
   return (
     <TextAreaContainer
-      className="sc-textarea"
       rows={rows}
       cols={cols}
       $variant={variant}


### PR DESCRIPTION
## TL;DR

Wrapping a core-ui component in `styled()` silently stripped its documented `sc-*` class from the DOM, so every CSS override, selector and trace lookup keyed on that class stopped matching. The class is now declared as the styled-components **`componentId`** instead of as a JSX prop, which puts it beyond the reach of a props spread. The emitted class is byte-identical, so nothing downstream changes.

## Context

`styled(Component)` restyles by generating a class and passing it *as* `className` — so a consumer using the documented way to restyle was overwriting the hook class. Nothing failed loudly: the component still rendered and still looked right, which is why it went unnoticed. Surfaced downstream while tracing an e2e failure during a dependency uplift; see CUI-42.

## Approach

`className` is an ordinary prop with exactly **one** slot, and two parties wanted to write it: the library (`sc-modal`) and the consumer (via `styled()` or directly). We wrote ours where it loses — a JSX spread is last-wins.

**Before** — the hook class in the contested slot:

```tsx
const ModalContainer = styled.div`
  position: fixed;
  z-index: ${zIndex.modal};
`;

const Modal = ({ isOpen, title, role = 'dialog', className, ...rest }: Props) => (
  <ModalContainer
    className="sc-modal"   // ←  we write the className slot…
    role={role}
    {...rest}              // ←  …and the consumer overwrites it
  >
);
```

**After** — the hook class declared on the component, never passed as a prop:

```tsx
const ModalContainer = styled.div.withConfig({
  componentId: 'sc-modal',   // ←
})`
  position: fixed;
  z-index: ${zIndex.modal};
`;

const Modal = ({ isOpen, title, role = 'dialog', ...rest }: Props) => (
  <ModalContainer role={role} {...rest}>   // ←  we never touch className
);
```

Only the consumer writes the `className` prop now, so there is nothing to clobber. `sc-modal` never enters the prop slot at all: styled-components emits it *after* props are resolved, in the same pass that appends the generated class and the folded ids.

### Why `componentId` rather than merging the two by hand

Reordering the spread is not an option — it keeps `sc-modal` but drops the consumer's generated class, so `styled()` silently does nothing. One slot cannot hold two authors, so something has to concatenate. Three candidates:

| | mechanism | verdict |
| --- | --- | --- |
| merge helper at each site | ours | correct, but re-implements the merge at 23 sites and nothing stops site 24 |
| `.attrs({ className })` | styled-components | works on 6.4.3, but **undocumented** for `className`, with a long history of ordering/dropping bugs across majors |
| **`withConfig({ componentId })`** | styled-components | typed and public; the identity `${Component}` selectors already resolve to; cannot be clobbered |

The library's documented contract is that a wrapped component "attach the passed `className` prop to a DOM element" — the third option satisfies it by never competing for the prop in the first place.

### Measured

Real DOM output, `styled(Button)` inside a `ButtonGroup` (the group styles `.sc-button` to strip each child's framing, so a lost class silently detaches its CSS):

| | `sc-button` present | group's hairline reaches it |
| --- | --- | --- |
| before | ❌ | ❌ silently no-ops |
| after | ✅ | ✅ `border-right: 0.0625rem` |

And the class is unchanged for everyone else, which is what makes this a non-breaking change:

| render | emitted `class` |
| --- | --- |
| `<Modal>` | `sc-modal cRtjOL` |
| `<Modal className="mine">` | `sc-modal cRtjOL mine` |
| `styled(Modal)` | `sc-modal cRtjOL sc-gWWYmq bDeILH` |

`componentId` alone emits exactly the literal string — no hash, no prefix. The babel plugin's `displayName` option would prefix it (`ModalContainer-sc-modal`), but this package builds with plain `tsc` and no `babel-plugin-styled-components`, so what is declared is what ships.

## Usage

No API change. What the fix restores, as the regression test in `Modal.test.tsx` exercises it:

```tsx
const WideModal = styled(Modal)`
  width: 80vw;
`;
```

Before, that dialog root carried only the generated classes. Now it carries `sc-modal` as well, so consumer CSS and selectors keyed on it keep matching through a `styled()` wrapper.

## Review focus

- 🟡 `src/lib/components/*/…` › the 22 `withConfig({ componentId })` declarations — the consumer's `className` now reaches the DOM **only** through the component's `{...rest}` spread, since nothing merges it any more. All 23 call sites were audited to confirm the spread lands on the DOM node; the bit worth confirming is that none was missed, because the failure mode is silent (class quietly absent, no error).
- 🟡 `src/lib/components/error-pages/ErrorPageStyle.ts` › the four wrappers — one shared `ErrorPageContainer` has to yield four distinct classes, so each page gets a thin `styled(ErrorPageContainer).withConfig({ componentId })`. This adds the base container's generated class alongside the page's own; verified each page emits its own class and not its siblings'.
- ⚪ `src/lib/utils.ts` › `mergeClassNames` removed — added earlier in this branch, unused once the class stops being a prop.

## How to test

No screenshot: the change is a DOM class, not a visual, and the emitted class is deliberately identical. The meaningful check is that a `styled()` wrapper no longer detaches descendant CSS.

1. `npm run storybook` → **Components / Button / Button Group**.
2. In the story source wrap a child in `styled(Button)` (any rule, e.g. `letter-spacing: 1px`) and reload.
3. Inspect that button: it carries `sc-button` alongside the generated classes, and still renders de-framed — no border, transparent background, hairline separator from its neighbour.
4. On `development/1.0` the same wrap drops `sc-button`, and the button visibly regains its own border and background inside the group.
5. `npx jest` — 44 suites / 436 tests, and `npx tsc --noEmit` clean.

## Follow-up

- **Internal descendant styling should move to component selectors.** `ButtonGroup`, `Navbar` and `Sidebar` target children by writing `.sc-button` in CSS; styled-components' intended mechanism for that is `${ButtonStyled} { … }`, which resolves to the same class and needs no naming convention. `ButtonStyled` is already exported and the repo already does this in `Card` and `Tablestyle`. Once internal styling stops depending on the classes, what remains is a deliberate public CSS API rather than a convention maintained by hand — which also settles whether test hooks should move to `data-*`. Own ticket, not this PR.
- **`Dropdown.component.tsx` opens with `// @ts-nocheck`.** Removing it surfaces 9 pre-existing errors, all the same shape: transient style props (`$variant`, `$size`, `$isOpen`, `$isSelected`, `$text`) read in CSS interpolations on `styled` definitions that were never given a generic type parameter. Worth typing properly — a blanket `@ts-nocheck` hides real API defects, which is exactly what happened to `className` here. Separate scope from this fix.
- **Tests should not select on `sc-*` classes.** Out of scope here, but worth making the rule: assertions belong on user-facing behaviour, and test hooks on `data-*` attributes.
- **`role` / `aria-*` are exposed the same way.** CUI-42 notes that `{...rest}` still lands after `role`, `aria-modal`, `aria-labelledby` and `aria-describedby`, so a consumer can override core-ui's accessibility wiring. Deliberately unchanged: this PR alters no prop precedence, and fixing it would change override behaviour across 21 components — a separate decision from the class bug.

## References

- **CUI-42** — "A consumer `className` silently clobbers the internal `sc-*` hook class". Bug / Severity Major / Impact Internal. Carries the downstream report, the original DOM evidence, and the merge-based fix this supersedes.

<details>
<summary>What changed</summary>

22 `componentId` declarations across 19 styled containers, covering every `sc-*` hook class the library exposed through a JSX prop: `sc-breadcrumb`, `sc-button`, `sc-button-group`, `sc-circularprogressbar`, `sc-dropdown`, `sc-error-page401/404/500/auth`, `sc-lateralnavbarlayout`, `sc-layout`, `sc-loader`, `sc-modal`, `sc-navbar`, `sc-notification`, `sc-notifications`, `sc-progressbar`, `sc-searchinput`, `sc-sidebar`, `sc-sidebar-item`, `sc-steppers`, `sc-textarea`. Each site drops its hardcoded `className` and stops destructuring `className` out of props, so the consumer's class flows through the existing spread untouched.

`className?: string` is added to 19 `Props` types that never declared it. That is a **separate, compile-time** defect: those components already forwarded `className` to a DOM element, but `tsc` rejected `<Comp className="x" />` (TS2322) and `<Styled className="x" />` (TS2769). The clobber itself was runtime-only — `styled(Comp)` with no explicit `className` compiled fine. `Dropdown` was the one component where this was easy to miss: the file opens with `// @ts-nocheck`, so `tsc` never reads it and the omission raised nothing locally while still breaking consumers in type-checked files. A type-level probe over all 21 components confirms every one now declares it.

CUI-42 proposed merging the classes and moving `{...rest}` ahead of the props core-ui owns. The merge is superseded by `componentId`; the reordering is deliberately left out, since it changes prop precedence for `role` and the `aria-*` attributes too.

The regression test is a sibling `describe` in the existing `Modal.test.tsx`, not a second test file for the same component.

Deliberately **not** in this PR: converting internal descendant styling to component selectors, any `data-*` test hooks, and the `role`/`aria-*` precedence question.
</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
