### PR TITLE
bugfix(toast): raise the toast to the notification z-index tier

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -27,3 +27,22 @@ This is **Scality's shared React component library** (`@scality/core-ui`). It co
 - `npm run build` — compile TypeScript to `dist/`
 - `npm run lint` — run ESLint
 - `npm run storybook` — start Storybook dev server on port 3001
+
+## Tests
+
+**One test file per source module — never one per feature.** Before writing a
+test, find the file that already covers the module: `<Source>.test.ts(x)` beside
+`<Source>.ts(x)` (32 of the 42 test files mirror their source's filename
+exactly; the rest are folder-level files such as `Form.test.tsx` covering
+`Form.component.tsx`). Add a nested `describe` there.
+
+Create a new file only when the module genuinely has none, and name it after the
+**module**, not after the behaviour being added — `Toast.component.test.tsx` for
+`Toast.component.tsx`, not `toastAnchoring.test.ts`.
+
+Two names for one component (`Modal.test.tsx` *and* `Modal.component.test.tsx`)
+is the failure this prevents: both files pass CI, so nothing flags the split and
+the next person ends up testing the same component in two places.
+
+Tests assert user-facing behaviour, never CSS properties. A test that only reads
+a style declaration back out is worth deleting rather than keeping.

--- a/src/lib/components/toast/Toast.component.tsx
+++ b/src/lib/components/toast/Toast.component.tsx
@@ -8,6 +8,7 @@ import { ToastPosition, positionOutput } from './ToastPositionHelpers';
 import { DurationBasedProgressBar } from './DurationBasedProgressBar';
 import { useToastParameters } from './useToastParameters';
 import styled from 'styled-components';
+import { zIndex } from '../../style/theme';
 
 export type ToastStatus = 'success' | 'error' | 'warning' | 'info';
 
@@ -160,6 +161,7 @@ function Toast({
       aria-labelledby={`${status}_toast`}
       style={{
         position: 'fixed',
+        zIndex: zIndex.notification,
         ...(style || positionStyle),
         width,
       }}

--- a/stories/toast.stories.tsx
+++ b/stories/toast.stories.tsx
@@ -12,6 +12,14 @@ export default {
   title: 'Components/Feedback/Toast',
   component: Toast,
   tags: ['autodocs'],
+  parameters: {
+    docs: {
+      description: {
+        component:
+          'A toast is `position: fixed`, so its offsets resolve against the viewport. When a host embeds the application in a box narrower than the viewport — a panel opening beside it, for instance — the toast stays anchored to the browser and can end up outside that box. Whichever element owns the box has to declare `contain: layout`, which makes it the containing block for its fixed descendants; a component cannot do that from the inside.',
+      },
+    },
+  },
   argTypes: {
     open: {
       control: {


### PR DESCRIPTION
## TL;DR

`Toast` rendered `position: fixed` with no `z-index` at all, so a toast raised from inside a modal was painted underneath it and never seen. It now uses the theme's `notification` tier, as its sibling `Notifications` component already does.

## Context

Reported as a toast going missing when a host embeds an application in a box narrower than the viewport. Two separate defects were in play there, and only one belongs to this library.

## Approach

| Symptom | Cause | Fixed here |
| --- | --- | --- |
| Toast painted under a modal | no `z-index` at all — it painted in DOM order against a modal at `8500` | **yes** |
| Toast sits outside the application's box | `position: fixed` resolves against the viewport, which is not the box the application was given | no — see below |

The second one cannot be fixed from inside `Toast`. A fixed element resolves its offsets against its nearest containing-block ancestor, and `contain: layout` on that ancestor is what redirects them — but a component cannot style its own ancestor, and no element in this library reliably sits at the application's boundary. Measured: in a 1440px viewport where the application's box ends at `870`, a toast at `top: 3rem; right: 1rem` lands at `1076→1426` with nothing declared and at `506→856` once the box declares `contain: layout`, inset preserved. That one declaration also covers `Notifications`, which has the same `position: fixed` and the same tier — another reason it belongs on the box rather than inside one component.

So the requirement is documented instead: `stories/toast.stories.tsx` gains a component-level note in the autodocs, stating that offsets resolve against the viewport and that whoever owns the box has to declare `contain: layout`.

## Review focus

- 🟡 `src/lib/components/toast/Toast.component.tsx` › `Toast` — the toast now paints above modals (`notification` 9000 > `modal` 8500). Intended, but it is a visible ordering change for any flow that currently shows a modal over a toast. `zIndex` sits before the `style` spread, so a caller-supplied `style` can still override it.
- ⚪ `CLAUDE.md` — records the existing one-test-file-per-module convention. No code impact.

## How to test

1. Open a `Toast` while a `Modal` is open. Before this change the toast was hidden behind the modal; now it paints above it.
2. Pass an explicit `style={{ zIndex: … }}` and confirm it still wins.
3. `npm run storybook` → **Components / Feedback / Toast** → the docs tab carries the anchoring note at the top.

## Follow-up

Anchoring is fixed where the box is owned, outside this library. This PR only stops the toast being painted under a modal, and records the contract.

<details>
<summary>What changed</summary>

Two lines in `Toast.component.tsx`: the `zIndex` import and `zIndex: zIndex.notification` in the inline style. Eight lines in `stories/toast.stories.tsx` for the autodocs note — attached at component level rather than to a story, because `ToastWithProgressBar` spreads `SimpleToast` and a story-level note would have leaked onto it.

Deliberately not here: no opt-out prop, since the tier already exists in the theme and the sibling component already uses it; no test, because asserting a `z-index` value would assert CSS rather than behaviour; and no story for the anchoring requirement — a demo would have to invent an application and a panel to show a consumer-side CSS declaration, which reads as though the component offered a containment mode.

</details>
