### PR TITLE
Form: let a responsive page form take its width from the parent

### DIFF
--- a/src/lib/components/box/Box.ts
+++ b/src/lib/components/box/Box.ts
@@ -43,6 +43,12 @@ const Box = styled.div.withConfig({
   ${({ container }) =>
     container &&
     css`
+      /* Containment takes the contents out of the intrinsic width, so a container
+         Box needs a definite width from its parent — a flex grow factor, a grid
+         track or block layout. min-width keeps it from being pinned to the content
+         width it no longer has; the Box itself stays unopinionated about where the
+         definite width comes from. */
+      min-width: 0;
       container-type: inline-size;
       container-name: responsive;
     `}

--- a/src/lib/components/form/Form.component.tsx
+++ b/src/lib/components/form/Form.component.tsx
@@ -77,17 +77,33 @@ const StyledForm = styled.form<{
   ${({ $containerize }) =>
     $containerize &&
     css`
+      /* Containment takes the contents out of the intrinsic width, so the width
+         has to come from the parent: as a content-sized flex item the form would
+         otherwise resolve to 0 and every child would overflow it. Same pairing as
+         LeftPanel/RightPanel in layout/v2/panels.tsx. */
+      flex: 1 1 auto;
+      min-width: 0;
       container-type: inline-size;
       container-name: responsive;
     `}
 `;
 
+// The header, the scroll area and the footer all extend this, so it decides how
+// wide a form's content is. 45rem is the page layout's *cap*, not its width — a
+// pinned width leaves the fields, the section actions and the fixed footer
+// outside the page, unreachable, as soon as there is less room than that.
+// `width: 100%` needs `box-sizing: border-box`, or the content-box padding
+// overflows the parent by exactly that padding. The cap then has to include the
+// padding to keep the same 45rem of *content* the pinned width gave.
+const PAGE_CONTENT_MAX_WIDTH = '45rem';
 const BasicPageLayout = styled.div<{ $layoutKind: 'page' | 'tab' }>`
+  box-sizing: border-box;
   margin: 0 auto;
   ${(props) =>
     props.$layoutKind === 'page'
       ? `
-  width: 45rem;
+  width: 100%;
+  max-width: calc(${PAGE_CONTENT_MAX_WIDTH} + ${spacing.f16});
   padding-right: ${spacing.f16};
   `
       : `

--- a/stories/form.stories.tsx
+++ b/stories/form.stories.tsx
@@ -411,15 +411,23 @@ export const ResponsiveForm = {
 
 // Drag the frame's right edge to narrow the Form. Toggle the `responsive` control
 // to compare the two layout modes on the same fields.
-const ResizeFrame = ({ children }: { children: React.ReactNode }) => (
+const ResizeFrame = ({
+  children,
+  minWidth = '16rem',
+  height = '26rem',
+}: {
+  children: React.ReactNode;
+  minWidth?: string;
+  height?: string;
+}) => (
   <div
     style={{
       resize: 'horizontal',
       overflow: 'auto',
-      minWidth: '16rem',
+      minWidth,
       maxWidth: '100%',
       border: '1px dashed #666',
-      height: '26rem',
+      height,
     }}
   >
     {children}
@@ -884,4 +892,69 @@ export const FormWithAccordion = {
   args: {
     requireMode: 'partial',
   },
+};
+
+const StepSidebar = () => (
+  <div
+    style={{
+      width: '324px',
+      flexShrink: 0,
+      padding: '1rem',
+      borderRight: '1px solid #666',
+    }}
+  >
+    <Stack direction="vertical" gap="r16">
+      <Text isEmphazed>Steps</Text>
+      <Text>1. Connection</Text>
+      <Text>2. Mapping</Text>
+      <Text>3. Review</Text>
+    </Stack>
+  </div>
+);
+
+const ProviderWizardForm = ({ requireMode, responsive }) => (
+  <Form
+    layout={{ kind: 'page', title: 'Create provider' }}
+    requireMode={requireMode}
+    responsive={responsive}
+    rightActions={<Button variant="primary" label="Continue" />}
+    leftActions={<Button variant="outline" label="Cancel" />}
+  >
+    <FormSection
+      title={{ name: 'Connection', icon: 'Node-backend' }}
+      forceLabelWidth={200}
+    >
+      <FormGroup
+        direction="horizontal"
+        label="Provider name"
+        id="wiz-name"
+        content={<Input id="wiz-name" />}
+        required
+      />
+      <FormGroup
+        direction="horizontal"
+        label="Endpoint"
+        id="wiz-endpoint"
+        content={<Input id="wiz-endpoint" />}
+        help="Optional helper text"
+        required
+      />
+    </FormSection>
+  </Form>
+);
+
+// A `page` Form in a flex row next to a fixed step sidebar — drag the frame's
+// right edge down to ~48rem. `responsive` containment removes the form's contents
+// from its own intrinsic width, so as a content-sized flex item it needs the width
+// to come from the row instead.
+export const ResponsivePageFormInFlexRow = {
+  render: ({ requireMode, responsive }) => (
+    <ResizeFrame minWidth="30rem" height="32rem">
+      <div style={{ display: 'flex', height: '100%' }}>
+        <StepSidebar />
+        <ProviderWizardForm requireMode={requireMode} responsive={responsive} />
+      </div>
+    </ResizeFrame>
+  ),
+  args: { requireMode: 'partial', responsive: true },
 };


### PR DESCRIPTION
**TL;DR**: A `responsive` page `Form` placed in a flex row collapsed to a 0px-wide box, and its content columns were pinned to `45rem` so they could not narrow — putting the fields, the section actions and the footer outside the page below ~1000px. The form now takes its width from its parent and treats `45rem` as a cap, so it stays usable down to ~600px with no change to how a page form looks today.

**Component**: `Form` (page layout), `Box`

**Description**:

A `page` Form with `responsive` collapses to a 0px-wide box in any flex row, and its content columns are pinned to `width: 45rem` so they cannot narrow below that. Together those two rules make a wizard-shaped page (step sidebar + form) unusable below ~1000px: the fields, the section actions and the Save/Continue footer sit outside the page with no way to reach them.

It is the first gap a consumer hits when it puts a page form in a flex layout, and it is currently worked around downstream with a local width wrapper.

**Design**: No visual change to a page form as it ships today (measured below). No API change.

**Breaking Changes**:

- [] Breaking Changes

---

### 🧠 Approach

**Two independent rules, both in `Form.component.tsx`.**

**1. Containment removed the form's own width.** `container-type: inline-size` implies `contain: inline-size`, so a `responsive` Form's contents stop contributing to its intrinsic width. As a content-sized flex item it therefore resolves to **0px** — and its own container query, measuring that 0px box, matches permanently, which silently pinned every flex-parented responsive form to the *stacked* label layout at all widths. The fix is the pairing `layout/v2/panels.tsx` already uses for `LeftPanel`/`RightPanel`:

Before:
```
container-type: inline-size;
container-name: responsive;
```

After:
```
flex: 1 1 auto;   // ←
min-width: 0;     // ←
container-type: inline-size;
container-name: responsive;
```

**2. The page columns were pinned, not capped.** `BasicPageLayout` is extended by the header, the scroll area and the footer, so it decides how wide a page form's content is:

Before:
```
const BasicPageLayout = styled.div`
  margin: 0 auto;
  width: 45rem;              // ←
  padding-right: ${spacing.f16};
`;
```

After:
```
const BasicPageLayout = styled.div`
  box-sizing: border-box;                              // ←
  margin: 0 auto;
  width: 100%;                                         // ←
  max-width: calc(${PAGE_CONTENT_MAX_WIDTH} + ${spacing.f16});   // ←
  padding-right: ${spacing.f16};
`;
```

Two things are load-bearing there and are the part worth reviewing:

- `box-sizing: border-box` is required by `width: 100%`, or the content-box `padding-right` overflows the parent by exactly that padding.
- the cap is `calc(45rem + 16px)`, **not** `45rem`. Under `border-box` a bare `45rem` cap would shrink the column from 646px to 630px — the padding used to sit outside the pinned width. Carrying it in the cap keeps exactly the same 45rem of *content* as before.

### 📐 Measured behaviour

Content box narrowed with the viewport held constant — the case a container query exists for, and the reason a media query would not have caught any of this: a host application can shrink the box it gives an app without the viewport changing at all.

| content box | 1420 | 1200 | 1000 | 900 | 800 | 768 | 700 | 600 |
|---|---|---|---|---|---|---|---|---|
| column width | 646 | 646 | 646 | 547 | 447 | 415 | 347 | 247 |
| horizontal overflow | 0 | 0 | 0 | 0 | 0 | 0 | 0 | 0 |

The 45rem cap still holds wherever there is room for it (≥1000), and the footer stays inside the box at every width. A page form that is **not** in a flex row is untouched: 646px column at x=397 in a 1440 viewport, identical to `development/1.0`.

### 📸 Screenshots

`Templates/Form → ResponsivePageFormInFlexRow` — a `page` form in a flex row beside a 324px step sidebar.

**At a 780px content box** — the drawer-open case. The `Continue` button is gone, `Optional helper text` is clipped to `Option`, the required-fields legend is missing, and the row scrolls sideways by 305px. After: the form box is 341px instead of 0, and everything is inside it with no scrollbar.

| `development/1.0` | this PR |
|---|---|
| <img width="400" alt="780px content box before: Continue button and helper text pushed outside the frame, horizontal scrollbar" src="https://github.com/user-attachments/assets/ba8bd70a-993e-4537-ad87-72efa43c580d" /> | <img width="400" alt="780px content box after: header legend, both fields, wrapped helper text and both footer buttons all inside the frame" src="https://github.com/user-attachments/assets/d9e3aaa4-1514-4d3b-9874-251981525985" /> |

**At a 1440px viewport** — the part that is easy to miss. The form's own `@container (max-width: …)` query was measuring its 0px box, so it matched permanently and every `direction="horizontal"` field row was pinned **stacked** at every width. The fields only become side-by-side once the form has a real width.

`development/1.0` — labels above their inputs, with 646px of unused room to the right:

<img width="900" alt="1440px before: labels stacked above their inputs despite ample room" src="https://github.com/user-attachments/assets/5b4cca3f-f9d2-4b77-8e9b-0bdf200252ca" />

This PR — side-by-side, as `direction="horizontal"` asks:

<img width="900" alt="1440px after: labels beside their inputs, columns capped at 45rem and centred in the row" src="https://github.com/user-attachments/assets/a0f9eb0c-1ab7-4d67-9572-69c679ff5219" />

### 🔧 Usage

No API change — `responsive` is unchanged, and this is what now works:

```tsx
<div style={{ display: 'flex' }}>
  <StepSidebar />
  <Form layout={{ kind: 'page', title: 'Create provider' }} responsive>
    <FormSection title={{ name: 'Connection', icon: 'Node-backend' }} forceLabelWidth={200}>
      ...
    </FormSection>
  </Form>
</div>
```

(from `stories/form.stories.tsx › ResponsivePageFormInFlexRow`, added here)

A consumer that worked around the collapse with its own width wrapper can drop it.

### 🔍 Review focus

- 🟡 `src/lib/components/form/Form.component.tsx › BasicPageLayout` — the `border-box` + `calc(45rem + 16px)` arithmetic. Getting the `+ 16px` wrong is a silent 16px narrowing of every page form in the fleet.
- 🟡 `src/lib/components/form/Form.component.tsx › StyledForm` — `flex: 1 1 auto` means a `responsive` page form now *grows* to fill a flex parent instead of being content-sized. Intended, and the only way the container query can measure anything, but it is the behavioural change here.
- ⚪ `src/lib/components/box/Box.ts › Box` — same containment trap, so `container` now also emits `min-width: 0`. No `flex` on this one: `Box` is a general primitive and stays unopinionated about where its definite width comes from.

### 🧪 How to test

1. `npm run storybook`, open **Templates/Form → ResponsivePageFormInFlexRow**.
2. Drag the dashed frame's right edge in to ~48rem. Everything stays reachable: the labels flip to stacked, the fields shrink, the footer buttons stay inside the frame, and no horizontal scrollbar appears.
3. Flip the `responsive` arg off and on — with it on, the labels are side-by-side at wide widths (before this PR they were stuck stacked, because the query was reading a 0px box).
4. Open **Templates/Form → PageForm** and confirm no change: 646px column, centred.

### 🧭 Follow-up

- A consumer working around this with its own width wrapper can delete it and go back to plain `responsive`. That deletion is this PR's real acceptance test.
- Column alignment at wide widths is left as-is (`margin: 0 auto`, centred). A form in a flex row now centres its capped columns in the row, where before its 0px box left them spilling from the row's left edge. Whether they should instead stay flush with a neighbouring sidebar is a design decision, so it is deliberately not part of this fix.

<details>
<summary>What changed</summary>

`Form.component.tsx` carries the whole fix in two rules — `StyledForm`'s containment block and `BasicPageLayout`'s width. `Box.ts` gets the `min-width: 0` companion for its `container` prop. `stories/form.stories.tsx` adds the story above, and generalises the existing `ResizeFrame` helper with optional `minWidth` / `height` rather than adding a second near-identical frame.

Deliberately not here: the `SearchInput` `fluid` gap (CUI-41), the label/field grid squeeze order, and the table/toast gaps — separate PRs, one surface each.

</details>