### PR TITLE
bugfix(modal): stack body portals by open order, not mount order (CUI-43)

### DIFF
--- a/src/lib/components/drawer/Drawer.component.test.tsx
+++ b/src/lib/components/drawer/Drawer.component.test.tsx
@@ -106,3 +106,52 @@ describe('Drawer', () => {
     ).not.toBeInTheDocument();
   });
 });
+
+/**
+ * Two open drawers share one `z-index`, so their order in `<body>` decides
+ * which paints on top — see the matching Modal.stacking tests.
+ */
+describe('Drawer stacking order', () => {
+  const { Wrapper } = getWrapper();
+
+  const bodyIndexOf = (text: string) => {
+    const node = screen.getByText(text);
+    return Array.from(document.body.children).findIndex((child) =>
+      child.contains(node),
+    );
+  };
+
+  const TwoDrawers = ({ aOpen, bOpen }: { aOpen: boolean; bOpen: boolean }) => (
+    <Wrapper>
+      <Drawer isOpen={aOpen} close={jest.fn()} title="A">
+        <p>first mounted</p>
+      </Drawer>
+      <Drawer isOpen={bOpen} close={jest.fn()} title="B">
+        <p>second mounted</p>
+      </Drawer>
+    </Wrapper>
+  );
+
+  it('claims no place in <body> while closed', () => {
+    render(<TwoDrawers aOpen={false} bOpen={false} />);
+
+    expect(document.body.children).toHaveLength(1);
+  });
+
+  it('paints an open drawer above one that merely mounted earlier', () => {
+    render(<TwoDrawers aOpen={false} bOpen={true} />);
+
+    expect(bodyIndexOf('second mounted')).toBe(document.body.children.length - 1);
+  });
+
+  it('orders two open drawers by open order, not mount order', () => {
+    const { rerender } = render(<TwoDrawers aOpen={false} bOpen={false} />);
+
+    rerender(<TwoDrawers aOpen={true} bOpen={false} />);
+    rerender(<TwoDrawers aOpen={true} bOpen={true} />);
+
+    expect(bodyIndexOf('first mounted')).toBeLessThan(
+      bodyIndexOf('second mounted'),
+    );
+  });
+});

--- a/src/lib/components/drawer/Drawer.component.tsx
+++ b/src/lib/components/drawer/Drawer.component.tsx
@@ -115,13 +115,19 @@ const Drawer = ({
   const [mounted, setMounted] = useState(isOpen);
   const [active, setActive] = useState(false);
 
+  // Same stacking rule as Modal: host the portal only while the drawer is
+  // mounted (which spans the closing transition) and append it, so the drawer
+  // opened last is the last `<body>` child and paints above the others.
   useLayoutEffect(() => {
+    if (!mounted) {
+      return;
+    }
     const container = drawerContainer.current;
-    document.body?.prepend(container);
+    document.body?.append(container);
     return () => {
-      document.body?.removeChild(container);
+      container.remove();
     };
-  }, []);
+  }, [mounted]);
 
   useEffect(() => {
     if (isOpen) {

--- a/src/lib/components/modal/Modal.component.tsx
+++ b/src/lib/components/modal/Modal.component.tsx
@@ -198,12 +198,21 @@ const Modal = ({
   const labelId = useId();
   const descId = useId();
 
+  // Host the portal only while open, and append rather than prepend: every
+  // ModalContainer shares one z-index, so `<body>` order alone decides which
+  // modal paints on top. Appending on open makes that the modal opened last;
+  // gating on `isOpen` stops a mounted-but-closed modal from holding a place
+  // in the stack it is not using.
   useLayoutEffect(() => {
-    document.body && document.body.prepend(modalContainer.current);
+    if (!isOpen) {
+      return;
+    }
+    const host = modalContainer.current;
+    document.body?.append(host);
     return () => {
-      document.body && document.body.removeChild(modalContainer.current);
+      host.remove();
     };
-  }, [modalContainer]);
+  }, [isOpen]);
 
   useEffect(() => {
     if (isOpen) {

--- a/src/lib/components/modal/Modal.test.tsx
+++ b/src/lib/components/modal/Modal.test.tsx
@@ -1,0 +1,69 @@
+import '@testing-library/jest-dom';
+import { render, screen } from '@testing-library/react';
+import { getWrapper } from '../../testUtils';
+import { Modal } from './Modal.component';
+
+/**
+ * Every open Modal gets the same `z-index`, so paint order is decided by the
+ * order of its host node in `<body>`: later sibling paints on top. These tests
+ * assert that order, which is the mechanism jsdom can observe — a real browser
+ * turns it into "which modal receives the click".
+ */
+const bodyIndexOf = (text: string) => {
+  const node = screen.getByText(text);
+  return Array.from(document.body.children).findIndex((child) =>
+    child.contains(node),
+  );
+};
+
+const lastBodyIndex = () => document.body.children.length - 1;
+
+describe('Modal stacking order', () => {
+  const { Wrapper } = getWrapper();
+
+  const TwoModals = ({ aOpen, bOpen }: { aOpen: boolean; bOpen: boolean }) => (
+    <Wrapper>
+      <Modal isOpen={aOpen} title="A" footer={null}>
+        first mounted
+      </Modal>
+      <Modal isOpen={bOpen} title="B" footer={null}>
+        second mounted
+      </Modal>
+    </Wrapper>
+  );
+
+  it('claims no place in <body> while closed', () => {
+    render(<TwoModals aOpen={false} bOpen={false} />);
+
+    // Testing Library's own render container is the only child left.
+    expect(document.body.children).toHaveLength(1);
+  });
+
+  it('paints an open modal above one that merely mounted earlier', () => {
+    render(<TwoModals aOpen={false} bOpen={true} />);
+
+    expect(bodyIndexOf('second mounted')).toBe(lastBodyIndex());
+  });
+
+  it('orders two open modals by open order, not mount order', () => {
+    const { rerender } = render(<TwoModals aOpen={false} bOpen={false} />);
+
+    rerender(<TwoModals aOpen={true} bOpen={false} />);
+    rerender(<TwoModals aOpen={true} bOpen={true} />);
+
+    expect(bodyIndexOf('first mounted')).toBeLessThan(
+      bodyIndexOf('second mounted'),
+    );
+  });
+
+  it('raises a modal that is closed and opened again', () => {
+    const { rerender } = render(<TwoModals aOpen={true} bOpen={true} />);
+
+    rerender(<TwoModals aOpen={false} bOpen={true} />);
+    rerender(<TwoModals aOpen={true} bOpen={true} />);
+
+    expect(bodyIndexOf('first mounted')).toBeGreaterThan(
+      bodyIndexOf('second mounted'),
+    );
+  });
+});

--- a/stories/Modal/modal.stories.tsx
+++ b/stories/Modal/modal.stories.tsx
@@ -601,3 +601,55 @@ export const WidthLayoutCases = {
     </Stack>
   ),
 };
+
+// Stacking follows the order modals were *opened* in, not the order they were
+// mounted in. Open B then A: A is on top and its buttons take the clicks.
+export const StackedModals = {
+  render: () => {
+    const [isAOpen, setIsAOpen] = useState(false);
+    const [isBOpen, setIsBOpen] = useState(false);
+    return (
+      <>
+        <Stack gap="r8">
+          <Button
+            onClick={() => setIsAOpen(true)}
+            label="Open A"
+            variant="primary"
+          />
+          <Button
+            onClick={() => setIsBOpen(true)}
+            label="Open B"
+            variant="secondary"
+          />
+        </Stack>
+        {/* A is declared first, so it always mounts first. */}
+        <Modal
+          isOpen={isAOpen}
+          close={() => setIsAOpen(false)}
+          title="Modal A"
+          actions={{
+            confirm: {
+              label: 'Confirm A',
+              onClick: action('Confirm A clicked'),
+            },
+          }}
+        >
+          <span>Modal A — mounted first.</span>
+        </Modal>
+        <Modal
+          isOpen={isBOpen}
+          close={() => setIsBOpen(false)}
+          title="Modal B"
+          actions={{
+            confirm: {
+              label: 'Confirm B',
+              onClick: action('Confirm B clicked'),
+            },
+          }}
+        >
+          <span>Modal B — mounted second.</span>
+        </Modal>
+      </>
+    );
+  },
+};


### PR DESCRIPTION
## TL;DR

Two open `Modal`s stacked by the order they *mounted* in, not the order they were *opened* in, so the modal a user opened last could be painted underneath another one with its buttons unclickable. The portal host is now attached when the modal opens — and appended rather than prepended — so `<body>` order is open order. `Drawer` had the identical defect and is fixed the same way.

## Context

Reported by a consuming application that composes two independently-owned Module Federation remotes, each auto-opening a modal on load: the modal that opened second painted *underneath* the first and swallowed clicks on its own close button. Long-standing bug, **not** a regression from any recent dependency bump — the bump only shifted remote-load timing enough to lose a pre-existing race consistently. The consumer worked around it in its own test suite; this fixes the library. See CUI-43 for the internal report.

## Approach

Every `ModalContainer` gets the same `z-index: 8500`, so paint order among open modals is decided purely by `<body>` order — and the host was `prepend`ed at **mount**, which puts the newest host *first*, where it paints *below* its siblings. Net effect: the earliest-**mounted** modal always won, and a mounted-but-closed modal still reserved a slot it never used.

**Before:**

```tsx
const modalContainer = useRef(document.createElement('div'));

useLayoutEffect(() => {
  document.body && document.body.prepend(modalContainer.current);  // ←
  return () => {
    document.body && document.body.removeChild(modalContainer.current);
  };
}, [modalContainer]);   // ← stable ref ⇒ runs once, at mount, never gated on isOpen
```

**After:**

```tsx
const modalContainer = useRef(document.createElement('div'));

useLayoutEffect(() => {
  if (!isOpen) {                    // ←
    return;
  }
  const host = modalContainer.current;
  document.body?.append(host);      // ←
  return () => {
    host.remove();
  };
}, [isOpen]);                       // ←
```

`Drawer` is gated on `mounted` rather than `isOpen`, because `mounted` spans the closing transition — gating on `isOpen` would yank the node out mid-animation. `document.body.removeChild(host)` also became `host.remove()`, which does not throw if the node has already moved.

### Why not the incrementing z-index the ticket recommended

CUI-43 proposed three fixes and called the third — assign an incrementing z-index when a modal opens — the most robust. It isn't, for *this* bug: a module-level counter in core-ui is **not shared across Module Federation remotes**. A federated host typically shares most dependencies non-singleton and lists only a chosen few as singletons; `@scality/core-ui` is not among the singletons in the host configuration checked here. So two remotes can each hold their own core-ui instance with its own counter, both starting at the same value — colliding straight back into DOM order, which is exactly the reported scenario. The DOM is the only coordination surface genuinely shared across remotes, so ordering stays keyed on `<body>` order and `zIndex.modal` remains a single shared constant.

### Measured

Real browser, `elementFromPoint` on each footer button. `A` always mounts first:

| | `<body>` order | paints on top | last-opened's `Confirm` |
| --- | --- | --- | --- |
| before, open A→B | `[B, A]` | A (mounted first) | ❌ intercepted by A |
| after, open A→B | `[A, B]` | B | ✅ clickable |
| after, open B→A | `[B, A]` | A | ✅ clickable |

Tracking both directions is the point: it shows the order follows *open* order, not merely a reversed mount order.

The sharpest user-facing symptom isn't the visual one. The focus effect is keyed on `isOpen`, so focus went to the modal that opened last while paint went to the one that mounted first — and both containers carry `aria-modal="true"`, so assistive tech announced a dialog the user could not see and `Tab` walked controls hidden behind another modal's overlay:

| open A then B | painted on top | holds focus | agree |
| --- | --- | --- | --- |
| before | A | B | ❌ |
| after | B | B | ✅ |

### Audit of the other `document.body` portals

CUI-43 asked for this. `Tooltip` needs **no fix**: its overlay portals straight to `document.body` and only while visible, so React appends it at show time (already the safe polarity) at `z-index: 9990`, above modal and drawer. The ticket's concern that `Button` wraps *every* button in a `Tooltip` is accurate (`Buttonv2.component.tsx:370`, unconditional) but harmless — with no overlay nothing is ever portalled, and `TooltipContainer` renders inline.

## Usage

No API change. The guarantee the fix adds, as the new `StackedModals` story exercises it:

```tsx
// A is declared first, so it always mounts first — stacking now follows
// the order the modals were opened in instead.
<Modal isOpen={isAOpen} close={() => setIsAOpen(false)} title="Modal A" actions={…}>…</Modal>
<Modal isOpen={isBOpen} close={() => setIsBOpen(false)} title="Modal B" actions={…}>…</Modal>
```

Open B then A, and A is on top with its buttons live. Before, A was on top either way.

## Review focus

- 🟡 `src/lib/components/modal/Modal.component.tsx` › the `useLayoutEffect` — a behaviour change on every `Modal` in every consumer. The bit worth confirming is effect ordering: the layout effect must attach the host *before* the `isOpen` focus effect runs, which is what keeps auto-focus working (layout effects run first, so it holds — but it's load-bearing).
- 🟡 `src/lib/components/drawer/Drawer.component.tsx` › the `useLayoutEffect` — gated on `mounted`, not `isOpen`, deliberately. If that call is wrong, the drawer loses its node mid closing-transition.
- ⚪ `stories/Modal/modal.stories.tsx` › `StackedModals` — new story; doubles as the manual repro.

## How to test

No screenshot: the change is a stacking order, so the meaningful evidence is which element takes the click. Reproduce it directly —

1. `npm run storybook` → **Components / Feedback / Modal / Stacked Modals**.
2. Click **Open A**, then **Open B**. B is on top and **Confirm B** takes the click.
3. Reload, click **Open B**, then **Open A**. Now A is on top and **Confirm A** takes the click.
4. On `development/1.0`, both orders leave A on top, and in step 2 **Confirm B** does nothing.
5. With both modals closed, `document.body` holds no leftover empty host `div`s — before, there was one per mounted `Modal` whether or not it ever opened.

## Follow-up

- Nothing enforces "one modal at a time", and in the reported case no consumer *could*: the two modals come from different MF remotes owned by different teams, both auto-opening on load. A dev-only warning is the sane guard, and it would have to count `.sc-modal` nodes in the document rather than use module state — same cross-remote reason that ruled out the incrementing z-index above. Not in this PR.
- `src/lib/components/charts/common/ChartTooltip.tsx:178` creates its portal host with `appendChild` at mount — mount-time rather than show-time, but `append` is the safe polarity and it declares no z-index of its own. Left alone.
- `Modal` registers its Esc handler on `document` per open modal, so Esc closes every open modal at once. Pre-existing, untouched here.

## References

- **CUI-43** — "`Modal` stacking is inverted and keyed on mount order, not open order". Bug / Severity Major / Impact Internal. Carries the downstream report and the consumer-side workaround this replaces at the library level.

<details>
<summary>What changed</summary>

`Modal.component.tsx` and `Drawer.component.tsx` each move their portal-host insertion out of a mount-time effect and into one gated on being open, switching `prepend` for `append`. Nothing else in either component changes — no props, no styles, no z-index values.

`Modal.test.tsx` is new and asserts the four cases in DOM terms (jsdom cannot paint): no host while closed, open-beats-mounted-first, two opens ordered by open order, and re-opening raising a modal back to the top. Three equivalent cases were added to the existing `Drawer.component.test.tsx`. All seven were confirmed to fail against `development/1.0` before the fix.

Deliberately **not** in this PR: making `zIndex.modal` per-instance (unnecessary once DOM order encodes open order), any enforcement of a single-modal rule, and the `ChartTooltip` mount-time host.
</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
