### PR TITLE
Feat/new UI components

### DIFF
--- a/src/lib/components/charts/barchart/Barchart.test.tsx
+++ b/src/lib/components/charts/barchart/Barchart.test.tsx
@@ -153,6 +153,117 @@ describe('Barchart', () => {
     });
   });
 
+  describe('Logarithmic Y axis', () => {
+    const spanningBars = [
+      {
+        label: 'Success',
+        data: [
+          ['category1', 2],
+          ['category2', 300],
+          ['category3', 0],
+        ],
+      },
+    ] as const;
+
+    /**
+     * The Y-axis tick labels, whitespace stripped: formatISONumber groups
+     * thousands with a non-breaking space, which is not what a test wants to
+     * pin down.
+     */
+    const yAxisTicks = (container: HTMLElement) =>
+      Array.from(
+        container.querySelectorAll('.recharts-yAxis-tick-labels text'),
+      ).map((tick) => (tick.textContent ?? '').replace(/\s/g, ''));
+
+    const renderBarchart = (props: {
+      yAxisScale?: 'linear' | 'log';
+      stacked?: boolean;
+    }) => {
+      const { Wrapper } = getWrapper();
+      return render(
+        <Wrapper>
+          <ChartLegendWrapper colorSet={testColorSet}>
+            <Barchart
+              title="Test Title"
+              type={{ type: 'category' }}
+              bars={spanningBars}
+              {...props}
+            />
+          </ChartLegendWrapper>
+        </Wrapper>,
+      );
+    };
+
+    it('labels the axis with the decades enclosing the data, plus a zero', () => {
+      const { container } = renderBarchart({ yAxisScale: 'log' });
+
+      // 2..300 gives a 1..1000 scale — a log axis cannot start at zero — and the
+      // dataset holds a zero, so the axis reserves a slot below it for one.
+      expect(yAxisTicks(container)).toEqual(['0', '1', '10', '100', '1000']);
+    });
+
+    it('reserves no zero slot when the data has none', () => {
+      const { Wrapper } = getWrapper();
+      const { container } = render(
+        <Wrapper>
+          <ChartLegendWrapper colorSet={testColorSet}>
+            <Barchart
+              title="Test Title"
+              type={{ type: 'category' }}
+              bars={[
+                {
+                  label: 'Success',
+                  data: [
+                    ['category1', 2],
+                    ['category2', 300],
+                  ],
+                },
+              ]}
+              yAxisScale="log"
+            />
+          </ChartLegendWrapper>
+        </Wrapper>,
+      );
+
+      // An empty band would spend a decade's worth of plot height on nothing.
+      expect(yAxisTicks(container)).toEqual(['1', '10', '100', '1000']);
+    });
+
+    it('keeps the linear ticks when no scale is asked for', () => {
+      const { container } = renderBarchart({});
+
+      // A linear axis starts at zero and tops out at the data, not at a decade.
+      expect(yAxisTicks(container)[0]).toBe('0');
+      expect(yAxisTicks(container)).not.toContain('1000');
+    });
+
+    it('draws a measured zero at the reserved slot rather than hiding it', () => {
+      const { container } = renderBarchart({ yAxisScale: 'log' });
+
+      // category3 is 0. It gets a rectangle like the other two — minPointSize
+      // gives it a visible stub at the `0` tick — so a measured zero stays
+      // distinguishable from an absent bar, which draws nothing at all.
+      expect(screen.getByText('category3')).toBeInTheDocument();
+      const heights = Array.from(
+        container.querySelectorAll('.recharts-bar-rectangle path'),
+      )
+        .map((rect) => Number(rect.getAttribute('height')))
+        .sort((a, b) => a - b);
+
+      expect(heights).toHaveLength(3);
+      // The zero is the shortest bar, at the minPointSize floor.
+      expect(heights[0]).toBe(3);
+      expect(heights[1]).toBeGreaterThan(3);
+    });
+
+    it('falls back to a linear axis when stacked, whose segments log would misplace', () => {
+      const { container } = renderBarchart({ yAxisScale: 'log', stacked: true });
+
+      expect(yAxisTicks(container)[0]).toBe('0');
+      expect(yAxisTicks(container)).not.toContain('1000');
+    });
+  });
+
   describe('Time data', () => {
     it('should render the chart with correct starting days even if the data is missing', async () => {
       const { Wrapper } = getWrapper();

--- a/src/lib/components/charts/barchart/Barchart.tsx
+++ b/src/lib/components/charts/barchart/Barchart.tsx
@@ -13,7 +13,15 @@ import { Stack } from '../../../spacing';
 import { chartColors, ChartColors, fontSize } from '../../../style/theme';
 import { useChartLegend } from '../legend/ChartLegendWrapper';
 import { BarchartTooltip } from './BarchartTooltip';
-import { formatTickValue, getTicks, splitTickLines } from '../common/chartUtils';
+import {
+  formatLogTickValue,
+  formatTickValue,
+  getLogAxis,
+  getTicks,
+  hasZeroValue,
+  placeNonPositiveValues,
+  splitTickLines,
+} from '../common/chartUtils';
 import { useChartData } from './Barchart.utils';
 import {
   ChartHeader,
@@ -55,6 +63,9 @@ const BARCHART_PRESETS: Record<'default' | 'modern', ResolvedBarchartDisplayOpti
   default: { noBackground: false, showHorizontalGridLines: false, noYAxisLine: false, noTickLine: false, noHeader: false },
   modern:  { noBackground: true,  showHorizontalGridLines: true,  noYAxisLine: true,  noTickLine: true,  noHeader: true  },
 };
+
+/** A Recharts row. `null` is a value the axis cannot place — see `dropNonPositiveValues`. */
+type BarchartRow = { [key: string]: string | number | null };
 
 export type Point = {
   key: string | number;
@@ -116,6 +127,32 @@ export type BarchartProps<T extends BarchartBars> = {
    * Only the properties you specify are overridden; the rest come from the preset.
    */
   displayOptions?: BarchartDisplayOptions;
+  /**
+   * Y-axis scale.
+   *
+   * `'log'` is for a dataset whose values span orders of magnitude: on a linear
+   * axis the small bars collapse onto the baseline and only the largest one is
+   * readable, and a log axis gives each decade the same height instead. The
+   * axis is bounded by the decades enclosing the data, and its ticks are the
+   * decades themselves.
+   *
+   * It changes the display and nothing else: no value is rescaled, and the
+   * tooltip, the legend and the unit scaling all keep the numbers the caller
+   * passed in.
+   *
+   * Two things it cannot do:
+   * - A bar whose value is zero or negative is dropped, because a log axis
+   *   has nowhere to put it. It renders as a gap, which is the same thing an
+   *   absent bar renders as — so on a log axis "measured zero" and "no data"
+   *   become indistinguishable. They are not the same fact. Stay linear where
+   *   that difference matters.
+   * - `stacked` falls back to a linear axis. Stacking places each segment at
+   *   a cumulative sum, so on a log axis a segment's height stops matching
+   *   its value and the chart misreads.
+   *
+   * @default 'linear'
+   */
+  yAxisScale?: 'linear' | 'log';
 };
 
 /* ---------------------------------- MAIN COMPONENT ---------------------------------- */
@@ -141,6 +178,7 @@ export const Barchart = <T extends BarchartBars>(props: BarchartProps<T>) => {
     rightTitle,
     isLoading,
     isError,
+    yAxisScale = 'linear',
     displayPreset = 'default',
     displayOptions,
   } = props;
@@ -175,6 +213,8 @@ export const Barchart = <T extends BarchartBars>(props: BarchartProps<T>) => {
     rechartsData,
     topDomain,
     valueBase,
+    minPositiveValue,
+    normalizedMaxValue,
   } = useChartData(
     bars || [],
     type,
@@ -185,6 +225,37 @@ export const Barchart = <T extends BarchartBars>(props: BarchartProps<T>) => {
     stackedBarSort,
   );
   const titleWithUnit = unitLabel ? `${title} (${unitLabel})` : title;
+
+  // Stacking a log axis would put each segment at a cumulative sum, so its
+  // height would no longer match its value. Linear is the honest fallback.
+  const isLogScale = yAxisScale === 'log' && !stacked;
+
+  const logAxis = useMemo(
+    () =>
+      isLogScale
+        ? getLogAxis(minPositiveValue, normalizedMaxValue, {
+            // Only spend a band when there is a zero to put in it.
+            withZeroBand: hasZeroValue(rechartsData, 'category'),
+          })
+        : null,
+    [isLogScale, minPositiveValue, normalizedMaxValue, rechartsData],
+  );
+
+  // A zero would draw towards minus infinity, so it moves to the axis's zero
+  // band, where `minPointSize` gives it a visible stub at the `0` tick. An
+  // absent bar draws nothing at all, so the two stay distinguishable — which
+  // matters here, because `transformCategoryData` fills an absent bar with 0.
+  const chartData = useMemo<BarchartRow[]>(
+    () =>
+      logAxis
+        ? placeNonPositiveValues<BarchartRow>(
+            rechartsData,
+            'category',
+            logAxis.zeroValue,
+          )
+        : rechartsData,
+    [logAxis, rechartsData],
+  );
 
   const tickFormatter = useCallback(
     (value: number) => formatTickValue(value, roundReferenceValue),
@@ -197,11 +268,11 @@ export const Barchart = <T extends BarchartBars>(props: BarchartProps<T>) => {
     if (type.type !== 'category') {
       return 1;
     }
-    return rechartsData.reduce((max, point) => {
+    return chartData.reduce((max, point) => {
       const lineCount = splitTickLines(point.category ?? '').length;
       return Math.max(max, lineCount);
     }, 1);
-  }, [type.type, rechartsData]);
+  }, [type.type, chartData]);
 
   const xAxisHeight = TICK_BASE_HEIGHT + (maxTickLines - 1) * TICK_LINE_HEIGHT;
 
@@ -216,7 +287,7 @@ export const Barchart = <T extends BarchartBars>(props: BarchartProps<T>) => {
     return (
       <StyledResponsiveContainer ref={chartRef} width="100%" height={height}>
         <RechartsBarChart
-          data={rechartsData}
+          data={chartData}
           accessibilityLayer
           barSize={
             type.type === 'category'
@@ -257,9 +328,18 @@ export const Barchart = <T extends BarchartBars>(props: BarchartProps<T>) => {
 
           <YAxis
             interval={0}
-            domain={[0, topDomain]}
-            ticks={getTicks(roundReferenceValue, false)}
-            tickFormatter={tickFormatter}
+            scale={logAxis ? 'log' : 'auto'}
+            domain={logAxis ? logAxis.domain : [0, topDomain]}
+            // A log axis is bounded by whole decades, so a value below the
+            // floor is clipped rather than dragging the axis down to it.
+            allowDataOverflow={logAxis !== null}
+            ticks={logAxis ? logAxis.ticks : getTicks(roundReferenceValue, false)}
+            tickFormatter={
+              logAxis
+                ? (value: number) =>
+                    formatLogTickValue(value, logAxis.zeroValue)
+                : tickFormatter
+            }
             axisLine={resolvedNoYAxisLine ? false : { stroke: theme.border }}
             tickLine={resolvedNoTickLine ? false : { stroke: theme.border }}
             tick={{
@@ -297,6 +377,7 @@ export const Barchart = <T extends BarchartBars>(props: BarchartProps<T>) => {
                 unitLabel={unitLabel}
                 unitRange={unitRange}
                 valueBase={valueBase}
+                logZeroValue={logAxis?.zeroValue ?? null}
                 chartContainerRef={chartRef}
               />
             )}

--- a/src/lib/components/charts/barchart/Barchart.utils.ts
+++ b/src/lib/components/charts/barchart/Barchart.utils.ts
@@ -2,7 +2,11 @@ import { BarchartProps, BarchartBars } from './Barchart';
 import { TooltipContentProps } from 'recharts';
 import { chartColors, ChartColors } from '../../../style/theme';
 import { useChartLegend } from '../legend/ChartLegendWrapper';
-import { normalizeChartDataWithUnits } from '../common/chartUtils';
+import {
+  getMinPositiveValue,
+  normalizeChartDataWithUnits,
+  readLogPlottedValue,
+} from '../common/chartUtils';
 import { UnitRange } from '../types';
 
 export const getMaxBarValue = (
@@ -410,12 +414,25 @@ export const useChartData = <T extends BarchartBars>(
     rechartsData,
     topDomain,
     valueBase,
+    // Read off the normalized data, like topDomain: a log axis is bounded by
+    // the smallest bar it has to show, and that bound has to be in the same
+    // units as the axis.
+    minPositiveValue: getMinPositiveValue(rechartsData, 'category'),
+    // maxValue is pre-normalization; the log axis needs the value the axis will
+    // actually plot.
+    normalizedMaxValue: valueBase === 0 ? maxValue : maxValue / valueBase,
   };
 };
 
+/**
+ * @param logZeroValue - A log axis's reserved zero band, so a bar drawn there is
+ *   reported as the 0 it actually is — to the default tooltip and to a caller's
+ *   own `tooltip` renderer alike.
+ */
 export const getCurrentPoint = <T extends BarchartBars>(
   props: TooltipContentProps<number, string>,
   hoveredValue: string | undefined,
+  logZeroValue: number | null = null,
 ) => {
   const { payload, label } = props;
 
@@ -425,7 +442,7 @@ export const getCurrentPoint = <T extends BarchartBars>(
     isHovered: boolean;
   }[] = payload.map((item) => ({
     label: item.name,
-    value: item.value,
+    value: readLogPlottedValue(item.value, logZeroValue),
     isHovered: item.name === hoveredValue,
   }));
 

--- a/src/lib/components/charts/barchart/BarchartTooltip.test.tsx
+++ b/src/lib/components/charts/barchart/BarchartTooltip.test.tsx
@@ -170,3 +170,46 @@ describe('ChartTooltip', () => {
     expect(screen.getByText('20 kB')).toBeInTheDocument();
   });
 });
+
+describe('BarchartTooltip on a logarithmic axis', () => {
+  it('reports a bar drawn at the reserved zero band as the 0 it is', () => {
+    // 0.1 is where getLogAxis put the band; the bar is drawn there, and the
+    // tooltip must not report the position as if it were the measurement.
+    render(
+      <BarchartTooltip
+        type={{ type: 'category' }}
+        tooltipProps={{
+          ...testTooltipProps,
+          payload: [
+            { name: 'Success', value: 0.1 },
+            { name: 'Failed', value: 42 },
+          ],
+        }}
+        hoveredValue={undefined}
+        logZeroValue={0.1}
+        chartContainerRef={mockChartContainerRef}
+      />,
+    );
+
+    expect(screen.getByText('0')).toBeInTheDocument();
+    expect(screen.queryByText('0.1')).not.toBeInTheDocument();
+    // Every other value is untouched.
+    expect(screen.getByText(/42/)).toBeInTheDocument();
+  });
+
+  it('leaves the value alone with no band in play', () => {
+    render(
+      <BarchartTooltip
+        type={{ type: 'category' }}
+        tooltipProps={{
+          ...testTooltipProps,
+          payload: [{ name: 'Success', value: 0.1 }],
+        }}
+        hoveredValue={undefined}
+        chartContainerRef={mockChartContainerRef}
+      />,
+    );
+
+    expect(screen.getByText('0.1')).toBeInTheDocument();
+  });
+});

--- a/src/lib/components/charts/barchart/BarchartTooltip.tsx
+++ b/src/lib/components/charts/barchart/BarchartTooltip.tsx
@@ -21,6 +21,7 @@ export const BarchartTooltip = <T extends BarchartBars>({
   unitLabel,
   unitRange,
   valueBase = 1,
+  logZeroValue = null,
   chartContainerRef,
 }: {
   type: TimeType | CategoryType;
@@ -31,6 +32,8 @@ export const BarchartTooltip = <T extends BarchartBars>({
   unitLabel?: string;
   unitRange?: UnitRange;
   valueBase?: number;
+  /** A log axis's reserved zero band, reported as 0 rather than as its position. */
+  logZeroValue?: number | null;
   chartContainerRef: React.RefObject<HTMLDivElement>;
 }) => {
   const { active, coordinate } = tooltipProps;
@@ -39,7 +42,7 @@ export const BarchartTooltip = <T extends BarchartBars>({
     return null;
   }
 
-  const currentPoint = getCurrentPoint(tooltipProps, hoveredValue);
+  const currentPoint = getCurrentPoint(tooltipProps, hoveredValue, logZeroValue);
 
   const duration =
     type.type === 'time'

--- a/src/lib/components/charts/common/chartUtils.test.ts
+++ b/src/lib/components/charts/common/chartUtils.test.ts
@@ -1,4 +1,10 @@
 import {
+  formatLogTickValue,
+  getLogAxis,
+  getMinPositiveValue,
+  hasZeroValue,
+  placeNonPositiveValues,
+  readLogPlottedValue,
   getRoundReferenceValue,
   getTicks,
   getUnitLabel,
@@ -511,5 +517,187 @@ describe('formatTooltipValueWithUnit', () => {
         '20 kB',
       );
     });
+  });
+});
+
+describe('getMinPositiveValue', () => {
+  it('ignores the excluded key, zeros, negatives and non-numbers', () => {
+    const data = [
+      { category: 'a', up: 0, down: 40 },
+      { category: 'b', up: 3, down: -10 },
+      { category: 'c', up: null, down: 'NAN' },
+    ];
+
+    // 'category' would sort as NaN, 0 and -10 have no logarithm, 'NAN' is a gap
+    // marker.
+    expect(getMinPositiveValue(data, 'category')).toBe(3);
+  });
+
+  it('returns null when nothing is positive', () => {
+    expect(getMinPositiveValue([{ category: 'a', up: 0, down: -1 }], 'category')).toBeNull();
+    expect(getMinPositiveValue([], 'category')).toBeNull();
+  });
+
+  it('reads a numeric string, because that is how prometheus data arrives', () => {
+    expect(getMinPositiveValue([{ timestamp: 1, load: '0.25' }], 'timestamp')).toBe(0.25);
+  });
+});
+
+describe('getLogAxis', () => {
+  it('bounds the axis with the decades enclosing the data', () => {
+    // 3..400 is not 0..400: a log axis cannot start at zero.
+    expect(getLogAxis(3, 400)).toMatchObject({
+      domain: [1, 1000],
+      ticks: [1, 10, 100, 1000],
+    });
+  });
+
+  it('keeps a max that already sits on a decade as its own bound', () => {
+    expect(getLogAxis(1, 1000).domain).toEqual([1, 1000]);
+  });
+
+  it('handles values below one', () => {
+    expect(getLogAxis(0.004, 0.5)).toMatchObject({
+      domain: [0.001, 1],
+      ticks: [0.001, 0.01, 0.1, 1],
+    });
+  });
+
+  it('still gives a decade of height when every value shares a magnitude', () => {
+    // Without this the domain would be [10, 10] and the plot would have no
+    // height.
+    expect(getLogAxis(20, 30)).toMatchObject({
+      domain: [10, 100],
+      ticks: [10, 100],
+    });
+  });
+
+  it('skips whole decades rather than crowding the axis, keeping both bounds', () => {
+    const { domain, ticks } = getLogAxis(1, 1e9, { maxTicks: 4 });
+
+    expect(domain).toEqual([1, 1e9]);
+    expect(ticks.length).toBeLessThanOrEqual(5);
+    expect(ticks[0]).toBe(1);
+    expect(ticks[ticks.length - 1]).toBe(1e9);
+    // Every tick is a decade — a log axis is never subdivided linearly.
+    ticks.forEach((tick) => expect(Number.isInteger(Math.log10(tick))).toBe(true));
+  });
+
+  it('falls back to one empty decade when there is nothing positive to plot', () => {
+    expect(getLogAxis(null, 0)).toMatchObject({ domain: [1, 10], ticks: [1, 10] });
+    expect(getLogAxis(0, 100)).toMatchObject({ domain: [1, 10], ticks: [1, 10] });
+  });
+
+  it('reserves a slot below the first decade for a measured zero', () => {
+    const axis = getLogAxis(3, 400, { withZeroBand: true });
+
+    // The scale still runs 1..1000; the slot sits one position below it.
+    expect(axis.zeroValue).toBe(0.1);
+    expect(axis.domain).toEqual([0.1, 1000]);
+    expect(axis.ticks).toEqual([0.1, 1, 10, 100, 1000]);
+  });
+
+  it('reserves nothing when not asked, so no height is spent on an empty band', () => {
+    const axis = getLogAxis(3, 400);
+
+    expect(axis.zeroValue).toBeNull();
+    expect(axis.domain).toEqual([1, 1000]);
+  });
+
+  it('puts the band below the first decade whatever the magnitude', () => {
+    expect(getLogAxis(0.004, 0.5, { withZeroBand: true })).toMatchObject({
+      zeroValue: 0.0001,
+      domain: [0.0001, 1],
+    });
+  });
+});
+
+describe('formatLogTickValue', () => {
+  it('takes its decimals from the tick, not from the axis maximum', () => {
+    // The same axis has to render both of these legibly.
+    expect(formatLogTickValue(0.001)).toBe('0.001');
+    expect(formatLogTickValue(1)).toBe('1');
+    expect(formatLogTickValue(100)).toBe('100');
+  });
+
+  it('goes compact past ten thousand, in the same ISO style as the linear axis', () => {
+    // formatISONumber separates the suffix with a non-breaking space, so match
+    // the shape rather than pinning the exact whitespace character.
+    expect(formatLogTickValue(1000000)).toMatch(/^1\sM$/);
+  });
+
+  it('renders nothing for a value a log axis has no place for', () => {
+    expect(formatLogTickValue(0)).toBe('');
+    expect(formatLogTickValue(-5)).toBe('');
+  });
+
+  it('labels the reserved band 0, not by the position it occupies', () => {
+    expect(formatLogTickValue(0.1, 0.1)).toBe('0');
+    // Without the band, the same position is just a tick like any other.
+    expect(formatLogTickValue(0.1)).toBe('0.1');
+  });
+});
+
+describe('hasZeroValue', () => {
+  it('is true only for a measured zero, not for a gap or a negative', () => {
+    expect(hasZeroValue([{ category: 'a', up: 0 }], 'category')).toBe(true);
+    expect(hasZeroValue([{ category: 'a', up: '0' }], 'category')).toBe(true);
+    expect(hasZeroValue([{ category: 'a', up: null }], 'category')).toBe(false);
+    expect(hasZeroValue([{ category: 'a', up: -1 }], 'category')).toBe(false);
+    expect(hasZeroValue([{ category: 'a', up: 3 }], 'category')).toBe(false);
+  });
+
+  it('never counts the excluded key, whose zero is not a value', () => {
+    expect(hasZeroValue([{ timestamp: 0, load: 2 }], 'timestamp')).toBe(false);
+  });
+});
+
+describe('placeNonPositiveValues', () => {
+  it('moves a zero to the reserved band, where the axis can draw it', () => {
+    const data = [
+      { category: 'a', up: 0, down: 40 },
+      { category: 'b', up: 0.5, down: 0 },
+    ];
+
+    expect(placeNonPositiveValues(data, 'category', 0.1)).toEqual([
+      { category: 'a', up: 0.1, down: 40 },
+      { category: 'b', up: 0.5, down: 0.1 },
+    ]);
+  });
+
+  it('drops a negative, which has no band and no logarithm', () => {
+    expect(
+      placeNonPositiveValues([{ category: 'a', up: -3 }], 'category', 0.1),
+    ).toEqual([{ category: 'a', up: null }]);
+  });
+
+  it('drops zeros when no band was reserved', () => {
+    expect(
+      placeNonPositiveValues([{ category: 'a', up: 0 }], 'category', null),
+    ).toEqual([{ category: 'a', up: null }]);
+  });
+
+  it('never touches the excluded key, even when it is zero', () => {
+    // A timestamp of 0 is a valid instant, not a value to move.
+    expect(
+      placeNonPositiveValues([{ timestamp: 0, load: 2 }], 'timestamp', 0.1),
+    ).toEqual([{ timestamp: 0, load: 2 }]);
+  });
+
+  it('leaves a gap marker as it found it', () => {
+    expect(
+      placeNonPositiveValues([{ timestamp: 1, load: null }], 'timestamp', 0.1),
+    ).toEqual([{ timestamp: 1, load: null }]);
+  });
+});
+
+describe('readLogPlottedValue', () => {
+  it('reports a value sitting at the band as the zero it is', () => {
+    expect(readLogPlottedValue(0.1, 0.1)).toBe(0);
+  });
+
+  it('leaves every other value alone', () => {
+    expect(readLogPlottedValue(0.5, 0.1)).toBe(0.5);
+    expect(readLogPlottedValue(0.1, null)).toBe(0.1);
   });
 });

--- a/src/lib/components/charts/common/chartUtils.ts
+++ b/src/lib/components/charts/common/chartUtils.ts
@@ -111,6 +111,236 @@ export const getTicks = (
   return ticks;
 };
 
+/* -------------------------------------------------------------------------- */
+/*                             logarithmic Y axis                             */
+/* -------------------------------------------------------------------------- */
+
+/**
+ * Smallest strictly positive value in a chart dataset, or `null` when there is
+ * none.
+ *
+ * A log axis is bounded from below by the data, not by zero, so it needs this
+ * where a linear axis only ever needs the maximum.
+ *
+ * @param data - Recharts rows @param excludeKey - Row key that is not a value
+ * (e.g. 'category', 'timestamp')
+ */
+export const getMinPositiveValue = (
+  // Read-only and shape-agnostic: it is called on both charts' row types, which
+  // differ in whether a value may be null.
+  data: readonly Readonly<Record<string, unknown>>[],
+  excludeKey: string,
+): number | null => {
+  let min: number | null = null;
+  data.forEach((row) => {
+    Object.entries(row).forEach(([key, value]) => {
+      if (key === excludeKey) return;
+      const numberValue = typeof value === 'string' ? Number(value) : value;
+      if (typeof numberValue !== 'number' || !Number.isFinite(numberValue)) {
+        return;
+      }
+      if (numberValue > 0 && (min === null || numberValue < min)) {
+        min = numberValue;
+      }
+    });
+  });
+  return min;
+};
+
+/**
+ * A logarithmic Y axis: its domain, its ticks, and where a measured zero goes.
+ *
+ * Three things make a log axis unlike the linear one built by
+ * `getRoundReferenceValue` + `getTicks`:
+ *
+ * - **It cannot start at zero.** Zero has no logarithm, so the scale is
+ *   bounded by the decades that enclose the data — values from 3 to 400 give
+ *   a 1..1000 scale — and `allowDataOverflow` clips anything below rather than
+ *   letting the axis chase it.
+ * - **Its ticks are the decades.** Evenly spaced linear ticks on a log axis
+ *   crowd into the top of the plot and read as a broken chart. When the data
+ *   spans more decades than `maxTicks`, whole decades are skipped at a
+ *   regular stride — never subdivided.
+ * - **A measured zero needs somewhere to go.** With `withZeroBand`, the axis
+ *   reserves one slot below its first decade and returns it as `zeroValue`.
+ *   Zeros are drawn there and the tick is labelled `0`, so "the metric read
+ *   zero" stops being indistinguishable from "no data" — which is what
+ *   dropping them made it. The slot is a reserved position, not a decade:
+ *   nothing is ever plotted between it and the first decade.
+ *
+ * @param minPositive - Smallest positive value, from `getMinPositiveValue`
+ * @param max - Largest value in the dataset
+ * @param options.maxTicks - Upper bound on the number of decade ticks
+ * @param options.withZeroBand - Reserve a slot for measured zeros. Pass it only
+ *   when the data actually holds one, or the axis spends height on nothing.
+ */
+export const getLogAxis = (
+  minPositive: number | null,
+  max: number,
+  options: { maxTicks?: number; withZeroBand?: boolean } = {},
+): {
+  domain: [number, number];
+  ticks: number[];
+  /** Axis position standing in for a measured zero, or `null` when unused. */
+  zeroValue: number | null;
+} => {
+  const { maxTicks = 6, withZeroBand = false } = options;
+
+  const withBand = (decades: number[]) => {
+    const firstDecade = decades[0];
+    const top = decades[decades.length - 1];
+    const stride = Math.ceil(decades.length / maxTicks);
+    const decadeTicks =
+      stride <= 1
+        ? decades
+        : // Keep both ends: the axis must state its own bounds even when
+          // decades are skipped.
+          [
+            ...decades.filter((_, index) => index % stride === 0),
+            top,
+          ].filter((value, index, all) => all.indexOf(value) === index);
+
+    if (!withZeroBand) {
+      return {
+        domain: [firstDecade, top] as [number, number],
+        ticks: decadeTicks,
+        zeroValue: null,
+      };
+    }
+
+    // One decade's worth of height, below the scale, standing in for zero.
+    const zeroValue = firstDecade / 10;
+    return {
+      domain: [zeroValue, top] as [number, number],
+      ticks: [zeroValue, ...decadeTicks],
+      zeroValue,
+    };
+  };
+
+  // Nothing positive to plot: a single empty decade, so the axis still draws.
+  if (
+    minPositive === null ||
+    minPositive <= 0 ||
+    !Number.isFinite(max) ||
+    max <= 0
+  ) {
+    return withBand([1, 10]);
+  }
+
+  const lowExponent = Math.floor(Math.log10(minPositive));
+  // A max sitting exactly on a decade is already its own bound; anything else
+  // rounds up to the next.
+  const highExponent = Math.ceil(Math.log10(max));
+  // Guarantee at least one decade of height even when every value shares a
+  // magnitude.
+  const topExponent =
+    highExponent > lowExponent ? highExponent : lowExponent + 1;
+
+  return withBand(
+    Array.from(
+      { length: topExponent - lowExponent + 1 },
+      (_, index) => 10 ** (lowExponent + index),
+    ),
+  );
+};
+
+/**
+ * Formats one tick of a logarithmic axis.
+ *
+ * Unlike `formatTickValue`, the number of decimals comes from the tick's own
+ * magnitude rather than from the axis maximum: a 0.01..1000 axis has to render
+ * `0.01` and `1k` on the same axis, and a single decimal count cannot serve
+ * both.
+ *
+ * @param zeroValue - The reserved zero band from `getLogAxis`. It is labelled
+ *   `0`, not by the position it happens to occupy.
+ */
+export const formatLogTickValue = (
+  value: number,
+  zeroValue: number | null = null,
+): string => {
+  if (zeroValue !== null && value === zeroValue) return '0';
+  if (!Number.isFinite(value) || value <= 0) return '';
+  const exponent = Math.log10(value);
+  return formatISONumber(value, {
+    decimals: exponent < 0 ? Math.ceil(-exponent) : 0,
+    fixedDecimals: exponent < 0,
+    compact: value >= 10000,
+  });
+};
+
+/**
+ * Whether any value in the data is a measured zero.
+ *
+ * `getLogAxis` only reserves a zero band when asked, and asking costs a
+ * decade's worth of plot height — so ask only when there is a zero to show.
+ *
+ * @param data - Recharts rows
+ * @param excludeKey - Row key that is not a value (e.g. 'category', 'timestamp')
+ */
+export const hasZeroValue = (
+  data: readonly Readonly<Record<string, unknown>>[],
+  excludeKey: string,
+): boolean =>
+  data.some((row) =>
+    Object.entries(row).some(([key, value]) => {
+      if (key === excludeKey) return false;
+      const numberValue = typeof value === 'string' ? Number(value) : value;
+      return numberValue === 0;
+    }),
+  );
+
+/**
+ * Moves the values a log axis cannot plot to where the axis can show them.
+ *
+ * `log(0)` is minus infinity, so a zero left in the data draws a bar or a line
+ * segment reaching off the bottom of the plot. Given a `zeroValue` from
+ * `getLogAxis`, a zero is moved to that reserved band instead, where the axis
+ * labels it `0` — so a measured zero stays visible, and stays distinguishable
+ * from a missing sample. Dropping it could not do either.
+ *
+ * Negatives have no band and no logarithm, so they are dropped. A series that
+ * goes negative does not belong on a log axis at all.
+ *
+ * With no `zeroValue`, zeros are dropped too — the fallback for a caller that
+ * did not reserve a band.
+ *
+ * @param data - Recharts rows
+ * @param excludeKey - Row key that is not a value (e.g. 'category', 'timestamp')
+ * @param zeroValue - The reserved zero band, or `null` to drop zeros
+ */
+export const placeNonPositiveValues = <T extends Record<string, unknown>>(
+  data: readonly T[],
+  excludeKey: string,
+  zeroValue: number | null,
+): T[] =>
+  data.map((row) => {
+    const placed: Record<string, unknown> = { ...row };
+    Object.entries(row).forEach(([key, value]) => {
+      if (key === excludeKey) return;
+      const numberValue = typeof value === 'string' ? Number(value) : value;
+      if (typeof numberValue !== 'number') return;
+      if (numberValue === 0) {
+        placed[key] = zeroValue;
+      } else if (!(numberValue > 0)) {
+        placed[key] = null;
+      }
+    });
+    return placed as T;
+  });
+
+/**
+ * Turns a plotted value back into the value the caller gave, for display.
+ *
+ * A zero sits at its reserved band in the Recharts data so the axis can draw
+ * it; a tooltip must still say `0`. No real value can collide with the band —
+ * `getLogAxis` puts it below the smallest positive value in the data.
+ */
+export const readLogPlottedValue = (
+  value: number,
+  zeroValue: number | null,
+): number => (zeroValue !== null && value === zeroValue ? 0 : value);
+
 /**
  * Return the unit label based on the current dataset, and the valueBase which is used to convert the data
  * Used by LineTimeSerieChart

--- a/src/lib/components/charts/linetimeseries/LineTimeSerieChart.test.tsx
+++ b/src/lib/components/charts/linetimeseries/LineTimeSerieChart.test.tsx
@@ -5,6 +5,22 @@ import { ChartLegendWrapper } from '../legend/ChartLegendWrapper';
 import { ThemeProvider } from 'styled-components';
 import { coreUIAvailableThemes } from '../../../style/theme';
 
+// ResponsiveContainer measures its parent, which has no size in jsdom, so the
+// chart would render an empty SVG. Give it a fixed box — the same trick
+// Barchart.test.tsx uses — so the axes exist and their ticks can be asserted.
+jest.mock('recharts', () => {
+  const actual = jest.requireActual('recharts');
+
+  return {
+    ...actual,
+    ResponsiveContainer: ({ children }: { children: React.ReactNode }) => (
+      <actual.ResponsiveContainer aspect={3} height={300}>
+        {children}
+      </actual.ResponsiveContainer>
+    ),
+  };
+});
+
 const TestSeries = [
   {
     resource: 'Series 1',
@@ -54,6 +70,99 @@ const renderLineTimeSerieChart = (props: Partial<LineChartProps> = {}) => {
     </ThemeProvider>,
   );
 };
+
+
+describe('LineTimeSerieChart logarithmic Y axis', () => {
+  /**
+   * The Y-axis tick labels, whitespace stripped: formatISONumber groups
+   * thousands with a non-breaking space, which is not what a test wants to pin
+   * down.
+   */
+  const yAxisTicks = (container: HTMLElement) =>
+    Array.from(
+      container.querySelectorAll('.recharts-yAxis-tick-labels text'),
+    ).map((tick) => (tick.textContent ?? '').replace(/\s/g, ''));
+
+  // Two decades apart, with a zero sample a log axis has no place for.
+  const SpanningSeries = [
+    {
+      resource: 'Series 1',
+      getTooltipLabel: () => 'Series 1',
+      data: [
+        [1622505600, 4],
+        [1622509200, 0],
+        [1622512800, 700],
+      ] as [number, number][],
+    },
+  ];
+
+  const renderChart = (props: Record<string, unknown>) =>
+    render(
+      <ThemeProvider theme={coreUIAvailableThemes.artescaLight}>
+        <ChartLegendWrapper colorSet={{ 'Series 1': '#FF0000' }}>
+          <LineTimeSerieChart
+            {...({
+              title: 'Test Chart',
+              series: SpanningSeries,
+              height: 400,
+              startingTimeStamp: 1622505600,
+              interval: 3600,
+              duration: 7200,
+              ...props,
+            } as LineChartProps)}
+          />
+        </ChartLegendWrapper>
+      </ThemeProvider>,
+    );
+
+  it('labels the axis with the decades enclosing the data, plus a zero', () => {
+    const { container } = renderChart({ yAxisScale: 'log' });
+
+    // 4..700 gives a 1..1000 scale — a log axis cannot start at zero — and the
+    // series holds a zero sample, so the axis reserves a slot below it for one.
+    expect(yAxisTicks(container)).toEqual(['0', '1', '10', '100', '1000']);
+  });
+
+  it('reserves no zero slot when the series has none', () => {
+    const { container } = renderChart({
+      yAxisScale: 'log',
+      series: [
+        {
+          resource: 'Series 1',
+          getTooltipLabel: () => 'Series 1',
+          data: [
+            [1622505600, 4],
+            [1622509200, 40],
+            [1622512800, 700],
+          ] as [number, number][],
+        },
+      ],
+    });
+
+    expect(yAxisTicks(container)).toEqual(['1', '10', '100', '1000']);
+  });
+
+  it('keeps the linear ticks when no scale is asked for', () => {
+    const { container } = renderChart({});
+
+    // A linear axis starts at zero and tops out at the data, not at a decade.
+    expect(yAxisTicks(container)[0]).toBe('0');
+    expect(yAxisTicks(container)).not.toContain('1000');
+  });
+
+  it('ignores the scale on a symmetrical chart, whose axis goes negative', () => {
+    // The prop type forbids this pairing; the cast is a plain-JS caller
+    // reaching past it.
+    const { container } = renderChart({
+      yAxisType: 'symmetrical',
+      yAxisScale: 'log',
+      series: { above: SpanningSeries, below: [] },
+    });
+
+    // A negative tick is proof the axis stayed linear.
+    expect(yAxisTicks(container).some((tick) => tick.startsWith('-'))).toBe(true);
+  });
+});
 
 describe('LineTimeSerieChart', () => {
   it('should render when with basic parameters', async () => {

--- a/src/lib/components/charts/linetimeseries/LineTimeSerieChart.tsx
+++ b/src/lib/components/charts/linetimeseries/LineTimeSerieChart.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useRef } from 'react';
+import React, { useCallback, useMemo, useRef } from 'react';
 import {
   Area,
   CartesianGrid,
@@ -13,7 +13,14 @@ import {
 import styled, { useTheme } from 'styled-components';
 import { fontSize } from '../../../style/theme';
 import { ChartHeader, StyledResponsiveContainer } from '../common/SharedComponents';
-import { formatTickValue, getTicks } from '../common/chartUtils';
+import {
+  formatLogTickValue,
+  formatTickValue,
+  getLogAxis,
+  getTicks,
+  hasZeroValue,
+  placeNonPositiveValues,
+} from '../common/chartUtils';
 import { formatXAxisLabel } from './LineTimeSerieChart.utils';
 import { LineChartProps, CHART_PRESETS } from './LineTimeSerieChart.types';
 import { LineTimeSerieChartTooltip } from './LineTimeSerieChartTooltip';
@@ -53,6 +60,7 @@ export function LineTimeSerieChart({
   unitRange,
   isLoading = false,
   yAxisType = 'default',
+  yAxisScale = 'linear',
   yAxisTitle,
   helpText,
   rightTitle,
@@ -79,6 +87,7 @@ export function LineTimeSerieChart({
     rechartsData,
     topDomain,
     topValue,
+    minPositiveValue,
     unitLabel,
     valueBase,
     xAxisTicks,
@@ -92,6 +101,33 @@ export function LineTimeSerieChart({
     yAxisType,
     unitRange,
   });
+
+  // The type keeps 'log' off symmetrical charts; the guard keeps a plain JS
+  // caller from getting a half-drawn axis out of one.
+  const isLogScale = yAxisScale === 'log' && yAxisType !== 'symmetrical';
+
+  const logAxis = useMemo(
+    () =>
+      isLogScale
+        ? getLogAxis(minPositiveValue, topDomain, {
+            // Only spend a band when there is a zero to put in it.
+            withZeroBand: hasZeroValue(rechartsData, 'timestamp'),
+          })
+        : null,
+    [isLogScale, minPositiveValue, topDomain, rechartsData],
+  );
+
+  // A zero sample would draw the line towards minus infinity, so it moves to the
+  // axis's zero band, where the tick reads `0`. Dropping it instead would leave
+  // the same gap `addMissingDataPoint` leaves for a missing sample, and a
+  // measured zero is not missing data.
+  const chartData = useMemo(
+    () =>
+      logAxis
+        ? placeNonPositiveValues(rechartsData, 'timestamp', logAxis.zeroValue)
+        : rechartsData,
+    [logAxis, rechartsData],
+  );
 
   // Format X-axis labels based on duration
   const formatXAxisLabelCallback = useCallback(
@@ -119,7 +155,7 @@ export function LineTimeSerieChart({
       <StyledResponsiveContainer width="100%" height={height}>
         <ComposedChart
           ref={chartRef}
-          data={rechartsData}
+          data={chartData}
           margin={{ top: 0, right: 0, bottom: 0, left: 0 }}
           aria-label={`Time series chart for ${title}`}
           syncId={syncId}
@@ -173,10 +209,13 @@ export function LineTimeSerieChart({
                 fontSize: fontSize.smaller,
               },
             }}
+            scale={logAxis ? 'log' : 'auto'}
             domain={
-              yAxisType === 'symmetrical'
-                ? [-topDomain, topDomain]
-                : [0, topDomain]
+              logAxis
+                ? logAxis.domain
+                : yAxisType === 'symmetrical'
+                  ? [-topDomain, topDomain]
+                  : [0, topDomain]
             }
             allowDataOverflow={true}
             axisLine={resolvedNoYAxisLine ? false : { stroke: theme.border }}
@@ -185,8 +224,15 @@ export function LineTimeSerieChart({
               fill: theme.textSecondary,
               fontSize: fontSize.smaller,
             }}
-            tickFormatter={tickFormatter}
-            ticks={getTicks(topValue, yAxisType === 'symmetrical')}
+            tickFormatter={
+              logAxis
+                ? (value: number) =>
+                    formatLogTickValue(value, logAxis.zeroValue)
+                : tickFormatter
+            }
+            ticks={
+              logAxis ? logAxis.ticks : getTicks(topValue, yAxisType === 'symmetrical')
+            }
             interval={0}
           />
           <Tooltip
@@ -198,6 +244,7 @@ export function LineTimeSerieChart({
                 duration={duration}
                 renderTooltip={renderTooltip}
                 isSymmetrical={yAxisType === 'symmetrical'}
+                logZeroValue={logAxis?.zeroValue ?? null}
                 belowSeriesLabels={belowSeriesLabels}
                 tooltipProps={props}
                 chartContainerRef={chartRef}

--- a/src/lib/components/charts/linetimeseries/LineTimeSerieChart.types.ts
+++ b/src/lib/components/charts/linetimeseries/LineTimeSerieChart.types.ts
@@ -18,6 +18,32 @@ export type Serie = {
 export type NonSymmetricalChartSerie = {
   yAxisType?: 'default' | 'percentage';
   series: Serie[] | undefined;
+  /**
+   * Y-axis scale.
+   *
+   * `'log'` is for a metric whose values span orders of magnitude: on a linear
+   * axis the quiet periods flatten onto the baseline and only the spikes are
+   * readable, and a log axis gives each decade the same height instead. The
+   * axis is bounded by the decades enclosing the data, and its ticks are the
+   * decades themselves.
+   *
+   * It changes the display and nothing else: no value is rescaled, and the
+   * tooltip, the legend and the unit scaling all keep the numbers the caller
+   * passed in.
+   *
+   * One thing to know before reaching for it. Zero has no logarithm, so a
+   * sample of zero or less is dropped and leaves a gap — which is exactly what
+   * a missing sample leaves. On a log axis "measured zero" and "no data" become
+   * indistinguishable, and they are different facts: a zero is a measurement,
+   * missing data is the absence of one. A metric that legitimately reads zero
+   * belongs on a linear axis.
+   *
+   * The negative half of a `'symmetrical'` axis has no logarithm either, which
+   * is why the option does not exist there.
+   *
+   * @default 'linear'
+   */
+  yAxisScale?: 'linear' | 'log';
 };
 
 /**
@@ -26,6 +52,11 @@ export type NonSymmetricalChartSerie = {
  */
 export type SymmetricalChartSerie = {
   yAxisType: 'symmetrical';
+  /**
+   * Not available on a symmetrical chart: its axis spans negative values, which
+   * have no logarithm.
+   */
+  yAxisScale?: never;
   series:
     | {
         above: Serie[] | undefined;
@@ -131,6 +162,11 @@ export type LineTimeSerieChartTooltipProps = {
     duration?: number,
   ) => React.ReactNode;
   isSymmetrical?: boolean;
+  /**
+   * A log axis's reserved zero band. A value drawn there is reported as the 0 it
+   * actually is, not as the position it occupies.
+   */
+  logZeroValue?: number | null;
   belowSeriesLabels?: Set<string>;
   chartContainerRef: React.RefObject<HTMLDivElement>;
   /** The unique ID of this chart instance */

--- a/src/lib/components/charts/linetimeseries/LineTimeSerieChartTooltip.tsx
+++ b/src/lib/components/charts/linetimeseries/LineTimeSerieChartTooltip.tsx
@@ -10,7 +10,10 @@ import {
 } from '../common/ChartTooltip';
 import { LineTimeSerieChartTooltipProps } from './LineTimeSerieChart.types';
 import { getCurrentlyHoveredChartId } from './useChartHover';
-import { formatTooltipValueWithUnit } from '../common/chartUtils';
+import {
+  formatTooltipValueWithUnit,
+  readLogPlottedValue,
+} from '../common/chartUtils';
 
 /**
  * Custom tooltip component for LineTimeSerieChart
@@ -26,6 +29,7 @@ export const LineTimeSerieChartTooltip: React.FC<
   tooltipProps,
   renderTooltip,
   isSymmetrical,
+  logZeroValue = null,
   belowSeriesLabels,
   chartContainerRef,
   chartId,
@@ -88,7 +92,9 @@ export const LineTimeSerieChartTooltip: React.FC<
               );
 
               const formattedValue = formatTooltipValueWithUnit(
-                entry.value,
+                // A zero is plotted at the axis's reserved band so it can be
+                // drawn; the tooltip has to report the 0 that was measured.
+                readLogPlottedValue(entry.value, logZeroValue),
                 valueBase,
                 unitRange,
                 unitLabel,

--- a/src/lib/components/charts/linetimeseries/useChartData.ts
+++ b/src/lib/components/charts/linetimeseries/useChartData.ts
@@ -2,6 +2,7 @@ import { useMemo } from 'react';
 import { useChartLegend } from '../legend/ChartLegendWrapper';
 import {
   addMissingDataPoint,
+  getMinPositiveValue,
   normalizeChartDataWithUnits,
 } from '../common/chartUtils';
 import { Serie, isSymmetricalSeries } from './LineTimeSerieChart.types';
@@ -30,6 +31,12 @@ type ChartDataOutput = {
   topDomain: number;
   /** Value used for tick calculation */
   topValue: number;
+  /**
+   * Smallest positive value in the normalized data, or `null` when there is
+   * none. A log axis is bounded from below by the data; a linear one never
+   * needs this.
+   */
+  minPositiveValue: number | null;
   /** Unit label (e.g., "KiB/s", "%") */
   unitLabel: string | undefined;
   /** Factor the dataset was divided by during normalization (for tooltip re-scaling) */
@@ -316,10 +323,16 @@ export function useChartData({
     return labels;
   }, [series, yAxisType]);
 
+  const minPositiveValue = useMemo(
+    () => getMinPositiveValue(rechartsData, 'timestamp'),
+    [rechartsData],
+  );
+
   return {
     rechartsData,
     topDomain,
     topValue,
+    minPositiveValue,
     unitLabel,
     valueBase,
     xAxisTicks,

--- a/stories/BarChart/barchart.stories.tsx
+++ b/stories/BarChart/barchart.stories.tsx
@@ -1332,3 +1332,61 @@ export const LogarithmicScaleIgnoredWhenStacked: Story = {
     );
   },
 };
+
+/**
+ * The scale as a control, for poking at it against your own numbers.
+ *
+ * `stacked` is here on purpose: turn it on and the axis snaps back to linear, because a stack
+ * places each segment at a cumulative sum and its height would stop matching its value.
+ */
+export const LogarithmicScalePlayground: StoryObj<{
+  yAxisScale: 'linear' | 'log';
+  stacked: boolean;
+  height: number;
+  spread: number;
+}> = {
+  argTypes: {
+    yAxisScale: { control: { type: 'radio' }, options: ['linear', 'log'] },
+    stacked: {
+      control: 'boolean',
+      description: 'Forces the axis back to linear — a log stack misreads',
+    },
+    height: { control: { type: 'range', min: 120, max: 480, step: 20 } },
+    spread: {
+      control: { type: 'range', min: 1, max: 6, step: 1 },
+      description: 'Orders of magnitude between the smallest and largest bar',
+    },
+  },
+  args: { yAxisScale: 'log', stacked: false, height: 240, spread: 4 },
+  render: (args) => {
+    const theme = useTheme() as CoreUITheme;
+    // One bar per decade, so the spread control is exactly what it says.
+    const bars = [
+      {
+        label: 'Requests',
+        data: Array.from(
+          { length: args.spread + 1 },
+          (_, index) => [`1e${index}`, 10 ** index * 2] as [string, number],
+        ),
+      },
+    ] as const;
+
+    return (
+      <div style={{ width: '60%', padding: spacing.r16 }}>
+        <ChartLegendWrapper colorSet={{ Requests: theme.statusHealthy }}>
+          <Stack direction="vertical" gap="r16">
+            <Barchart
+              type={{ type: 'category' }}
+              bars={bars}
+              title="Requests per endpoint"
+              height={args.height}
+              stacked={args.stacked}
+              yAxisScale={args.yAxisScale}
+            />
+            <ChartLegend shape="rectangle" direction="horizontal" />
+          </Stack>
+        </ChartLegendWrapper>
+      </div>
+    );
+  },
+};

--- a/stories/BarChart/barchart.stories.tsx
+++ b/stories/BarChart/barchart.stories.tsx
@@ -1194,3 +1194,141 @@ export const StackedHistogram: Story = {
     );
   },
 };
+
+/**
+ * The same dataset on both scales.
+ *
+ * Values spanning four orders of magnitude are the case a linear axis cannot serve: the axis is
+ * sized by the largest bar, so everything below one thousandth of it lands on the baseline and
+ * reads as zero. A log axis gives every decade the same height, so "2" and "40 000" are both
+ * legible — at the cost of no longer being able to compare bars by eye, which is the trade-off to
+ * make consciously.
+ *
+ * Note that the scale is a display choice only: no value is rescaled, and the tooltips still read
+ * 2, 45, 1200 and 40000.
+ *
+ * `category5` is 0. Zero has no logarithm, so the axis reserves a slot below its first decade,
+ * labels it `0`, and draws the bar there as a stub — visible, and distinct from an absent bar,
+ * which draws nothing at all. The tooltip still reads 0.
+ */
+export const LogarithmicScale: Story = {
+  render: () => {
+    const theme = useTheme() as CoreUITheme;
+    const spanningData = [
+      {
+        label: 'Requests',
+        data: [
+          ['category1', 2],
+          ['category2', 45],
+          ['category3', 1200],
+          ['category4', 40000],
+          ['category5', 0],
+        ],
+      },
+    ] as const;
+
+    return (
+      <div style={{ width: '60%', padding: spacing.r16 }}>
+        <ChartLegendWrapper colorSet={{ Requests: theme.statusHealthy }}>
+          <Stack direction="vertical" gap="r24">
+            <Stack direction="vertical" gap="r8">
+              <Text variant="Basic" isEmphazed>
+                Linear — only the tallest bar is readable
+              </Text>
+              <Barchart
+                type={{ type: 'category' }}
+                bars={spanningData}
+                title="Requests per endpoint"
+                height={200}
+              />
+            </Stack>
+            <Stack direction="vertical" gap="r8">
+              <Text variant="Basic" isEmphazed>
+                Logarithmic — one decade per step; category5 (0) sits at the
+                reserved 0
+              </Text>
+              <Barchart
+                type={{ type: 'category' }}
+                bars={spanningData}
+                title="Requests per endpoint"
+                height={200}
+                yAxisScale="log"
+              />
+            </Stack>
+            <ChartLegend shape="rectangle" direction="horizontal" />
+          </Stack>
+        </ChartLegendWrapper>
+      </div>
+    );
+  },
+};
+
+/**
+ * A log axis and a stack do not combine, so `yAxisScale="log"` is ignored here and the axis stays
+ * linear.
+ *
+ * Stacking places each segment at a running total, so on a log axis a segment's height would be
+ * `log(cumulative) - log(previous cumulative)` — unrelated to the value it represents. The chart
+ * would still draw, and it would be wrong. Compare the two: the ticks are identical.
+ */
+export const LogarithmicScaleIgnoredWhenStacked: Story = {
+  render: () => {
+    const theme = useTheme() as CoreUITheme;
+    const stackedData = [
+      {
+        label: 'Test 1',
+        data: [
+          ['category1', 5],
+          ['category2', 500],
+        ],
+      },
+      {
+        label: 'Test 2',
+        data: [
+          ['category1', 3000],
+          ['category2', 40],
+        ],
+      },
+    ] as const;
+
+    return (
+      <div style={{ width: '60%', padding: spacing.r16 }}>
+        <ChartLegendWrapper
+          colorSet={{
+            'Test 1': theme.statusHealthy,
+            'Test 2': theme.statusWarning,
+          }}
+        >
+          <Stack direction="vertical" gap="r24">
+            <Stack direction="vertical" gap="r8">
+              <Text variant="Basic" isEmphazed>
+                stacked with yAxisScale="log" — falls back to linear
+              </Text>
+              <Barchart
+                type={{ type: 'category' }}
+                bars={stackedData}
+                title="Stacked"
+                height={200}
+                stacked
+                yAxisScale="log"
+              />
+            </Stack>
+            <Stack direction="vertical" gap="r8">
+              <Text variant="Basic" isEmphazed>
+                stacked with no scale asked for
+              </Text>
+              <Barchart
+                type={{ type: 'category' }}
+                bars={stackedData}
+                title="Stacked"
+                height={200}
+                stacked
+              />
+            </Stack>
+            <ChartLegend shape="rectangle" direction="horizontal" />
+          </Stack>
+        </ChartLegendWrapper>
+      </div>
+    );
+  },
+};

--- a/stories/Heatmap/heatmap.stories.tsx
+++ b/stories/Heatmap/heatmap.stories.tsx
@@ -42,7 +42,7 @@ const FIVE_MINUTES = 5 * 60 * 1000;
 const ONE_HOUR = 60 * 60 * 1000;
 const ONE_DAY = 24 * ONE_HOUR;
 
-const buildBuckets = (start: Date, count: number, step: number): Date[] =>
+const buildTimeSlots = (start: Date, count: number, step: number): Date[] =>
   Array.from({ length: count }, (_, i) => new Date(start.getTime() + i * step));
 
 /** Deterministic pseudo-random so the stories stay stable between renders. */
@@ -50,13 +50,13 @@ const noise = (a: number, b: number) => (a * 73 + b * 151 + a * b * 17) % 100;
 
 const buildStatusRows = (
   labels: string[],
-  bucketCount: number,
+  columnCount: number,
   /** Index from which the whole column is reported as NONE (no data yet). */
-  noDataFrom = bucketCount,
+  noDataFrom = columnCount,
 ): HeatmapRow<CellStatus>[] =>
   labels.map((label, rowIndex) => ({
     label,
-    cells: Array.from({ length: bucketCount }, (_, colIndex) => {
+    cells: Array.from({ length: columnCount }, (_, colIndex) => {
       if (colIndex >= noDataFrom) return 'NONE' as CellStatus;
       const value = noise(rowIndex + 1, colIndex + 1);
       if (value < 7) return 'CRITICAL' as CellStatus;
@@ -86,7 +86,7 @@ const Cell = styled.div<{ $color: string; $dimmed: boolean; $height: string }>`
 
 type StatusHeatmapProps = {
   rows: HeatmapRow<CellStatus>[];
-  buckets: Date[];
+  timeSlots: Date[];
   /** Show one label every N columns. */
   labelEvery?: number;
   cellHeight?: string;
@@ -100,7 +100,7 @@ type StatusHeatmapProps = {
  */
 const StatusGrid = ({
   rows,
-  buckets,
+  timeSlots,
   labelEvery = 1,
   cellHeight = spacing.f20,
   columnGap = spacing.f4,
@@ -111,7 +111,7 @@ const StatusGrid = ({
   return (
     <Box
       display="grid"
-      gridTemplateColumns={`${labelWidth} repeat(${buckets.length}, minmax(0, 1fr))`}
+      gridTemplateColumns={`${labelWidth} repeat(${timeSlots.length}, minmax(0, 1fr))`}
       gap={columnGap}
       alignItems="center"
       flex="1"
@@ -135,7 +135,7 @@ const StatusGrid = ({
                   <Text variant="Smaller" color="textSecondary">
                     <FormattedDateTime
                       format="date-time"
-                      value={buckets[colIndex]}
+                      value={timeSlots[colIndex]}
                     />
                   </Text>
                   <Text variant="Smaller">{status}</Text>
@@ -157,11 +157,11 @@ const StatusGrid = ({
 
       {/* x-axis labels row */}
       <Box />
-      {buckets.map((bucket, colIndex) => (
+      {timeSlots.map((timeSlot, colIndex) => (
         <Box key={`tick-${colIndex}`} textAlign="center" pt={spacing.f4}>
           {colIndex % labelEvery === 0 && (
             <Text variant="Smaller" color="textSecondary">
-              <FormattedDateTime format="time" value={bucket} />
+              <FormattedDateTime format="time" value={timeSlot} />
             </Text>
           )}
         </Box>
@@ -219,7 +219,7 @@ const StatusHeatmap = ({
 const NumericHeatmap = ({
   title,
   rows,
-  buckets,
+  timeSlots,
   unit,
   minOpacity = 0.1,
   labelEvery = 1,
@@ -227,7 +227,7 @@ const NumericHeatmap = ({
 }: {
   title: string;
   rows: HeatmapRow<number>[];
-  buckets: Date[];
+  timeSlots: Date[];
   unit: string;
   /** Opacity given to the lowest value, so it stays visible instead of dissolving. */
   minOpacity?: number;
@@ -245,7 +245,7 @@ const NumericHeatmap = ({
       <Box display="flex" gap={spacing.f24} alignItems="flex-start">
         <Box
           display="grid"
-          gridTemplateColumns={`${labelWidth} repeat(${buckets.length}, minmax(0, 1fr))`}
+          gridTemplateColumns={`${labelWidth} repeat(${timeSlots.length}, minmax(0, 1fr))`}
           gap={spacing.f2}
           alignItems="center"
           flex="1"
@@ -269,7 +269,7 @@ const NumericHeatmap = ({
                       <Text variant="Smaller" color="textSecondary">
                         <FormattedDateTime
                           format="date-time"
-                          value={buckets[colIndex]}
+                          value={timeSlots[colIndex]}
                         />
                       </Text>
                       <Text variant="Smaller">{`${value} ${unit}`}</Text>
@@ -293,11 +293,11 @@ const NumericHeatmap = ({
           ))}
 
           <Box />
-          {buckets.map((bucket, colIndex) => (
+          {timeSlots.map((timeSlot, colIndex) => (
             <Box key={`tick-${colIndex}`} textAlign="center" pt={spacing.f4}>
               {colIndex % labelEvery === 0 && (
                 <Text variant="Smaller" color="textSecondary">
-                  <FormattedDateTime format="time" value={bucket} />
+                  <FormattedDateTime format="time" value={timeSlot} />
                 </Text>
               )}
             </Box>
@@ -341,94 +341,141 @@ const NumericHeatmap = ({
 /*                                  STORIES                                   */
 /* -------------------------------------------------------------------------- */
 
-type HeatmapArgs = {
-  /** Rows to plot, taken from the story's own label source. */
-  rows: number;
-  /** Time buckets, i.e. columns. */
-  buckets: number;
-  /** Trailing columns reported as NONE — the "collection has not caught up" tail. */
-  noDataColumns: number;
+/** Presentational props, shared by every story so a control means the same thing. */
+type LayoutArgs = {
   cellHeight: number;
   columnGap: number;
   labelEvery: number;
   labelWidth: string;
-  /** NumericHeatmap only: opacity given to the lowest value. */
-  minOpacity: number;
 };
 
-const meta: Meta<HeatmapArgs> = {
-  title: 'Components/Data Display/Charts/Heatmap (composition)',
-  argTypes: {
-    rows: { control: { type: 'range', min: 1, max: 24, step: 1 } },
-    buckets: { control: { type: 'range', min: 1, max: 96, step: 1 } },
-    noDataColumns: { control: { type: 'range', min: 0, max: 12, step: 1 } },
-    cellHeight: {
-      control: { type: 'range', min: 4, max: 48, step: 1 },
-      description: 'Cell height in px',
-    },
-    columnGap: {
-      control: { type: 'range', min: 0, max: 16, step: 1 },
-      description:
-        'Gap between cells in px. At 0 the grid reads as a continuous timeline',
-    },
-    labelEvery: {
-      control: { type: 'range', min: 1, max: 12, step: 1 },
-      description: 'Show one column label every N columns',
-    },
-    labelWidth: {
-      control: 'text',
-      description: 'Row label gutter. Labels truncate rather than widen it',
-    },
-    minOpacity: {
-      control: { type: 'range', min: 0, max: 0.6, step: 0.05 },
-      description:
-        'NumericValues only: opacity floor, so low values stay visible',
-    },
+/** Stories whose grid is typed in by hand. The data is the source of truth. */
+type DataArgs = LayoutArgs & { rows: HeatmapRow<CellStatus>[] };
+
+/** Stories whose grid is generated, because hand-editing 400 cells is not a thing. */
+type GeneratedArgs = LayoutArgs & {
+  /** Rows — one per monitored entity: a bucket, a service, a node. */
+  entities: number;
+  /** Columns — one per time slot on the x-axis. */
+  columns: number;
+  /** Trailing columns reported as NONE: the "collection has not caught up" tail. */
+  noDataColumns: number;
+};
+
+const layoutArgTypes = {
+  cellHeight: {
+    control: { type: 'range' as const, min: 4, max: 48, step: 1 },
+    description: 'Cell height in px',
+  },
+  columnGap: {
+    control: { type: 'range' as const, min: 0, max: 16, step: 1 },
+    description:
+      'Gap between cells in px. At 0 the grid reads as a continuous timeline',
+  },
+  labelEvery: {
+    control: { type: 'range' as const, min: 1, max: 12, step: 1 },
+    description: 'Show one column label every N columns',
+  },
+  labelWidth: {
+    control: 'text' as const,
+    description: 'Row label gutter. Labels truncate rather than widen it',
   },
 };
-export default meta;
 
-type Story = StoryObj<HeatmapArgs>;
+const layoutArgs: LayoutArgs = {
+  cellHeight: 20,
+  columnGap: 4,
+  labelEvery: 1,
+  labelWidth: '7rem',
+};
 
-const HOUR_START = new Date('2026-08-25T10:00:00Z');
-const DAY_START = new Date('2026-08-25T00:00:00Z');
-
-/** Args every status story shares, so a control means the same thing in each. */
-const statusArgs = (args: HeatmapArgs) => ({
+const gridProps = (args: LayoutArgs) => ({
   labelEvery: args.labelEvery,
   labelWidth: args.labelWidth,
   cellHeight: `${args.cellHeight}px`,
   columnGap: `${args.columnGap}px`,
 });
 
-const nodeLabels = (count: number) =>
-  Array.from({ length: count }, (_, index) => `storage-node-${index + 1}`);
+const meta: Meta = {
+  title: 'Components/Data Display/Charts/Heatmap (composition)',
+};
+export default meta;
+
+const HOUR_START = new Date('2026-08-25T10:00:00Z');
+const DAY_START = new Date('2026-08-25T00:00:00Z');
+
+/** Row labels for the generated stories, so the count control is honest at any N. */
+const entityLabels = (count: number) =>
+  Array.from(
+    { length: count },
+    (_, index) =>
+      MONITORING_SERVICES[index] ??
+      `storage-node-${index - MONITORING_SERVICES.length + 1}`,
+  );
 
 /**
- * 1:1 with the reference screenshot: 5 services, 4 buckets, the last column
- * has no data yet.
+ * The interactive one: edit the grid itself.
+ *
+ * `rows` is a real control — add a row, rename one, or change any cell to OK,
+ * WARNING, CRITICAL or NONE and the grid follows. The x-axis is derived from the
+ * longest row, so adding cells adds columns; a row with fewer cells leaves the
+ * rest of its line empty rather than shifting anything.
  */
-export const ScreenshotEquivalent: Story = {
+export const Playground: StoryObj<DataArgs> = {
+  argTypes: {
+    ...layoutArgTypes,
+    rows: {
+      control: 'object',
+      description:
+        'One entry per row: { label, cells }. A cell is OK | WARNING | CRITICAL | NONE',
+    },
+  },
   args: {
-    rows: MONITORING_SERVICES.length,
-    buckets: 4,
-    noDataColumns: 1,
-    cellHeight: 20,
-    columnGap: 4,
-    labelEvery: 1,
-    labelWidth: '7rem',
+    ...layoutArgs,
+    rows: [
+      { label: 'Alertmanager', cells: ['OK', 'OK', 'WARNING', 'OK', 'NONE'] },
+      { label: 'Grafana', cells: ['OK', 'OK', 'OK', 'OK', 'NONE'] },
+      {
+        label: 'Prometheus',
+        cells: ['WARNING', 'CRITICAL', 'CRITICAL', 'OK', 'NONE'],
+      },
+      { label: 'Supervisor', cells: ['OK', 'OK', 'OK', 'OK', 'NONE'] },
+      { label: 'Thanos', cells: ['OK', 'WARNING', 'OK', 'OK', 'NONE'] },
+    ],
   },
   render: (args) => {
-    const buckets = buildBuckets(
+    const columns = Math.max(1, ...args.rows.map((row) => row.cells.length));
+    const timeSlots = buildTimeSlots(HOUR_START, columns, FIVE_MINUTES);
+
+    return (
+      <Box maxWidth="60rem">
+        <StatusHeatmap
+          title="Monitoring Services Status"
+          rows={args.rows}
+          timeSlots={timeSlots}
+          {...gridProps(args)}
+        />
+      </Box>
+    );
+  },
+};
+
+/**
+ * 1:1 with the reference screenshot: 5 services, 4 columns, the last one has no
+ * data yet.
+ */
+export const ScreenshotEquivalent: StoryObj<LayoutArgs> = {
+  argTypes: layoutArgTypes,
+  args: layoutArgs,
+  render: (args) => {
+    const timeSlots = buildTimeSlots(
       new Date('2026-08-25T10:30:00Z'),
-      args.buckets,
+      4,
       FIVE_MINUTES,
     );
-    const rows = MONITORING_SERVICES.slice(0, args.rows).map((label) => ({
+    const rows = MONITORING_SERVICES.map((label) => ({
       label,
-      cells: Array.from({ length: args.buckets }, (_, colIndex) =>
-        colIndex >= args.buckets - args.noDataColumns ? 'NONE' : 'OK',
-      ) as CellStatus[],
+      cells: ['OK', 'OK', 'OK', 'NONE'] as CellStatus[],
     }));
 
     return (
@@ -436,40 +483,29 @@ export const ScreenshotEquivalent: Story = {
         <StatusHeatmap
           title="Monitoring Services Status"
           rows={rows}
-          buckets={buckets}
-          {...statusArgs(args)}
+          timeSlots={timeSlots}
+          {...gridProps(args)}
         />
       </Box>
     );
   },
 };
 
-/** Realistic mix over one hour, 5-minute buckets, label every 15 minutes. */
-export const ServiceStatusOverOneHour: Story = {
-  args: {
-    rows: MONITORING_SERVICES.length,
-    buckets: 12,
-    noDataColumns: 2,
-    cellHeight: 20,
-    columnGap: 4,
-    labelEvery: 3,
-    labelWidth: '7rem',
-  },
+/** Realistic generated mix over one hour, 5-minute slots, label every 15 minutes. */
+export const ServiceStatusOverOneHour: StoryObj<LayoutArgs> = {
+  argTypes: layoutArgTypes,
+  args: { ...layoutArgs, labelEvery: 3 },
   render: (args) => {
-    const buckets = buildBuckets(HOUR_START, args.buckets, FIVE_MINUTES);
-    const rows = buildStatusRows(
-      MONITORING_SERVICES.slice(0, args.rows),
-      args.buckets,
-      args.buckets - args.noDataColumns,
-    );
+    const timeSlots = buildTimeSlots(HOUR_START, 12, FIVE_MINUTES);
+    const rows = buildStatusRows(MONITORING_SERVICES, 12, 10);
 
     return (
       <Box maxWidth="60rem">
         <StatusHeatmap
           title="Monitoring Services Status — last hour"
           rows={rows}
-          buckets={buckets}
-          {...statusArgs(args)}
+          timeSlots={timeSlots}
+          {...gridProps(args)}
         />
       </Box>
     );
@@ -477,13 +513,27 @@ export const ServiceStatusOverOneHour: Story = {
 };
 
 /**
- * Dense grid: 8 nodes x 48 buckets over 24 hours. Push the gap to 0 and the grid
- * reads as a continuous timeline; the label frequency is what keeps the axis legible.
+ * Dense grid, generated: entities against time slots. Push the gap to 0 and the
+ * grid reads as a continuous timeline; the label frequency is what keeps the
+ * x-axis legible.
  */
-export const DenseGrid: Story = {
+export const DenseGrid: StoryObj<GeneratedArgs> = {
+  argTypes: {
+    ...layoutArgTypes,
+    entities: {
+      control: { type: 'range', min: 1, max: 24, step: 1 },
+      description: 'Rows — one per monitored entity',
+    },
+    columns: {
+      control: { type: 'range', min: 2, max: 96, step: 1 },
+      description: 'Columns — one per time slot',
+    },
+    noDataColumns: { control: { type: 'range', min: 0, max: 12, step: 1 } },
+  },
   args: {
-    rows: 8,
-    buckets: 48,
+    ...layoutArgs,
+    entities: 8,
+    columns: 48,
     noDataColumns: 3,
     cellHeight: 16,
     columnGap: 1,
@@ -491,15 +541,15 @@ export const DenseGrid: Story = {
     labelWidth: '9rem',
   },
   render: (args) => {
-    const buckets = buildBuckets(
+    const timeSlots = buildTimeSlots(
       DAY_START,
-      args.buckets,
-      ONE_DAY / args.buckets,
+      args.columns,
+      ONE_DAY / args.columns,
     );
     const rows = buildStatusRows(
-      nodeLabels(args.rows),
-      args.buckets,
-      args.buckets - args.noDataColumns,
+      entityLabels(args.entities),
+      args.columns,
+      args.columns - args.noDataColumns,
     );
 
     return (
@@ -507,8 +557,8 @@ export const DenseGrid: Story = {
         <StatusHeatmap
           title="Node health — last 24 hours"
           rows={rows}
-          buckets={buckets}
-          {...statusArgs(args)}
+          timeSlots={timeSlots}
+          {...gridProps(args)}
         />
       </Box>
     );
@@ -516,22 +566,31 @@ export const DenseGrid: Story = {
 };
 
 /** Continuous values instead of statuses: opacity ramp + gradient scale. */
-export const NumericValues: Story = {
+export const NumericValues: StoryObj<
+  Omit<GeneratedArgs, 'noDataColumns'> & { minOpacity: number }
+> = {
+  argTypes: {
+    ...layoutArgTypes,
+    entities: { control: { type: 'range', min: 1, max: 24, step: 1 } },
+    columns: { control: { type: 'range', min: 2, max: 48, step: 1 } },
+    minOpacity: {
+      control: { type: 'range', min: 0, max: 0.6, step: 0.05 },
+      description: 'Opacity floor, so the low values stay visible',
+    },
+  },
   args: {
-    rows: 6,
-    buckets: 24,
-    noDataColumns: 0,
-    cellHeight: 20,
-    columnGap: 2,
+    ...layoutArgs,
+    entities: 6,
+    columns: 24,
     labelEvery: 3,
     labelWidth: '9rem',
     minOpacity: 0.1,
   },
   render: (args) => {
-    const buckets = buildBuckets(DAY_START, args.buckets, ONE_HOUR);
-    const rows = nodeLabels(args.rows).map((label, rowIndex) => ({
+    const timeSlots = buildTimeSlots(DAY_START, args.columns, ONE_HOUR);
+    const rows = entityLabels(args.entities).map((label, rowIndex) => ({
       label,
-      cells: Array.from({ length: args.buckets }, (_, colIndex) =>
+      cells: Array.from({ length: args.columns }, (_, colIndex) =>
         Math.round(noise(rowIndex + 3, colIndex + 5)),
       ),
     }));
@@ -541,7 +600,7 @@ export const NumericValues: Story = {
         <NumericHeatmap
           title="CPU usage — last 24 hours"
           rows={rows}
-          buckets={buckets}
+          timeSlots={timeSlots}
           unit="%"
           minOpacity={args.minOpacity}
           labelEvery={args.labelEvery}

--- a/stories/Heatmap/heatmap.stories.tsx
+++ b/stories/Heatmap/heatmap.stories.tsx
@@ -2,11 +2,9 @@ import { Meta, StoryObj } from '@storybook/react-webpack5';
 import React from 'react';
 import styled, { useTheme } from 'styled-components';
 import {
-  Alert,
   Box,
   ChartLegend,
   ChartLegendWrapper,
-  GlobalHealthBar,
   useChartLegend,
 } from '../../src/lib/next';
 import { spacing, Stack } from '../../src/lib/spacing';
@@ -18,8 +16,8 @@ import { FormattedDateTime } from '../../src/lib/components/date/FormattedDateTi
  * Heatmap built by composing existing core-ui primitives — no new component.
  *
  * Two recipes:
- *  - `StatusHeatmap`    : Box (CSS grid) + Tooltip + ChartLegendWrapper/ChartLegend
- *  - `HealthBarHeatmap` : one GlobalHealthBar per row
+ *  - `StatusHeatmap`  : discrete statuses — Box (CSS grid) + Tooltip + ChartLegend
+ *  - `NumericHeatmap` : continuous values — the same grid under an opacity ramp
  */
 
 /* -------------------------------------------------------------------------- */
@@ -215,132 +213,7 @@ const StatusHeatmap = ({
 };
 
 /* -------------------------------------------------------------------------- */
-/*                    RECIPE 2 — one GlobalHealthBar per row                  */
-/* -------------------------------------------------------------------------- */
-
-const SEVERITY_BY_STATUS: Record<CellStatus, Alert['severity'] | null> = {
-  // OK needs no alert: the GlobalHealthBar background bar is already healthy
-  OK: null,
-  WARNING: 'warning',
-  CRITICAL: 'critical',
-  NONE: 'unavailable',
-};
-
-const statusRowToAlerts = (
-  row: HeatmapRow<CellStatus>,
-  buckets: Date[],
-  step: number,
-): Alert[] =>
-  row.cells.flatMap((status, colIndex) => {
-    const severity = SEVERITY_BY_STATUS[status];
-    if (!severity) return [];
-    const bucketStart = buckets[colIndex];
-    return [
-      {
-        key: `${row.label}-${colIndex}`,
-        severity,
-        description: `${row.label} — ${status}`,
-        startsAt: bucketStart.toISOString(),
-        endsAt: new Date(bucketStart.getTime() + step).toISOString(),
-      },
-    ];
-  });
-
-/**
- * GlobalHealthBar draws its own x-axis. On a stack of rows we keep only the
- * last one, and claw back the vertical space the hidden axes still occupy.
- */
-const HealthBarCell = styled.div<{ $hideAxis: boolean }>`
-  ${({ $hideAxis }) =>
-    $hideAxis &&
-    `
-      .recharts-xAxis {
-        visibility: hidden;
-      }
-      margin-bottom: -0.75rem;
-    `}
-`;
-
-const HealthBarHeatmap = ({
-  title,
-  rows,
-  buckets,
-  step,
-  start,
-  end,
-  labelWidth = '7rem',
-}: {
-  title: string;
-  rows: HeatmapRow<CellStatus>[];
-  buckets: Date[];
-  step: number;
-  start: Date;
-  end: Date;
-  labelWidth?: string;
-}) => {
-  const theme = useTheme();
-
-  return (
-    <ChartLegendWrapper
-      colorSet={{
-        OK: theme.statusHealthy,
-        WARNING: theme.statusWarning,
-        CRITICAL: theme.statusCritical,
-        NONE: theme.textSecondary,
-      }}
-      sortOrder={(a, b) =>
-        STATUS_ORDER.indexOf(a as CellStatus) -
-        STATUS_ORDER.indexOf(b as CellStatus)
-      }
-    >
-      <Stack direction="vertical" gap="r16">
-        <Text variant="Large" isEmphazed>
-          {title}
-        </Text>
-        <Box display="flex" gap={spacing.f24} alignItems="flex-start">
-          <Box
-            display="grid"
-            gridTemplateColumns={`${labelWidth} minmax(0, 1fr)`}
-            alignItems="center"
-            flex="1"
-          >
-            {rows.map((row, rowIndex) => (
-              <React.Fragment key={row.label}>
-                <Box textAlign="right" pr={spacing.f8}>
-                  <Text variant="Smaller" color="textSecondary">
-                    {row.label}
-                  </Text>
-                </Box>
-                <HealthBarCell $hideAxis={rowIndex !== rows.length - 1}>
-                  <GlobalHealthBar
-                    id={`healthmap-${row.label}`}
-                    start={start}
-                    end={end}
-                    alerts={statusRowToAlerts(row, buckets, step)}
-                  />
-                </HealthBarCell>
-              </React.Fragment>
-            ))}
-          </Box>
-          <Stack direction="vertical" gap="r8">
-            <Text variant="Smaller" isEmphazed>
-              Service Status
-            </Text>
-            <ChartLegend
-              shape="rectangle"
-              direction="vertical"
-              legendSize="Smaller"
-              legendColor="textSecondary"
-            />
-          </Stack>
-        </Box>
-      </Stack>
-    </ChartLegendWrapper>
-  );
-};
-
-/* -------------------------------------------------------------------------- */
-/*                    RECIPE 3 — continuous (numeric) heatmap                 */
+/*                   RECIPE 2 — continuous (numeric) heatmap                  */
 /* -------------------------------------------------------------------------- */
 
 const NumericHeatmap = ({
@@ -348,6 +221,7 @@ const NumericHeatmap = ({
   rows,
   buckets,
   unit,
+  minOpacity = 0.1,
   labelEvery = 1,
   labelWidth = '7rem',
 }: {
@@ -355,6 +229,8 @@ const NumericHeatmap = ({
   rows: HeatmapRow<number>[];
   buckets: Date[];
   unit: string;
+  /** Opacity given to the lowest value, so it stays visible instead of dissolving. */
+  minOpacity?: number;
   labelEvery?: number;
   labelWidth?: string;
 }) => {
@@ -402,8 +278,8 @@ const NumericHeatmap = ({
                 >
                   <Cell
                     $color={`rgba(${theme.statusHealthyRGB}, ${(
-                      0.1 +
-                      0.9 * (value / max)
+                      minOpacity +
+                      (1 - minOpacity) * (value / max)
                     ).toFixed(2)})`}
                     $dimmed={false}
                     $height={spacing.f20}
@@ -439,7 +315,7 @@ const NumericHeatmap = ({
               height="6rem"
               borderRadius={spacing.f2}
               style={{
-                background: `linear-gradient(to top, rgba(${theme.statusHealthyRGB}, 0.1), rgba(${theme.statusHealthyRGB}, 1))`,
+                background: `linear-gradient(to top, rgba(${theme.statusHealthyRGB}, ${minOpacity}), rgba(${theme.statusHealthyRGB}, 1))`,
               }}
             />
             <Box
@@ -465,30 +341,94 @@ const NumericHeatmap = ({
 /*                                  STORIES                                   */
 /* -------------------------------------------------------------------------- */
 
-const meta: Meta = {
+type HeatmapArgs = {
+  /** Rows to plot, taken from the story's own label source. */
+  rows: number;
+  /** Time buckets, i.e. columns. */
+  buckets: number;
+  /** Trailing columns reported as NONE — the "collection has not caught up" tail. */
+  noDataColumns: number;
+  cellHeight: number;
+  columnGap: number;
+  labelEvery: number;
+  labelWidth: string;
+  /** NumericHeatmap only: opacity given to the lowest value. */
+  minOpacity: number;
+};
+
+const meta: Meta<HeatmapArgs> = {
   title: 'Components/Data Display/Charts/Heatmap (composition)',
+  argTypes: {
+    rows: { control: { type: 'range', min: 1, max: 24, step: 1 } },
+    buckets: { control: { type: 'range', min: 1, max: 96, step: 1 } },
+    noDataColumns: { control: { type: 'range', min: 0, max: 12, step: 1 } },
+    cellHeight: {
+      control: { type: 'range', min: 4, max: 48, step: 1 },
+      description: 'Cell height in px',
+    },
+    columnGap: {
+      control: { type: 'range', min: 0, max: 16, step: 1 },
+      description:
+        'Gap between cells in px. At 0 the grid reads as a continuous timeline',
+    },
+    labelEvery: {
+      control: { type: 'range', min: 1, max: 12, step: 1 },
+      description: 'Show one column label every N columns',
+    },
+    labelWidth: {
+      control: 'text',
+      description: 'Row label gutter. Labels truncate rather than widen it',
+    },
+    minOpacity: {
+      control: { type: 'range', min: 0, max: 0.6, step: 0.05 },
+      description:
+        'NumericValues only: opacity floor, so low values stay visible',
+    },
+  },
 };
 export default meta;
 
-type Story = StoryObj;
+type Story = StoryObj<HeatmapArgs>;
 
 const HOUR_START = new Date('2026-08-25T10:00:00Z');
 const DAY_START = new Date('2026-08-25T00:00:00Z');
+
+/** Args every status story shares, so a control means the same thing in each. */
+const statusArgs = (args: HeatmapArgs) => ({
+  labelEvery: args.labelEvery,
+  labelWidth: args.labelWidth,
+  cellHeight: `${args.cellHeight}px`,
+  columnGap: `${args.columnGap}px`,
+});
+
+const nodeLabels = (count: number) =>
+  Array.from({ length: count }, (_, index) => `storage-node-${index + 1}`);
 
 /**
  * 1:1 with the reference screenshot: 5 services, 4 buckets, the last column
  * has no data yet.
  */
 export const ScreenshotEquivalent: Story = {
-  render: () => {
+  args: {
+    rows: MONITORING_SERVICES.length,
+    buckets: 4,
+    noDataColumns: 1,
+    cellHeight: 20,
+    columnGap: 4,
+    labelEvery: 1,
+    labelWidth: '7rem',
+  },
+  render: (args) => {
     const buckets = buildBuckets(
       new Date('2026-08-25T10:30:00Z'),
-      4,
+      args.buckets,
       FIVE_MINUTES,
     );
-    const rows = MONITORING_SERVICES.map((label) => ({
+    const rows = MONITORING_SERVICES.slice(0, args.rows).map((label) => ({
       label,
-      cells: ['OK', 'OK', 'OK', 'NONE'] as CellStatus[],
+      cells: Array.from({ length: args.buckets }, (_, colIndex) =>
+        colIndex >= args.buckets - args.noDataColumns ? 'NONE' : 'OK',
+      ) as CellStatus[],
     }));
 
     return (
@@ -497,6 +437,7 @@ export const ScreenshotEquivalent: Story = {
           title="Monitoring Services Status"
           rows={rows}
           buckets={buckets}
+          {...statusArgs(args)}
         />
       </Box>
     );
@@ -505,9 +446,22 @@ export const ScreenshotEquivalent: Story = {
 
 /** Realistic mix over one hour, 5-minute buckets, label every 15 minutes. */
 export const ServiceStatusOverOneHour: Story = {
-  render: () => {
-    const buckets = buildBuckets(HOUR_START, 12, FIVE_MINUTES);
-    const rows = buildStatusRows(MONITORING_SERVICES, 12, 10);
+  args: {
+    rows: MONITORING_SERVICES.length,
+    buckets: 12,
+    noDataColumns: 2,
+    cellHeight: 20,
+    columnGap: 4,
+    labelEvery: 3,
+    labelWidth: '7rem',
+  },
+  render: (args) => {
+    const buckets = buildBuckets(HOUR_START, args.buckets, FIVE_MINUTES);
+    const rows = buildStatusRows(
+      MONITORING_SERVICES.slice(0, args.rows),
+      args.buckets,
+      args.buckets - args.noDataColumns,
+    );
 
     return (
       <Box maxWidth="60rem">
@@ -515,7 +469,7 @@ export const ServiceStatusOverOneHour: Story = {
           title="Monitoring Services Status — last hour"
           rows={rows}
           buckets={buckets}
-          labelEvery={3}
+          {...statusArgs(args)}
         />
       </Box>
     );
@@ -523,35 +477,30 @@ export const ServiceStatusOverOneHour: Story = {
 };
 
 /**
- * Same data, rendered as one GlobalHealthBar per row: continuous timeline,
- * and you get the existing tooltip + keyboard navigation for free.
+ * Dense grid: 8 nodes x 48 buckets over 24 hours. Push the gap to 0 and the grid
+ * reads as a continuous timeline; the label frequency is what keeps the axis legible.
  */
-export const AsGlobalHealthBarRows: Story = {
-  render: () => {
-    const buckets = buildBuckets(HOUR_START, 12, FIVE_MINUTES);
-    const rows = buildStatusRows(MONITORING_SERVICES, 12, 10);
-
-    return (
-      <Box maxWidth="60rem">
-        <HealthBarHeatmap
-          title="Monitoring Services Status — last hour"
-          rows={rows}
-          buckets={buckets}
-          step={FIVE_MINUTES}
-          start={HOUR_START}
-          end={new Date(HOUR_START.getTime() + ONE_HOUR)}
-        />
-      </Box>
-    );
-  },
-};
-
-/** Dense grid: 8 nodes x 48 buckets of 30 minutes over 24 hours. */
 export const DenseGrid: Story = {
-  render: () => {
-    const buckets = buildBuckets(DAY_START, 48, ONE_DAY / 48);
-    const nodes = Array.from({ length: 8 }, (_, i) => `storage-node-${i + 1}`);
-    const rows = buildStatusRows(nodes, 48, 45);
+  args: {
+    rows: 8,
+    buckets: 48,
+    noDataColumns: 3,
+    cellHeight: 16,
+    columnGap: 1,
+    labelEvery: 6,
+    labelWidth: '9rem',
+  },
+  render: (args) => {
+    const buckets = buildBuckets(
+      DAY_START,
+      args.buckets,
+      ONE_DAY / args.buckets,
+    );
+    const rows = buildStatusRows(
+      nodeLabels(args.rows),
+      args.buckets,
+      args.buckets - args.noDataColumns,
+    );
 
     return (
       <Box maxWidth="75rem">
@@ -559,10 +508,7 @@ export const DenseGrid: Story = {
           title="Node health — last 24 hours"
           rows={rows}
           buckets={buckets}
-          labelEvery={6}
-          columnGap={spacing.f1}
-          cellHeight={spacing.f16}
-          labelWidth="9rem"
+          {...statusArgs(args)}
         />
       </Box>
     );
@@ -571,11 +517,21 @@ export const DenseGrid: Story = {
 
 /** Continuous values instead of statuses: opacity ramp + gradient scale. */
 export const NumericValues: Story = {
-  render: () => {
-    const buckets = buildBuckets(DAY_START, 24, ONE_HOUR);
-    const rows = Array.from({ length: 6 }, (_, rowIndex) => ({
-      label: `storage-node-${rowIndex + 1}`,
-      cells: Array.from({ length: 24 }, (_, colIndex) =>
+  args: {
+    rows: 6,
+    buckets: 24,
+    noDataColumns: 0,
+    cellHeight: 20,
+    columnGap: 2,
+    labelEvery: 3,
+    labelWidth: '9rem',
+    minOpacity: 0.1,
+  },
+  render: (args) => {
+    const buckets = buildBuckets(DAY_START, args.buckets, ONE_HOUR);
+    const rows = nodeLabels(args.rows).map((label, rowIndex) => ({
+      label,
+      cells: Array.from({ length: args.buckets }, (_, colIndex) =>
         Math.round(noise(rowIndex + 3, colIndex + 5)),
       ),
     }));
@@ -587,8 +543,9 @@ export const NumericValues: Story = {
           rows={rows}
           buckets={buckets}
           unit="%"
-          labelEvery={3}
-          labelWidth="9rem"
+          minOpacity={args.minOpacity}
+          labelEvery={args.labelEvery}
+          labelWidth={args.labelWidth}
         />
       </Box>
     );

--- a/stories/Heatmap/heatmap.stories.tsx
+++ b/stories/Heatmap/heatmap.stories.tsx
@@ -1,0 +1,596 @@
+import { Meta, StoryObj } from '@storybook/react-webpack5';
+import React from 'react';
+import styled, { useTheme } from 'styled-components';
+import {
+  Alert,
+  Box,
+  ChartLegend,
+  ChartLegendWrapper,
+  GlobalHealthBar,
+  useChartLegend,
+} from '../../src/lib/next';
+import { spacing, Stack } from '../../src/lib/spacing';
+import { Text } from '../../src/lib/components/text/Text.component';
+import { Tooltip } from '../../src/lib/components/tooltip/Tooltip.component';
+import { FormattedDateTime } from '../../src/lib/components/date/FormattedDateTime';
+
+/**
+ * Heatmap built by composing existing core-ui primitives — no new component.
+ *
+ * Two recipes:
+ *  - `StatusHeatmap`    : Box (CSS grid) + Tooltip + ChartLegendWrapper/ChartLegend
+ *  - `HealthBarHeatmap` : one GlobalHealthBar per row
+ */
+
+/* -------------------------------------------------------------------------- */
+/*                                    DATA                                    */
+/* -------------------------------------------------------------------------- */
+
+type CellStatus = 'OK' | 'WARNING' | 'CRITICAL' | 'NONE';
+
+const STATUS_ORDER: CellStatus[] = ['OK', 'WARNING', 'CRITICAL', 'NONE'];
+
+type HeatmapRow<T> = { label: string; cells: T[] };
+
+const MONITORING_SERVICES = [
+  'Alertmanager',
+  'Grafana',
+  'Prometheus',
+  'Supervisor',
+  'Thanos',
+];
+
+const FIVE_MINUTES = 5 * 60 * 1000;
+const ONE_HOUR = 60 * 60 * 1000;
+const ONE_DAY = 24 * ONE_HOUR;
+
+const buildBuckets = (start: Date, count: number, step: number): Date[] =>
+  Array.from({ length: count }, (_, i) => new Date(start.getTime() + i * step));
+
+/** Deterministic pseudo-random so the stories stay stable between renders. */
+const noise = (a: number, b: number) => (a * 73 + b * 151 + a * b * 17) % 100;
+
+const buildStatusRows = (
+  labels: string[],
+  bucketCount: number,
+  /** Index from which the whole column is reported as NONE (no data yet). */
+  noDataFrom = bucketCount,
+): HeatmapRow<CellStatus>[] =>
+  labels.map((label, rowIndex) => ({
+    label,
+    cells: Array.from({ length: bucketCount }, (_, colIndex) => {
+      if (colIndex >= noDataFrom) return 'NONE' as CellStatus;
+      const value = noise(rowIndex + 1, colIndex + 1);
+      if (value < 7) return 'CRITICAL' as CellStatus;
+      if (value < 22) return 'WARNING' as CellStatus;
+      return 'OK' as CellStatus;
+    }),
+  }));
+
+/* -------------------------------------------------------------------------- */
+/*                        RECIPE 1 — Box grid + Tooltip                       */
+/* -------------------------------------------------------------------------- */
+
+const Cell = styled.div<{ $color: string; $dimmed: boolean; $height: string }>`
+  height: ${({ $height }) => $height};
+  border-radius: ${spacing.f2};
+  background-color: ${({ $color }) => $color};
+  opacity: ${({ $dimmed }) => ($dimmed ? 0.15 : 1)};
+  transition: opacity 0.15s ease;
+  cursor: pointer;
+
+  /* outline, not border: it paints outside the box so nothing is re-laid out */
+  &:hover {
+    outline: ${spacing.f2} solid ${({ theme }) => theme.selectedActive};
+    outline-offset: ${spacing.f1};
+  }
+`;
+
+type StatusHeatmapProps = {
+  rows: HeatmapRow<CellStatus>[];
+  buckets: Date[];
+  /** Show one label every N columns. */
+  labelEvery?: number;
+  cellHeight?: string;
+  columnGap?: string;
+  labelWidth?: string;
+};
+
+/**
+ * Reads its colors from the ChartLegendWrapper context, so the legend is the
+ * single source of truth and clicking a legend item actually filters the grid.
+ */
+const StatusGrid = ({
+  rows,
+  buckets,
+  labelEvery = 1,
+  cellHeight = spacing.f20,
+  columnGap = spacing.f4,
+  labelWidth = '7rem',
+}: StatusHeatmapProps) => {
+  const { getColor, isSelected } = useChartLegend();
+
+  return (
+    <Box
+      display="grid"
+      gridTemplateColumns={`${labelWidth} repeat(${buckets.length}, minmax(0, 1fr))`}
+      gap={columnGap}
+      alignItems="center"
+      flex="1"
+    >
+      {rows.map((row) => (
+        <React.Fragment key={row.label}>
+          <Box textAlign="right" pr={spacing.f8}>
+            <Text variant="Smaller" color="textSecondary">
+              {row.label}
+            </Text>
+          </Box>
+          {row.cells.map((status, colIndex) => (
+            <Tooltip
+              key={`${row.label}-${colIndex}`}
+              placement="top"
+              overlay={
+                <Stack direction="vertical" gap="r2">
+                  <Text variant="Smaller" isEmphazed>
+                    {row.label}
+                  </Text>
+                  <Text variant="Smaller" color="textSecondary">
+                    <FormattedDateTime
+                      format="date-time"
+                      value={buckets[colIndex]}
+                    />
+                  </Text>
+                  <Text variant="Smaller">{status}</Text>
+                </Stack>
+              }
+            >
+              <Cell
+                $color={getColor(status) ?? 'transparent'}
+                $dimmed={!isSelected(status)}
+                $height={cellHeight}
+                tabIndex={0}
+                role="img"
+                aria-label={`${row.label} ${status}`}
+              />
+            </Tooltip>
+          ))}
+        </React.Fragment>
+      ))}
+
+      {/* x-axis labels row */}
+      <Box />
+      {buckets.map((bucket, colIndex) => (
+        <Box key={`tick-${colIndex}`} textAlign="center" pt={spacing.f4}>
+          {colIndex % labelEvery === 0 && (
+            <Text variant="Smaller" color="textSecondary">
+              <FormattedDateTime format="time" value={bucket} />
+            </Text>
+          )}
+        </Box>
+      ))}
+    </Box>
+  );
+};
+
+const StatusHeatmap = ({
+  title,
+  ...gridProps
+}: StatusHeatmapProps & { title: string }) => {
+  const theme = useTheme();
+
+  return (
+    <ChartLegendWrapper
+      colorSet={{
+        OK: theme.statusHealthy,
+        WARNING: theme.statusWarning,
+        CRITICAL: theme.statusCritical,
+        NONE: theme.textSecondary,
+      }}
+      sortOrder={(a, b) =>
+        STATUS_ORDER.indexOf(a as CellStatus) -
+        STATUS_ORDER.indexOf(b as CellStatus)
+      }
+    >
+      <Stack direction="vertical" gap="r16">
+        <Text variant="Large" isEmphazed>
+          {title}
+        </Text>
+        <Box display="flex" gap={spacing.f24} alignItems="flex-start">
+          <StatusGrid {...gridProps} />
+          <Stack direction="vertical" gap="r8">
+            <Text variant="Smaller" isEmphazed>
+              Service Status
+            </Text>
+            <ChartLegend
+              shape="rectangle"
+              direction="vertical"
+              legendSize="Smaller"
+              legendColor="textSecondary"
+            />
+          </Stack>
+        </Box>
+      </Stack>
+    </ChartLegendWrapper>
+  );
+};
+
+/* -------------------------------------------------------------------------- */
+/*                    RECIPE 2 — one GlobalHealthBar per row                  */
+/* -------------------------------------------------------------------------- */
+
+const SEVERITY_BY_STATUS: Record<CellStatus, Alert['severity'] | null> = {
+  // OK needs no alert: the GlobalHealthBar background bar is already healthy
+  OK: null,
+  WARNING: 'warning',
+  CRITICAL: 'critical',
+  NONE: 'unavailable',
+};
+
+const statusRowToAlerts = (
+  row: HeatmapRow<CellStatus>,
+  buckets: Date[],
+  step: number,
+): Alert[] =>
+  row.cells.flatMap((status, colIndex) => {
+    const severity = SEVERITY_BY_STATUS[status];
+    if (!severity) return [];
+    const bucketStart = buckets[colIndex];
+    return [
+      {
+        key: `${row.label}-${colIndex}`,
+        severity,
+        description: `${row.label} — ${status}`,
+        startsAt: bucketStart.toISOString(),
+        endsAt: new Date(bucketStart.getTime() + step).toISOString(),
+      },
+    ];
+  });
+
+/**
+ * GlobalHealthBar draws its own x-axis. On a stack of rows we keep only the
+ * last one, and claw back the vertical space the hidden axes still occupy.
+ */
+const HealthBarCell = styled.div<{ $hideAxis: boolean }>`
+  ${({ $hideAxis }) =>
+    $hideAxis &&
+    `
+      .recharts-xAxis {
+        visibility: hidden;
+      }
+      margin-bottom: -0.75rem;
+    `}
+`;
+
+const HealthBarHeatmap = ({
+  title,
+  rows,
+  buckets,
+  step,
+  start,
+  end,
+  labelWidth = '7rem',
+}: {
+  title: string;
+  rows: HeatmapRow<CellStatus>[];
+  buckets: Date[];
+  step: number;
+  start: Date;
+  end: Date;
+  labelWidth?: string;
+}) => {
+  const theme = useTheme();
+
+  return (
+    <ChartLegendWrapper
+      colorSet={{
+        OK: theme.statusHealthy,
+        WARNING: theme.statusWarning,
+        CRITICAL: theme.statusCritical,
+        NONE: theme.textSecondary,
+      }}
+      sortOrder={(a, b) =>
+        STATUS_ORDER.indexOf(a as CellStatus) -
+        STATUS_ORDER.indexOf(b as CellStatus)
+      }
+    >
+      <Stack direction="vertical" gap="r16">
+        <Text variant="Large" isEmphazed>
+          {title}
+        </Text>
+        <Box display="flex" gap={spacing.f24} alignItems="flex-start">
+          <Box
+            display="grid"
+            gridTemplateColumns={`${labelWidth} minmax(0, 1fr)`}
+            alignItems="center"
+            flex="1"
+          >
+            {rows.map((row, rowIndex) => (
+              <React.Fragment key={row.label}>
+                <Box textAlign="right" pr={spacing.f8}>
+                  <Text variant="Smaller" color="textSecondary">
+                    {row.label}
+                  </Text>
+                </Box>
+                <HealthBarCell $hideAxis={rowIndex !== rows.length - 1}>
+                  <GlobalHealthBar
+                    id={`healthmap-${row.label}`}
+                    start={start}
+                    end={end}
+                    alerts={statusRowToAlerts(row, buckets, step)}
+                  />
+                </HealthBarCell>
+              </React.Fragment>
+            ))}
+          </Box>
+          <Stack direction="vertical" gap="r8">
+            <Text variant="Smaller" isEmphazed>
+              Service Status
+            </Text>
+            <ChartLegend
+              shape="rectangle"
+              direction="vertical"
+              legendSize="Smaller"
+              legendColor="textSecondary"
+            />
+          </Stack>
+        </Box>
+      </Stack>
+    </ChartLegendWrapper>
+  );
+};
+
+/* -------------------------------------------------------------------------- */
+/*                    RECIPE 3 — continuous (numeric) heatmap                 */
+/* -------------------------------------------------------------------------- */
+
+const NumericHeatmap = ({
+  title,
+  rows,
+  buckets,
+  unit,
+  labelEvery = 1,
+  labelWidth = '7rem',
+}: {
+  title: string;
+  rows: HeatmapRow<number>[];
+  buckets: Date[];
+  unit: string;
+  labelEvery?: number;
+  labelWidth?: string;
+}) => {
+  const theme = useTheme();
+  const max = Math.max(...rows.flatMap((row) => row.cells));
+
+  return (
+    <Stack direction="vertical" gap="r16">
+      <Text variant="Large" isEmphazed>
+        {title}
+      </Text>
+      <Box display="flex" gap={spacing.f24} alignItems="flex-start">
+        <Box
+          display="grid"
+          gridTemplateColumns={`${labelWidth} repeat(${buckets.length}, minmax(0, 1fr))`}
+          gap={spacing.f2}
+          alignItems="center"
+          flex="1"
+        >
+          {rows.map((row) => (
+            <React.Fragment key={row.label}>
+              <Box textAlign="right" pr={spacing.f8}>
+                <Text variant="Smaller" color="textSecondary">
+                  {row.label}
+                </Text>
+              </Box>
+              {row.cells.map((value, colIndex) => (
+                <Tooltip
+                  key={`${row.label}-${colIndex}`}
+                  placement="top"
+                  overlay={
+                    <Stack direction="vertical" gap="r2">
+                      <Text variant="Smaller" isEmphazed>
+                        {row.label}
+                      </Text>
+                      <Text variant="Smaller" color="textSecondary">
+                        <FormattedDateTime
+                          format="date-time"
+                          value={buckets[colIndex]}
+                        />
+                      </Text>
+                      <Text variant="Smaller">{`${value} ${unit}`}</Text>
+                    </Stack>
+                  }
+                >
+                  <Cell
+                    $color={`rgba(${theme.statusHealthyRGB}, ${(
+                      0.1 +
+                      0.9 * (value / max)
+                    ).toFixed(2)})`}
+                    $dimmed={false}
+                    $height={spacing.f20}
+                    tabIndex={0}
+                    role="img"
+                    aria-label={`${row.label} ${value} ${unit}`}
+                  />
+                </Tooltip>
+              ))}
+            </React.Fragment>
+          ))}
+
+          <Box />
+          {buckets.map((bucket, colIndex) => (
+            <Box key={`tick-${colIndex}`} textAlign="center" pt={spacing.f4}>
+              {colIndex % labelEvery === 0 && (
+                <Text variant="Smaller" color="textSecondary">
+                  <FormattedDateTime format="time" value={bucket} />
+                </Text>
+              )}
+            </Box>
+          ))}
+        </Box>
+
+        {/* continuous scale: a gradient instead of discrete legend items */}
+        <Stack direction="vertical" gap="r8">
+          <Text variant="Smaller" isEmphazed>
+            {unit}
+          </Text>
+          <Stack direction="horizontal" gap="r8">
+            <Box
+              width={spacing.f12}
+              height="6rem"
+              borderRadius={spacing.f2}
+              style={{
+                background: `linear-gradient(to top, rgba(${theme.statusHealthyRGB}, 0.1), rgba(${theme.statusHealthyRGB}, 1))`,
+              }}
+            />
+            <Box
+              display="flex"
+              flexDirection="column"
+              justifyContent="space-between"
+            >
+              <Text variant="Smaller" color="textSecondary">
+                {max}
+              </Text>
+              <Text variant="Smaller" color="textSecondary">
+                0
+              </Text>
+            </Box>
+          </Stack>
+        </Stack>
+      </Box>
+    </Stack>
+  );
+};
+
+/* -------------------------------------------------------------------------- */
+/*                                  STORIES                                   */
+/* -------------------------------------------------------------------------- */
+
+const meta: Meta = {
+  title: 'Components/Data Display/Charts/Heatmap (composition)',
+};
+export default meta;
+
+type Story = StoryObj;
+
+const HOUR_START = new Date('2026-08-25T10:00:00Z');
+const DAY_START = new Date('2026-08-25T00:00:00Z');
+
+/**
+ * 1:1 with the reference screenshot: 5 services, 4 buckets, the last column
+ * has no data yet.
+ */
+export const ScreenshotEquivalent: Story = {
+  render: () => {
+    const buckets = buildBuckets(
+      new Date('2026-08-25T10:30:00Z'),
+      4,
+      FIVE_MINUTES,
+    );
+    const rows = MONITORING_SERVICES.map((label) => ({
+      label,
+      cells: ['OK', 'OK', 'OK', 'NONE'] as CellStatus[],
+    }));
+
+    return (
+      <Box maxWidth="60rem">
+        <StatusHeatmap
+          title="Monitoring Services Status"
+          rows={rows}
+          buckets={buckets}
+        />
+      </Box>
+    );
+  },
+};
+
+/** Realistic mix over one hour, 5-minute buckets, label every 15 minutes. */
+export const ServiceStatusOverOneHour: Story = {
+  render: () => {
+    const buckets = buildBuckets(HOUR_START, 12, FIVE_MINUTES);
+    const rows = buildStatusRows(MONITORING_SERVICES, 12, 10);
+
+    return (
+      <Box maxWidth="60rem">
+        <StatusHeatmap
+          title="Monitoring Services Status — last hour"
+          rows={rows}
+          buckets={buckets}
+          labelEvery={3}
+        />
+      </Box>
+    );
+  },
+};
+
+/**
+ * Same data, rendered as one GlobalHealthBar per row: continuous timeline,
+ * and you get the existing tooltip + keyboard navigation for free.
+ */
+export const AsGlobalHealthBarRows: Story = {
+  render: () => {
+    const buckets = buildBuckets(HOUR_START, 12, FIVE_MINUTES);
+    const rows = buildStatusRows(MONITORING_SERVICES, 12, 10);
+
+    return (
+      <Box maxWidth="60rem">
+        <HealthBarHeatmap
+          title="Monitoring Services Status — last hour"
+          rows={rows}
+          buckets={buckets}
+          step={FIVE_MINUTES}
+          start={HOUR_START}
+          end={new Date(HOUR_START.getTime() + ONE_HOUR)}
+        />
+      </Box>
+    );
+  },
+};
+
+/** Dense grid: 8 nodes x 48 buckets of 30 minutes over 24 hours. */
+export const DenseGrid: Story = {
+  render: () => {
+    const buckets = buildBuckets(DAY_START, 48, ONE_DAY / 48);
+    const nodes = Array.from({ length: 8 }, (_, i) => `storage-node-${i + 1}`);
+    const rows = buildStatusRows(nodes, 48, 45);
+
+    return (
+      <Box maxWidth="75rem">
+        <StatusHeatmap
+          title="Node health — last 24 hours"
+          rows={rows}
+          buckets={buckets}
+          labelEvery={6}
+          columnGap={spacing.f1}
+          cellHeight={spacing.f16}
+          labelWidth="9rem"
+        />
+      </Box>
+    );
+  },
+};
+
+/** Continuous values instead of statuses: opacity ramp + gradient scale. */
+export const NumericValues: Story = {
+  render: () => {
+    const buckets = buildBuckets(DAY_START, 24, ONE_HOUR);
+    const rows = Array.from({ length: 6 }, (_, rowIndex) => ({
+      label: `storage-node-${rowIndex + 1}`,
+      cells: Array.from({ length: 24 }, (_, colIndex) =>
+        Math.round(noise(rowIndex + 3, colIndex + 5)),
+      ),
+    }));
+
+    return (
+      <Box maxWidth="75rem">
+        <NumericHeatmap
+          title="CPU usage — last 24 hours"
+          rows={rows}
+          buckets={buckets}
+          unit="%"
+          labelEvery={3}
+          labelWidth="9rem"
+        />
+      </Box>
+    );
+  },
+};

--- a/stories/NestedProportionBar/nestedproportionbar.stories.tsx
+++ b/stories/NestedProportionBar/nestedproportionbar.stories.tsx
@@ -376,6 +376,8 @@ type NpbArgs = Omit<BoxOptions, 'total' | 'levelHeight'> & {
   depth: number;
   /** NestingDepth only: share of its parent each level keeps. */
   shareOfParent: number;
+  /** Playground only: the breakdown itself. */
+  root: ProportionNode;
 };
 
 const meta: Meta<NpbArgs> = {
@@ -440,6 +442,35 @@ const defaultArgs: NpbArgs = {
   levelHeight: 24,
   depth: 4,
   shareOfParent: 0.7,
+  root: CAPACITY,
+};
+
+/**
+ * The interactive one: edit the breakdown itself.
+ *
+ * `root` is a real control — change a value, add a child, drop one, or set a
+ * `color` to any theme token, `chartColors` key or CSS colour. The widths follow,
+ * and so does the axis of the argument: make the children sum past their parent
+ * and watch them scale to fit while the labels keep stating what you typed.
+ */
+export const Playground: Story = {
+  argTypes: {
+    root: {
+      control: 'object',
+      description:
+        'A node is { key, label, value, color?, children? }. Values are absolute, in one unit across the whole tree',
+    },
+  },
+  args: { ...defaultArgs, root: CAPACITY },
+  render: (args) => (
+    <Box maxWidth="60rem">
+      <NestedProportionBar
+        title="True Reality"
+        root={args.root}
+        {...npbProps(args)}
+      />
+    </Box>
+  ),
 };
 
 /** 1:1 with the reference mock: four levels, the value beside the children where it fits. */

--- a/stories/NestedProportionBar/nestedproportionbar.stories.tsx
+++ b/stories/NestedProportionBar/nestedproportionbar.stories.tsx
@@ -369,18 +369,89 @@ const NestedProportionBar = ({
 /*                                  STORIES                                   */
 /* -------------------------------------------------------------------------- */
 
-const meta: Meta = {
+type NpbArgs = Omit<BoxOptions, 'total' | 'levelHeight'> & {
+  /** Level height in px — the component takes a CSS length. */
+  levelHeight: number;
+  /** NestingDepth only. */
+  depth: number;
+  /** NestingDepth only: share of its parent each level keeps. */
+  shareOfParent: number;
+};
+
+const meta: Meta<NpbArgs> = {
   title: 'Components/Data Display/Charts/NestedProportionBar (composition)',
+  argTypes: {
+    variant: {
+      control: { type: 'radio' },
+      options: ['outline', 'filled'],
+      description:
+        'filled tints each box with its own colour on top of the outline',
+    },
+    valuePosition: {
+      control: { type: 'radio' },
+      options: ['auto', 'header'],
+      description:
+        'auto keeps the value beside the children while the remainder leaves room, and moves it onto the label row otherwise. header always uses the label row',
+    },
+    percentageBase: {
+      control: { type: 'radio' },
+      options: ['total', 'parent'],
+      description:
+        'Which share the printed value states. Widths always follow the parent, so total prints a number that does not match the box width — on purpose',
+    },
+    minInlineValueShare: {
+      control: { type: 'range', min: 0, max: 0.4, step: 0.01 },
+      description:
+        'How much width the unattributed remainder must leave for auto to inline the value',
+    },
+    levelHeight: {
+      control: { type: 'range', min: 12, max: 48, step: 1 },
+      description: 'Minimum height of one nesting level, in px',
+    },
+    depth: {
+      control: { type: 'range', min: 1, max: 8, step: 1 },
+      description: 'NestingDepth only',
+    },
+    shareOfParent: {
+      control: { type: 'range', min: 0.2, max: 0.95, step: 0.05 },
+      description: 'NestingDepth only',
+    },
+  },
 };
 export default meta;
 
-type Story = StoryObj;
+type Story = StoryObj<NpbArgs>;
+
+/** The option props, so one control governs every bar in a story. */
+const npbProps = (args: NpbArgs) => ({
+  variant: args.variant,
+  valuePosition: args.valuePosition,
+  percentageBase: args.percentageBase,
+  minInlineValueShare: args.minInlineValueShare,
+  levelHeight: `${args.levelHeight}px`,
+});
+
+/** Defaults matching the component's own, so a story starts where the code does. */
+const defaultArgs: NpbArgs = {
+  variant: 'outline',
+  valuePosition: 'auto',
+  percentageBase: 'total',
+  minInlineValueShare: 0.08,
+  levelHeight: 24,
+  depth: 4,
+  shareOfParent: 0.7,
+};
 
 /** 1:1 with the reference mock: four levels, the value beside the children where it fits. */
 export const ScreenshotEquivalent: Story = {
-  render: () => (
+  args: { ...defaultArgs },
+  render: (args) => (
     <Box maxWidth="60rem">
-      <NestedProportionBar title="True Reality" root={CAPACITY} />
+      <NestedProportionBar
+        title="True Reality"
+        root={CAPACITY}
+        {...npbProps(args)}
+      />
     </Box>
   ),
 };
@@ -390,12 +461,13 @@ export const ScreenshotEquivalent: Story = {
  * tokens are for. `outline` is what the mock shows.
  */
 export const FilledVariant: Story = {
-  render: () => (
+  args: { ...defaultArgs, variant: 'filled' },
+  render: (args) => (
     <Box maxWidth="60rem">
       <NestedProportionBar
         title="True Reality"
         root={CAPACITY}
-        variant="filled"
+        {...npbProps(args)}
       />
     </Box>
   ),
@@ -406,12 +478,13 @@ export const FilledVariant: Story = {
  * level. Compare the total height with `ScreenshotEquivalent`.
  */
 export const ValueInHeader: Story = {
-  render: () => (
+  args: { ...defaultArgs, valuePosition: 'header' },
+  render: (args) => (
     <Box maxWidth="60rem">
       <NestedProportionBar
         title="True Reality"
         root={CAPACITY}
-        valuePosition="header"
+        {...npbProps(args)}
       />
     </Box>
   ),
@@ -422,12 +495,13 @@ export const ValueInHeader: Story = {
  * than 56 %. The widths do not move — they always follow the parent.
  */
 export const PercentageOfParent: Story = {
-  render: () => (
+  args: { ...defaultArgs, percentageBase: 'parent' },
+  render: (args) => (
     <Box maxWidth="60rem">
       <NestedProportionBar
         title="True Reality"
         root={CAPACITY}
-        percentageBase="parent"
+        {...npbProps(args)}
       />
     </Box>
   ),
@@ -439,13 +513,15 @@ export const PercentageOfParent: Story = {
  * the root — and the labels run out of room before the widths do.
  */
 export const NestingDepth: Story = {
-  render: () => (
+  args: { ...defaultArgs },
+  render: (args) => (
     <Stack direction="vertical" gap="r24">
-      {[2, 4, 6].map((depth) => (
-        <Box key={depth} maxWidth="60rem">
+      {[2, args.depth, 6].map((depth, index) => (
+        <Box key={`${depth}-${index}`} maxWidth="60rem">
           <NestedProportionBar
             title={`${depth} levels`}
-            root={deepTree(depth, 0.7)}
+            root={deepTree(depth, args.shareOfParent)}
+            {...npbProps(args)}
           />
         </Box>
       ))}
@@ -455,7 +531,8 @@ export const NestingDepth: Story = {
 
 /** The payloads that break a proportional layout — every one of them is a real answer. */
 export const EdgeCases: Story = {
-  render: () => (
+  args: { ...defaultArgs },
+  render: (args) => (
     <Stack direction="vertical" gap="r24">
       <Box maxWidth="60rem">
         <NestedProportionBar
@@ -479,6 +556,7 @@ export const EdgeCases: Story = {
               },
             ],
           }}
+          {...npbProps(args)}
         />
       </Box>
       <Box maxWidth="60rem">
@@ -503,6 +581,7 @@ export const EdgeCases: Story = {
               },
             ],
           }}
+          {...npbProps(args)}
         />
       </Box>
       <Box maxWidth="60rem">
@@ -529,12 +608,14 @@ export const EdgeCases: Story = {
               },
             ],
           }}
+          {...npbProps(args)}
         />
       </Box>
       <Box maxWidth="60rem">
         <NestedProportionBar
           title="A total of zero"
           root={{ key: 'total', label: 'Total', value: 0 }}
+          {...npbProps(args)}
         />
       </Box>
     </Stack>

--- a/stories/NestedProportionBar/nestedproportionbar.stories.tsx
+++ b/stories/NestedProportionBar/nestedproportionbar.stories.tsx
@@ -1,0 +1,542 @@
+import { Meta, StoryObj } from '@storybook/react-webpack5';
+import React from 'react';
+import styled, { useTheme } from 'styled-components';
+import { Box } from '../../src/lib/next';
+import { spacing, Stack } from '../../src/lib/spacing';
+import { Text } from '../../src/lib/components/text/Text.component';
+import { Tooltip } from '../../src/lib/components/tooltip/Tooltip.component';
+import { chartColors, CoreUITheme } from '../../src/lib/style/theme';
+
+/**
+ * NestedProportionBar built by composing existing core-ui primitives — no new component.
+ *
+ * A hierarchical breakdown of one total: each node is a box whose width is proportional to its
+ * parent and which *contains* its children. That containment is the point, and it is what
+ * `Barchart` stacked loses — side by side, segments only say "these add up"; nested, they say
+ * "this one is part of that one".
+ *
+ * Two pieces are reusable beyond this recipe, and both are candidates for `charts/`:
+ *  - `resolveChartColor` : theme token → `chartColors` palette → raw CSS colour, so a caller
+ *                          writes `color: 'statusHealthy'` without reaching for `useTheme()`.
+ *  - `ProportionBox`     : the recursive box itself.
+ */
+
+/* -------------------------------------------------------------------------- */
+/*                             SHARED — chart colour                          */
+/* -------------------------------------------------------------------------- */
+
+/**
+ * Today `GlobalHealthBar` hardcodes `theme.statusX`, `Sparkline` wants a hex and `LegendShape`
+ * does `chartColors[c] || c`: three conventions for one question. This is the single answer.
+ */
+const resolveChartColor = (
+  color: string | undefined,
+  theme: CoreUITheme,
+  fallback: string,
+): string => {
+  if (!color) return fallback;
+  const token = (theme as unknown as Record<string, unknown>)[color];
+  if (typeof token === 'string') return token;
+  const palette = chartColors[color as keyof typeof chartColors];
+  return typeof palette === 'string' ? palette : color;
+};
+
+/* -------------------------------------------------------------------------- */
+/*                                    DATA                                    */
+/* -------------------------------------------------------------------------- */
+
+type ProportionNode = {
+  key: string;
+  /** Single line, truncated rather than wrapped: keep it short. */
+  label: string;
+  value: number;
+  /** Theme token, `chartColors` key, or raw CSS colour. */
+  color?: string;
+  children?: ProportionNode[];
+};
+
+/**
+ * The reference breakdown: 71 % used, of which 56 points are stored and 32 of those unique.
+ * Used + Available is 99, not 100 — the missing point is unattributed, and showing it is the
+ * point. Nothing here is normalised up to a full parent.
+ */
+const CAPACITY: ProportionNode = {
+  key: 'total',
+  label: 'Total',
+  value: 100,
+  children: [
+    {
+      key: 'used',
+      label: 'Used',
+      value: 71,
+      color: 'selectedActive',
+      children: [
+        {
+          key: 'stored',
+          label: 'Stored',
+          value: 56,
+          color: 'lineColor3',
+          children: [
+            { key: 'unique', label: 'Unique', value: 32, color: 'lineColor1' },
+          ],
+        },
+      ],
+    },
+    { key: 'available', label: 'Available', value: 28, color: 'statusHealthy' },
+  ],
+};
+
+/** A tree `depth` levels deep, each level keeping `share` of its parent. */
+const deepTree = (depth: number, share: number): ProportionNode => {
+  const build = (level: number, value: number): ProportionNode => ({
+    key: `level-${level}`,
+    label: level === 0 ? 'Total' : `Level ${level}`,
+    value,
+    color: level === 0 ? undefined : `lineColor${((level - 1) % 8) + 1}`,
+    children:
+      level >= depth
+        ? undefined
+        : [build(level + 1, Math.round(value * share))],
+  });
+  return build(0, 100);
+};
+
+/* -------------------------------------------------------------------------- */
+/*                         RECIPE — nested Box + Tooltip                      */
+/* -------------------------------------------------------------------------- */
+
+const clamp01 = (value: number) =>
+  Number.isFinite(value) ? Math.min(1, Math.max(0, value)) : 0;
+
+const percentage = (ratio: number) => `${Math.round(ratio * 100)}%`;
+
+/**
+ * Owns a box's width.
+ *
+ * The parent's row is a flex row spanning the parent's *inner* width, so a child claims its share
+ * with flex-basis: a percentage width would resolve against a shrink-to-fit container and collapse
+ * to its content's size, which on a bar of text is a bar the size of its text.
+ */
+const NodeSlot = styled.div<{ $isRoot: boolean; $share: number }>`
+  min-width: 0;
+  ${({ $isRoot, $share }) =>
+    $isRoot ? 'width: 100%;' : `flex: 0 0 ${($share * 100).toFixed(4)}%;`}
+`;
+
+const NodeBox = styled.div<{ $color: string; $filled: boolean }>`
+  border: 1px solid ${({ $color }) => $color};
+  border-radius: ${spacing.f8};
+  padding: ${spacing.f4};
+  min-width: 0;
+  overflow: hidden;
+
+  /* color-mix takes any CSS colour, so a token, a palette hex and an rgba() all tint alike —
+     no hex parsing, and no need for the theme's hand-picked *RGB companions. */
+  background: ${({ $filled, $color }) =>
+    $filled ? `color-mix(in srgb, ${$color} 15%, transparent)` : 'transparent'};
+
+  &:focus-visible {
+    outline: ${spacing.f2} solid ${({ theme }) => theme.selectedActive};
+    outline-offset: ${spacing.f1};
+  }
+`;
+
+/**
+ * Holds the label, and the Tooltip wrapper around it.
+ *
+ * The tooltip belongs to the label, not to the box: `Tooltip` opens on pointer-enter, which reaches
+ * every ancestor of the pointer, and a box *contains* its children — so a tooltip there stacks one
+ * overlay per level on a single hover. Labels never nest, so exactly one can be under the pointer.
+ */
+const LabelSlot = styled.div`
+  flex: 1 1 auto;
+  min-width: 0;
+
+  /* Tooltip wraps its child in a shrink-to-fit inline-block; let it fill the slot so the label
+     inside still has a width to ellipsise against. */
+  > * {
+    display: block;
+    min-width: 0;
+    max-width: 100%;
+  }
+`;
+
+const NodeLabel = styled.div`
+  padding: 0 ${spacing.f4};
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+`;
+
+const NodeValue = styled.div`
+  padding: 0 ${spacing.f4};
+  overflow: hidden;
+  white-space: nowrap;
+  /* Digits of equal width: a value ticking 9% → 10% must not shift the boxes beside it. */
+  font-variant-numeric: tabular-nums;
+`;
+
+const Row = styled.div<{ $height: string; $gap: string }>`
+  display: flex;
+  align-items: center;
+  gap: ${({ $gap }) => $gap};
+  min-width: 0;
+  min-height: ${({ $height }) => $height};
+`;
+
+type BoxOptions = {
+  total: number;
+  /** Which share the printed value states. Widths always follow the parent. */
+  percentageBase: 'total' | 'parent';
+  variant: 'outline' | 'filled';
+  valuePosition: 'auto' | 'header';
+  /** How much width the unattributed remainder must leave for `auto` to inline the value. */
+  minInlineValueShare: number;
+  levelHeight: string;
+};
+
+const ProportionBox = ({
+  node,
+  parentValue,
+  basisShare,
+  depth,
+  options,
+}: {
+  node: ProportionNode;
+  parentValue: number;
+  /**
+   * The box's width as a share of its parent's inner width. Normally the same as its share of
+   * the parent's *value* — the two come apart only when a payload's children sum past it.
+   */
+  basisShare: number;
+  depth: number;
+  options: BoxOptions;
+}) => {
+  const theme = useTheme();
+  const ratioOfParent = parentValue > 0 ? clamp01(node.value / parentValue) : 0;
+  const ratioOfTotal =
+    options.total > 0 ? clamp01(node.value / options.total) : 0;
+  const color = resolveChartColor(node.color, theme, theme.border);
+  const valueText = percentage(
+    options.percentageBase === 'total' ? ratioOfTotal : ratioOfParent,
+  );
+
+  const children = node.children ?? [];
+
+  // Children that sum past their parent would overflow the row — the flex bases do not shrink —
+  // so the row, not the numbers, gives way: they share the parent's full inner width in
+  // proportion to each other, while every label keeps stating the share the payload sent.
+  const childrenSum = children.reduce(
+    (sum, child) => sum + Math.max(0, child.value),
+    0,
+  );
+  const childrenBasis = Math.max(node.value, childrenSum);
+  const remainderShare =
+    1 - (node.value > 0 ? clamp01(childrenSum / node.value) : 0);
+
+  const label = (
+    <LabelSlot>
+      <Tooltip
+        placement="top"
+        overlay={
+          <Stack direction="vertical" gap="r2">
+            <Text variant="Smaller" isEmphazed>
+              {node.label}
+            </Text>
+            <Text variant="Smaller" color="textSecondary">
+              {`${percentage(ratioOfTotal)} of the total`}
+            </Text>
+            <Text variant="Smaller" color="textSecondary">
+              {`${percentage(ratioOfParent)} of its parent`}
+            </Text>
+          </Stack>
+        }
+      >
+        <NodeLabel>
+          <Text variant="Smaller" color="textSecondary">
+            {node.label}
+          </Text>
+        </NodeLabel>
+      </Tooltip>
+    </LabelSlot>
+  );
+  const value = (
+    <NodeValue>
+      <Text>{valueText}</Text>
+    </NodeValue>
+  );
+  const childBoxes = children.map((child) => (
+    <ProportionBox
+      key={child.key}
+      node={child}
+      parentValue={node.value}
+      basisShare={
+        childrenBasis > 0
+          ? clamp01(Math.max(0, child.value) / childrenBasis)
+          : 0
+      }
+      depth={depth + 1}
+      options={options}
+    />
+  ));
+
+  /* auto: the value sits beside the children while the remainder leaves room for it, and climbs
+     onto the label row otherwise — which reproduces the reference mock without ever overflowing. */
+  const inlineValue =
+    children.length > 0 &&
+    options.valuePosition === 'auto' &&
+    remainderShare >= options.minInlineValueShare;
+
+  return (
+    <NodeSlot $isRoot={depth === 0} $share={basisShare}>
+      <NodeBox
+        $color={color}
+        $filled={options.variant === 'filled'}
+        role="group"
+        aria-label={`${node.label} ${valueText}`}
+        tabIndex={0}
+      >
+        {inlineValue ? (
+          <>
+            {label}
+            <Row $height={options.levelHeight} $gap={spacing.f2}>
+              {childBoxes}
+              {/* Takes the leftover, so the value sits in the unattributed remainder rather
+                  than widening the row past its parent. */}
+              <Box flex="1 1 0" minWidth="0">
+                {value}
+              </Box>
+            </Row>
+          </>
+        ) : (
+          <>
+            <Row $height={options.levelHeight} $gap={spacing.f8}>
+              {label}
+              <Box flex="0 0 auto">{value}</Box>
+            </Row>
+            {children.length > 0 && (
+              <Row $height={options.levelHeight} $gap={spacing.f2}>
+                {childBoxes}
+              </Row>
+            )}
+          </>
+        )}
+      </NodeBox>
+    </NodeSlot>
+  );
+};
+
+const NestedProportionBar = ({
+  title,
+  root,
+  percentageBase = 'total',
+  variant = 'outline',
+  valuePosition = 'auto',
+  minInlineValueShare = 0.08,
+  levelHeight = spacing.f24,
+}: {
+  title: string;
+  root: ProportionNode;
+} & Partial<Omit<BoxOptions, 'total'>>) => (
+  <Stack direction="vertical" gap="r16">
+    <Text variant="Large" isEmphazed>
+      {title}
+    </Text>
+    {root.value <= 0 ? (
+      <Text color="textSecondary">Nothing to break down over this range.</Text>
+    ) : (
+      <Box role="figure" aria-label={`Breakdown of ${root.label}`}>
+        <ProportionBox
+          node={root}
+          parentValue={root.value}
+          basisShare={1}
+          depth={0}
+          options={{
+            total: root.value,
+            percentageBase,
+            variant,
+            valuePosition,
+            minInlineValueShare,
+            levelHeight,
+          }}
+        />
+      </Box>
+    )}
+  </Stack>
+);
+
+/* -------------------------------------------------------------------------- */
+/*                                  STORIES                                   */
+/* -------------------------------------------------------------------------- */
+
+const meta: Meta = {
+  title: 'Components/Data Display/Charts/NestedProportionBar (composition)',
+};
+export default meta;
+
+type Story = StoryObj;
+
+/** 1:1 with the reference mock: four levels, the value beside the children where it fits. */
+export const ScreenshotEquivalent: Story = {
+  render: () => (
+    <Box maxWidth="60rem">
+      <NestedProportionBar title="True Reality" root={CAPACITY} />
+    </Box>
+  ),
+};
+
+/**
+ * `filled` tints every box with its own colour — precisely what the theme's alpha-capable
+ * tokens are for. `outline` is what the mock shows.
+ */
+export const FilledVariant: Story = {
+  render: () => (
+    <Box maxWidth="60rem">
+      <NestedProportionBar
+        title="True Reality"
+        root={CAPACITY}
+        variant="filled"
+      />
+    </Box>
+  ),
+};
+
+/**
+ * `header` puts every value on its own label row: uniform and predictable, one line taller per
+ * level. Compare the total height with `ScreenshotEquivalent`.
+ */
+export const ValueInHeader: Story = {
+  render: () => (
+    <Box maxWidth="60rem">
+      <NestedProportionBar
+        title="True Reality"
+        root={CAPACITY}
+        valuePosition="header"
+      />
+    </Box>
+  ),
+};
+
+/**
+ * The same tree with percentages of the *parent* instead of the total: Stored reads 79 % rather
+ * than 56 %. The widths do not move — they always follow the parent.
+ */
+export const PercentageOfParent: Story = {
+  render: () => (
+    <Box maxWidth="60rem">
+      <NestedProportionBar
+        title="True Reality"
+        root={CAPACITY}
+        percentageBase="parent"
+      />
+    </Box>
+  ),
+};
+
+/**
+ * Where the recommended four-level limit comes from: each level spends a border and a padding on
+ * its own frame, so a box is exact against its parent's inner width and only approximate against
+ * the root — and the labels run out of room before the widths do.
+ */
+export const NestingDepth: Story = {
+  render: () => (
+    <Stack direction="vertical" gap="r24">
+      {[2, 4, 6].map((depth) => (
+        <Box key={depth} maxWidth="60rem">
+          <NestedProportionBar
+            title={`${depth} levels`}
+            root={deepTree(depth, 0.7)}
+          />
+        </Box>
+      ))}
+    </Stack>
+  ),
+};
+
+/** The payloads that break a proportional layout — every one of them is a real answer. */
+export const EdgeCases: Story = {
+  render: () => (
+    <Stack direction="vertical" gap="r24">
+      <Box maxWidth="60rem">
+        <NestedProportionBar
+          title="Unattributed remainder — 40 + 35 of 100"
+          root={{
+            key: 'total',
+            label: 'Total',
+            value: 100,
+            children: [
+              {
+                key: 'used',
+                label: 'Used',
+                value: 40,
+                color: 'selectedActive',
+              },
+              {
+                key: 'available',
+                label: 'Available',
+                value: 35,
+                color: 'statusHealthy',
+              },
+            ],
+          }}
+        />
+      </Box>
+      <Box maxWidth="60rem">
+        <NestedProportionBar
+          title="Children summing past their parent — 80 + 60 of 100"
+          root={{
+            key: 'total',
+            label: 'Total',
+            value: 100,
+            children: [
+              {
+                key: 'a',
+                label: 'Reported 80',
+                value: 80,
+                color: 'selectedActive',
+              },
+              {
+                key: 'b',
+                label: 'Reported 60',
+                value: 60,
+                color: 'statusCritical',
+              },
+            ],
+          }}
+        />
+      </Box>
+      <Box maxWidth="60rem">
+        <NestedProportionBar
+          title="Labels wider than their box"
+          root={{
+            key: 'total',
+            label: 'Total capacity across every selected deployment',
+            value: 100,
+            children: [
+              {
+                key: 'used',
+                label: 'Used by object storage, including replicas',
+                value: 60,
+                color: 'selectedActive',
+                children: [
+                  {
+                    key: 'unique',
+                    label: 'Unique, deduplicated payload bytes',
+                    value: 30,
+                    color: 'lineColor1',
+                  },
+                ],
+              },
+            ],
+          }}
+        />
+      </Box>
+      <Box maxWidth="60rem">
+        <NestedProportionBar
+          title="A total of zero"
+          root={{ key: 'total', label: 'Total', value: 0 }}
+        />
+      </Box>
+    </Stack>
+  ),
+};

--- a/stories/NestedProportionBar/nestedproportionbar.stories.tsx
+++ b/stories/NestedProportionBar/nestedproportionbar.stories.tsx
@@ -119,11 +119,14 @@ const percentage = (ratio: number) => `${Math.round(ratio * 100)}%`;
  */
 const NodeSlot = styled.div<{ $isRoot: boolean; $share: number }>`
   min-width: 0;
+  display: flex;
+  flex-direction: column;
   ${({ $isRoot, $share }) =>
     $isRoot ? 'width: 100%;' : `flex: 0 0 ${($share * 100).toFixed(4)}%;`}
 `;
 
 const NodeBox = styled.div<{ $color: string; $filled: boolean }>`
+  flex: 1;
   border: 1px solid ${({ $color }) => $color};
   border-radius: ${spacing.f8};
   padding: ${spacing.f4};
@@ -176,10 +179,27 @@ const NodeValue = styled.div`
   font-variant-numeric: tabular-nums;
 `;
 
-const Row = styled.div<{ $height: string; $gap: string }>`
+/**
+ * Holds a node's children.
+ *
+ * `stretch` is what makes siblings the same height: the row's cross size is set
+ * by its tallest child — the one with the deepest subtree — and every other
+ * child fills it. Without it a leaf sits at its own content height and the row
+ * reads as ragged, with a shallow branch floating beside a deep one.
+ */
+const ChildrenRow = styled.div<{ $height: string }>`
+  display: flex;
+  align-items: stretch;
+  gap: ${spacing.f2};
+  min-width: 0;
+  min-height: ${({ $height }) => $height};
+`;
+
+/** A node's own label and value, on one line. */
+const HeaderRow = styled.div<{ $height: string }>`
   display: flex;
   align-items: center;
-  gap: ${({ $gap }) => $gap};
+  gap: ${spacing.f8};
   min-width: 0;
   min-height: ${({ $height }) => $height};
 `;
@@ -299,25 +319,26 @@ const ProportionBox = ({
         {inlineValue ? (
           <>
             {label}
-            <Row $height={options.levelHeight} $gap={spacing.f2}>
+            <ChildrenRow $height={options.levelHeight}>
               {childBoxes}
               {/* Takes the leftover, so the value sits in the unattributed remainder rather
-                  than widening the row past its parent. */}
-              <Box flex="1 1 0" minWidth="0">
+                  than widening the row past its parent. The row stretches its children, so
+                  the value is centred back against the boxes beside it. */}
+              <Box flex="1 1 0" minWidth="0" display="flex" alignItems="center">
                 {value}
               </Box>
-            </Row>
+            </ChildrenRow>
           </>
         ) : (
           <>
-            <Row $height={options.levelHeight} $gap={spacing.f8}>
+            <HeaderRow $height={options.levelHeight}>
               {label}
               <Box flex="0 0 auto">{value}</Box>
-            </Row>
+            </HeaderRow>
             {children.length > 0 && (
-              <Row $height={options.levelHeight} $gap={spacing.f2}>
+              <ChildrenRow $height={options.levelHeight}>
                 {childBoxes}
-              </Row>
+              </ChildrenRow>
             )}
           </>
         )}

--- a/stories/linetimeseriechart.stories.tsx
+++ b/stories/linetimeseriechart.stories.tsx
@@ -1563,3 +1563,57 @@ export const LogarithmicScaleBelowOne: Story = {
     );
   },
 };
+
+/**
+ * The scale as a control, for poking at it against your own shape of data.
+ *
+ * `zeros` is the one worth trying: it drops a stretch of zero samples into the series, and on the
+ * log axis they land on the reserved `0` at the bottom rather than disappearing.
+ */
+export const LogarithmicScalePlayground: StoryObj<{
+  yAxisScale: 'linear' | 'log';
+  baseline: number;
+  spikeTo: number;
+  zeros: boolean;
+}> = {
+  argTypes: {
+    yAxisScale: { control: { type: 'radio' }, options: ['linear', 'log'] },
+    baseline: {
+      control: { type: 'range', min: 0.001, max: 10, step: 0.001 },
+      description: 'Where the series idles',
+    },
+    spikeTo: {
+      control: { type: 'range', min: 1, max: 10000, step: 1 },
+      description:
+        'Peak value — pull it far from the baseline to see what linear cannot show',
+    },
+    zeros: {
+      control: 'boolean',
+      description:
+        'Insert a stretch of measured zeros, which a log axis has to place somewhere',
+    },
+  },
+  args: { yAxisScale: 'log', baseline: 2, spikeTo: 4000, zeros: true },
+  render: (args) => {
+    const data = Array.from({ length: 120 }, (_, index) => {
+      const isZero = args.zeros && index >= 60 && index < 72;
+      const value = isZero
+        ? 0
+        : index % 41 === 0
+          ? args.spikeTo
+          : args.baseline * (1 + (index % 7) * 0.2);
+      return [LOG_START + index * SAMPLE_FREQUENCY_LAST_ONE_HOUR, value] as [
+        number,
+        number,
+      ];
+    });
+
+    return (
+      <ChartWithProviders
+        {...logChartArgs(data)}
+        title={`Request latency — ${args.yAxisScale}`}
+        yAxisScale={args.yAxisScale}
+      />
+    );
+  },
+};

--- a/stories/linetimeseriechart.stories.tsx
+++ b/stories/linetimeseriechart.stories.tsx
@@ -980,7 +980,10 @@ export const EmptyDataExample: Story = {
     return (
       <ChartLegendWrapper
         // @ts-ignore
-        colorSet={{ Success: theme.statusHealthy, Failed: theme.statusCritical }}
+        colorSet={{
+          Success: theme.statusHealthy,
+          Failed: theme.statusCritical,
+        }}
         sortOrder="status"
       >
         <LineTimeSerieChart
@@ -999,7 +1002,6 @@ export const EmptyDataExample: Story = {
   },
 };
 
-
 // Generate 1-hour data with 30s intervals, all zeros
 const generateAllZeroValuesData = (): [number, string][] => {
   const baseTimestamp = 1740405600;
@@ -1016,9 +1018,25 @@ const allZeroValuesData = generateAllZeroValuesData();
 export const AllZeroValuesExample: Story = {
   render: () => {
     return (
-      <ChartLegendWrapper colorSet={{ 'server-1': lineTimeSeriesColorRange[0] }}>
-        <LineTimeSerieChart yAxisType='default' startingTimeStamp={allZeroValuesData[0][0]} interval={SAMPLE_FREQUENCY_LAST_ONE_HOUR} duration={SAMPLE_DURATION_LAST_ONE_HOUR}
-          series={[{ data: allZeroValuesData, resource: 'server-1', metricPrefix: 'bandwidth', getTooltipLabel: (prefix, resource) => `${resource}-${prefix}` }]} title="All Zero Values" height={200} />
+      <ChartLegendWrapper
+        colorSet={{ 'server-1': lineTimeSeriesColorRange[0] }}
+      >
+        <LineTimeSerieChart
+          yAxisType="default"
+          startingTimeStamp={allZeroValuesData[0][0]}
+          interval={SAMPLE_FREQUENCY_LAST_ONE_HOUR}
+          duration={SAMPLE_DURATION_LAST_ONE_HOUR}
+          series={[
+            {
+              data: allZeroValuesData,
+              resource: 'server-1',
+              metricPrefix: 'bandwidth',
+              getTooltipLabel: (prefix, resource) => `${resource}-${prefix}`,
+            },
+          ]}
+          title="All Zero Values"
+          height={200}
+        />
       </ChartLegendWrapper>
     );
   },
@@ -1113,8 +1131,6 @@ const verySmallValuesData: [number, string][] = [
   [1740422880, '0.00000435'],
   [1740423600, '0.00000367'],
 ];
-
-
 
 export const SmallValuesExample: Story = {
   render: () => {
@@ -1254,7 +1270,9 @@ const mixedMagnitudeOpsData: [number, string][] = [
 export const TooltipUnitRangeExample: Story = {
   render: () => {
     return (
-      <ChartLegendWrapper colorSet={{ 'operations': lineTimeSeriesColorRange[0] }}>
+      <ChartLegendWrapper
+        colorSet={{ operations: lineTimeSeriesColorRange[0] }}
+      >
         <LineTimeSerieChart
           series={[
             {
@@ -1370,7 +1388,7 @@ export const BigValuesExample: Story = {
           ]}
           title="Big Values"
           height={200}
-          yAxisTitle='Big Number Example '
+          yAxisTitle="Big Number Example "
           startingTimeStamp={bigValuesData2[0][0]}
           isLoading={false}
           yAxisType={'default'}
@@ -1388,7 +1406,7 @@ export const BigValuesExample: Story = {
           ]}
           title="Big Values"
           height={200}
-          yAxisTitle='Big Number Example '
+          yAxisTitle="Big Number Example "
           startingTimeStamp={bigValuesData2[0][0]}
           isLoading={false}
           unitRange={UNIT_RANGE_BS}
@@ -1401,8 +1419,147 @@ export const BigValuesExample: Story = {
   },
 };
 
+/* -------------------------------------------------------------------------- */
+/*                            logarithmic Y axis                              */
+/* -------------------------------------------------------------------------- */
 
+const LOG_START = 1740405600;
 
+/**
+ * A latency-shaped series: a quiet baseline around 2 ms with occasional spikes into the seconds.
+ * Deterministic, so the two scales below are always compared on the same data.
+ */
+const spikyData = Array.from({ length: 120 }, (_, index) => {
+  const isSpike = index % 17 === 0;
+  const isBigSpike = index % 41 === 0;
+  const value = isBigSpike ? 4200 : isSpike ? 180 : 1.5 + (index % 7) * 0.4;
+  return [LOG_START + index * SAMPLE_FREQUENCY_LAST_ONE_HOUR, value] as [
+    number,
+    number,
+  ];
+});
 
+/** The same series with a stretch of zeros — the values a log axis has no place for. */
+const spikyDataWithZeros = spikyData.map(
+  ([timestamp, value], index) =>
+    [timestamp, index >= 60 && index < 72 ? 0 : value] as [number, number],
+);
 
+const logSerie = (data: [number, number][]): Serie[] => [
+  {
+    data,
+    resource: 'ip-10-160-122-207.eu-north-1.compute.internal',
+    getTooltipLabel: (prefix, resource) => `${resource}`,
+  },
+];
 
+const logChartArgs = (data: [number, number][]) => ({
+  series: logSerie(data),
+  height: 200,
+  startingTimeStamp: LOG_START,
+  interval: SAMPLE_FREQUENCY_LAST_ONE_HOUR,
+  duration: SAMPLE_DURATION_LAST_ONE_HOUR,
+  yAxisTitle: 'ms',
+});
+
+/**
+ * The same series on both scales.
+ *
+ * A metric that idles at 2 ms and spikes to 4 s is the case a linear axis cannot serve: the axis is
+ * sized by the spike, so the baseline — where the metric spends nearly all its time — is pressed
+ * flat against zero and its variation is invisible. A log axis gives every decade the same height,
+ * so the quiet periods and the spikes are both readable.
+ *
+ * The scale is a display choice only: no value is rescaled, and the tooltip still reads the
+ * milliseconds the series carries.
+ *
+ * What you give up: distances no longer read as differences. Two points twice as far apart
+ * vertically are ten times apart in value, not twice. Use it to see shape across magnitudes, not
+ * to compare magnitudes by eye.
+ */
+export const LogarithmicScaleExample: Story = {
+  render: () => (
+    <div>
+      <ChartWithProviders
+        {...logChartArgs(spikyData)}
+        title="Request latency — linear"
+      />
+      <ChartWithProviders
+        {...logChartArgs(spikyData)}
+        title="Request latency — logarithmic"
+        yAxisScale="log"
+      />
+    </div>
+  ),
+};
+
+/**
+ * Zero has no logarithm, so the axis reserves one slot below its first decade and labels it `0`.
+ * The zero samples are drawn there. Note that the step from `0` to the first decade is that single
+ * reserved slot and not one more tenfold step — it is the one place on the axis where the spacing
+ * does not mean a factor of ten.
+ *
+ * This is what keeps "the metric read zero for twelve minutes" from looking like "we have no data
+ * for twelve minutes". Dropping the zeros would leave the same gap a missing sample leaves, and
+ * those are not the same fact; clamping them to the first decade would draw them as the smallest
+ * measured value, a number the reader would believe. The tooltip reports 0 either way.
+ *
+ * A negative sample has neither a logarithm nor a slot, so it is still dropped: a series that goes
+ * negative does not belong on a log axis at all.
+ */
+export const LogarithmicScaleWithZeros: Story = {
+  render: () => (
+    <div>
+      <ChartWithProviders
+        {...logChartArgs(spikyDataWithZeros)}
+        title="With a stretch of zeros — linear"
+      />
+      <ChartWithProviders
+        {...logChartArgs(spikyDataWithZeros)}
+        title="With a stretch of zeros — logarithmic, the zeros sit at the reserved 0"
+        yAxisScale="log"
+      />
+    </div>
+  ),
+};
+
+/**
+ * The axis follows the data's own decades — it is not anchored to 1.
+ *
+ * Here everything sits between 0.001 and 0.1 with occasional spikes to 32 and 50, and the axis
+ * comes out 0.001..100: six decades, one tick each, decimals on the low ones and none on the high
+ * ones. Nothing had to be configured for that; `getLogAxis` reads the smallest positive value and
+ * the largest, and rounds each outwards to a decade.
+ *
+ * On the linear chart above, the entire baseline is a flat line on zero — the axis is sized by the
+ * 50 spike, and 0.002 against 50 is 1/25000 of the plot height.
+ */
+export const LogarithmicScaleBelowOne: Story = {
+  render: () => {
+    // Baseline in the milli range, two spikes four decades above it. Deterministic.
+    const data = Array.from({ length: 120 }, (_, index) => {
+      const value =
+        index === 30 ? 32 : index === 78 ? 50 : 0.002 + (index % 9) * 0.011;
+      return [LOG_START + index * SAMPLE_FREQUENCY_LAST_ONE_HOUR, value] as [
+        number,
+        number,
+      ];
+    });
+
+    return (
+      <div>
+        <ChartWithProviders
+          {...logChartArgs(data)}
+          title="Error rate — linear, the baseline is unreadable"
+          yAxisTitle="/s"
+        />
+        <ChartWithProviders
+          {...logChartArgs(data)}
+          title="Error rate — logarithmic, 0.001 to 100"
+          yAxisTitle="/s"
+          yAxisScale="log"
+        />
+      </div>
+    );
+  },
+};

--- a/stories/linetimeseriechart.stories.tsx
+++ b/stories/linetimeseriechart.stories.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { Meta, StoryObj } from '@storybook/react-webpack5';
 import {
   LineTimeSerieChart,
+  LineChartProps,
   Serie,
   ChartLegendWrapper,
   ChartLegend,
@@ -1445,13 +1446,25 @@ const spikyDataWithZeros = spikyData.map(
     [timestamp, index >= 60 && index < 72 ? 0 : value] as [number, number],
 );
 
+const LOG_RESOURCE = 'storage-node-1';
+
 const logSerie = (data: [number, number][]): Serie[] => [
   {
     data,
-    resource: 'ip-10-160-122-207.eu-north-1.compute.internal',
+    resource: LOG_RESOURCE,
     getTooltipLabel: (prefix, resource) => `${resource}`,
   },
 ];
+
+/** Own legend, so the generic resource label still resolves to a colour. */
+const LogChart = (props: LineChartProps) => (
+  <ChartLegendWrapper
+    colorSet={{ [LOG_RESOURCE]: lineTimeSeriesColorRange[0] }}
+  >
+    <LineTimeSerieChart {...props} />
+    <ChartLegend shape="line" />
+  </ChartLegendWrapper>
+);
 
 const logChartArgs = (data: [number, number][]) => ({
   series: logSerie(data),
@@ -1480,11 +1493,8 @@ const logChartArgs = (data: [number, number][]) => ({
 export const LogarithmicScaleExample: Story = {
   render: () => (
     <div>
-      <ChartWithProviders
-        {...logChartArgs(spikyData)}
-        title="Request latency — linear"
-      />
-      <ChartWithProviders
+      <LogChart {...logChartArgs(spikyData)} title="Request latency — linear" />
+      <LogChart
         {...logChartArgs(spikyData)}
         title="Request latency — logarithmic"
         yAxisScale="log"
@@ -1510,11 +1520,11 @@ export const LogarithmicScaleExample: Story = {
 export const LogarithmicScaleWithZeros: Story = {
   render: () => (
     <div>
-      <ChartWithProviders
+      <LogChart
         {...logChartArgs(spikyDataWithZeros)}
         title="With a stretch of zeros — linear"
       />
-      <ChartWithProviders
+      <LogChart
         {...logChartArgs(spikyDataWithZeros)}
         title="With a stretch of zeros — logarithmic, the zeros sit at the reserved 0"
         yAxisScale="log"
@@ -1548,12 +1558,12 @@ export const LogarithmicScaleBelowOne: Story = {
 
     return (
       <div>
-        <ChartWithProviders
+        <LogChart
           {...logChartArgs(data)}
           title="Error rate — linear, the baseline is unreadable"
           yAxisTitle="/s"
         />
-        <ChartWithProviders
+        <LogChart
           {...logChartArgs(data)}
           title="Error rate — logarithmic, 0.001 to 100"
           yAxisTitle="/s"
@@ -1609,7 +1619,7 @@ export const LogarithmicScalePlayground: StoryObj<{
     });
 
     return (
-      <ChartWithProviders
+      <LogChart
         {...logChartArgs(data)}
         title={`Request latency — ${args.yAxisScale}`}
         yAxisScale={args.yAxisScale}


### PR DESCRIPTION
**Component**: `charts` — Barchart, LineTimeSerieChart, and two new Storybook recipes

**TL;DR** — Adds an opt-in logarithmic Y axis to `Barchart` and `LineTimeSerieChart`, plus two story-only recipes proposing a `Heatmap` and a `NestedProportionBar` built from primitives that already exist.

### Context / Why

A metric that idles at 2 ms and spikes to 4 s cannot be read on a linear axis: the axis is sized by the spike, so the baseline where the metric spends nearly all its time is pressed flat against zero.

The two recipes are a **design proposal, not a component**. They live entirely in `stories/` so the shape can be reviewed, and argued with, before anything is added to `src/`.

### 🧩 Approach — the logarithmic axis

`yAxisScale="log"`, defaulting to `linear`. It is a display option and nothing more: no value is rescaled, and tooltips, legend and unit scaling all keep the numbers the caller passed in. Only the axis and where the marks land on it change.

Three things a log axis has to do differently, all in `charts/common` so both charts share them:

| | Why |
|---|---|
| The scale cannot start at zero | Bounded by the decades enclosing the data, read off the smallest positive value and the largest — so it follows the data rather than being anchored to 1. Values between 0.001 and 0.1 with spikes to 50 give a 0.001..100 axis. |
| Its ticks are the decades | Evenly spaced linear ticks on a log axis crowd into the top of the plot and read as a broken chart. Past six decades, whole decades are skipped — never subdivided. |
| A measured zero needs somewhere to go | It has no logarithm and no place on the scale, so the axis reserves one slot below its first decade, labels it `0`, and draws zeros there. |

That last one is the part worth arguing about. Without the reserved slot a zero has to be dropped, and a dropped zero leaves exactly the gap a missing sample leaves — making "the metric read zero" indistinguishable from "we have no data", which are not the same fact. Clamping to the first decade is worse, not better: it draws the zero as the smallest measured value, a number the reader will believe. The slot costs a decade's worth of height, so it is only reserved when the data actually holds a zero.

Two pairings are refused rather than drawn wrong. **Stacked bars fall back to linear**, since stacking places each segment at a cumulative sum and a segment's height would stop matching its value. **A symmetrical line chart refuses the scale at the type level** — half its axis is negative by construction.

### 📷 Screenshots

**Barchart — `LogarithmicScale`.** Linear on top: only the 40 000 bar is legible. Log below: every decade gets the same height, and `category5` (value `0`) is the stub at the reserved `0`.

<img width="668" height="589" alt="Barchart logarithmic scale story, linear and log side by side" src="https://github.com/user-attachments/assets/9c4112f4-3e38-4e72-bf18-224c1a36a47d" />

**LineTimeSerieChart — `LogarithmicScaleExample`.** Same series twice. On the linear axis the baseline is a flat line on zero; on the log axis its variation and both spike tiers are readable.

<img width="1094" height="512" alt="LineTimeSerieChart logarithmic scale story, linear and log side by side" src="https://github.com/user-attachments/assets/5a06da2a-9d01-44cd-946b-b34b242724b1" />

**Heatmap — default story.** One recipe of the proposal; the rest is worth clicking through rather than screenshotting.

<img width="868" height="205" alt="Heatmap composition recipe, services against time slots with a status legend" src="https://github.com/user-attachments/assets/d910713a-8b61-49ef-801c-ca745e487d69" />

**NestedProportionBar — default story.**

<img width="961" height="211" alt="image" src="https://github.com/user-attachments/assets/a032037c-3eef-4f8f-92d0-44ecff46c512" />
### 🔍 Review focus

- 🟡 **Moderate** — `charts/common/chartUtils.ts › getLogAxis`, `placeNonPositiveValues` — the domain, the decade ticks and the reserved zero slot. The zero handling is the design decision in this PR; if you disagree with reserving a slot, this is the place to say so.
- 🟡 **Moderate** — `barchart/Barchart.utils.ts › getCurrentPoint` and `LineTimeSerieChartTooltip` — a zero is plotted at the reserved slot, so both tooltips map it back before formatting, including a caller's own Barchart `tooltip` renderer. No real value can collide with the slot: it sits below the smallest positive value in the data.
- ⚪ **Minor** — `stories/Heatmap`, `stories/NestedProportionBar` — story-only, nothing in `src/`. Review the shape, not the code.

### 🧪 How to test

```bash
npm run storybook
```

**The logarithmic axis** — *Charts → Barchartv2* and *Charts → LineTimeSerieChart*:

1. Open `Logarithmic scale` on either chart and compare the two stacked charts. Same data, only the axis differs.
2. Open `Logarithmic scale playground` and use the Controls panel — `yAxisScale` flips the axis live.
3. On the Barchart playground, tick **`stacked`**. The axis snaps back to linear: that is the documented refusal, not a bug.
4. On the LineTimeSerieChart playground, tick **`zeros`**. The zeros land on the reserved `0` at the bottom; untick and the axis loses that slot.
5. `Logarithmic scale below one` shows the axis following data between 0.001 and 0.1 with spikes to 50 — nothing is anchored to 1.

**The two proposed recipes** — *Charts → Heatmap (composition)* and *Charts → NestedProportionBar (composition)*. Both open on a `Playground` story whose **data is a control**, so this is meant to be poked at rather than read:

6. Heatmap → `Playground` → Controls → **`rows`**. It is a JSON editor: add a row, rename one, change any cell to `OK` / `WARNING` / `CRITICAL` / `NONE`. The x-axis is derived from the longest row, so adding cells adds columns.
7. Click a legend entry. Unselected statuses fade rather than vanish, so the shape of the data survives the filter.
8. NestedProportionBar → `Playground` → Controls → **`root`**. Change a value, add a child, set a `color` to a theme token, a `chartColors` key or a raw CSS colour.
9. Still on `root`: make the children sum **past** their parent (say 80 and 60 of 100). They scale to fit the row while every label keeps stating what you typed — an inconsistent payload should read as inconsistent, not as a broken component.
10. `Edge cases` covers the rest: an unattributed remainder, labels wider than their box, a total of zero.

Theme switching is worth a pass on all of the above — the reserved `0`, the status colours and the box outlines all come from tokens.

```bash
npm test -- src/lib/components/charts
```

### 🔗 References

**Breaking Changes**: none. `yAxisScale` is optional and defaults to `linear`, so every existing caller renders exactly as before. Nothing is added to `src/` for the two recipes.

No issue or ticket for this one.

<details><summary>What changed</summary>

`charts/common/chartUtils.ts` carries the whole log-axis vocabulary — `getLogAxis`, `getMinPositiveValue`, `hasZeroValue`, `placeNonPositiveValues`, `formatLogTickValue`, `readLogPlottedValue` — next to `getRoundReferenceValue`/`getTicks`, which do the same job for the linear axis. Both charts wire it the same way, which is why the two diffs read almost identically.

`stories/Heatmap/` proposes two recipes: `StatusHeatmap` for discrete statuses, built from `Box` + `Tooltip` + the existing `ChartLegend`, and `NumericHeatmap` for continuous values under an opacity ramp. An earlier third recipe stacking one `GlobalHealthBar` per row was dropped — it worked, but it needs one chart instance per row and hides every x-axis but the last.

`stories/NestedProportionBar/` also carries `resolveChartColor`, which is a candidate for `charts/common` in its own right: `GlobalHealthBar` hardcodes `theme.statusX`, `Sparkline` wants a hex and `LegendShape` does `chartColors[c] || c` — three conventions for one question, where a single theme-token → palette → raw-CSS resolution serves all three.

</details>
