### PR TITLE
docs(responsive): add a Responsive guideline and name what declares the container

### DIFF
--- a/src/lib/components/box/Box.ts
+++ b/src/lib/components/box/Box.ts
@@ -35,7 +35,18 @@ export type BoxComponentProps = LayoutProps &
   BackgroundProps &
   BordersProps &
   TypographyProps &
-  ShadowProps & { gap?: string | number; container?: boolean };
+  ShadowProps & {
+    gap?: string | number;
+    /**
+     * Declare this Box the `responsive` container, so `@container responsive`
+     * queries inside it — `Button iconOnly={number}`, a `Form responsive`
+     * section's row/stack flip — resolve against its width instead of looking
+     * further up the tree. Containment takes the contents out of the intrinsic
+     * width, so the Box needs a definite width from its parent; see the
+     * "Responsive" guideline.
+     */
+    container?: boolean;
+  };
 
 const Box = styled.div.withConfig({
   shouldForwardProp: (prop) => prop !== 'container' && shouldForwardProp(prop),

--- a/src/lib/components/buttonv2/Buttonv2.component.tsx
+++ b/src/lib/components/buttonv2/Buttonv2.component.tsx
@@ -30,7 +30,15 @@ type ButtonStyledProps = Omit<
 type ButtonWithLabel = ButtonStyledProps & {
   label: React.ReactNode;
   tooltip?: Omit<TooltipProps, 'children'>;
-  /** Collapse to icon-only: true = always; number = below N px (needs a `responsive` container ancestor); omit = never. */
+  /**
+   * Collapse to icon-only: `true` = always; a number = below N px; omit = never.
+   *
+   * The numeric form is a `@container responsive` query, so it only takes effect
+   * inside an ancestor that declares that container: `<Form responsive>`,
+   * `<Box container>`, or `<TwoPanelLayout container="left | right | both">`.
+   * Without one the query never matches and the label never collapses — see the
+   * "Responsive" guideline. `true` needs no container.
+   */
   iconOnly?: boolean | number;
 };
 

--- a/src/lib/components/form/Form.component.tsx
+++ b/src/lib/components/form/Form.component.tsx
@@ -37,6 +37,10 @@ type FormProps = Omit<
    * breakpoint prop; the flip point is derived from the layout (see below).
    * Note: `Input` and `Select` currently honor the fluid width — `SearchInput`,
    * `TextArea` and other size-driven content keep their fixed width for now.
+   *
+   * It also declares the Form the `responsive` container, so any
+   * `@container responsive` query inside it — `Button iconOnly={number}`, for
+   * one — resolves against the Form's width. See the "Responsive" guideline.
    */
   responsive?: boolean;
 };

--- a/src/lib/components/layout/v2/panels.tsx
+++ b/src/lib/components/layout/v2/panels.tsx
@@ -98,6 +98,14 @@ export const TwoPanelLayout = ({
   leftPanel: { children: ReactElement; background?: ThemeColors };
   rightPanel: { children: ReactElement; background?: ThemeColors };
   noGap?: boolean;
+  /**
+   * Declare the named panel(s) the `responsive` container, so
+   * `@container responsive` queries inside them — `Button iconOnly={number}`, a
+   * `Form responsive` section's row/stack flip — resolve against the panel's
+   * width rather than looking further up the tree. A panel is usually much
+   * narrower than the page, which is what makes this worth opting into; see the
+   * "Responsive" guideline.
+   */
   container?: 'left' | 'right' | 'both';
 }) => {
   const panelsObjectRatio = getPanelsObjectRation(panelsRatio);

--- a/stories/form.guideline.mdx
+++ b/stories/form.guideline.mdx
@@ -58,6 +58,11 @@ A `responsive` Form establishes a CSS containment context
 width**. Put the Form in a narrow panel, drawer, or split view and it flips based
 on the space it actually has — no viewport media queries, no JS resize listeners.
 
+It declares that container under the name `responsive`, which is the same one
+`Button iconOnly={number}` queries — so a collapsing button placed inside a
+`responsive` Form works with no extra wrapper. See the **Responsive** guideline
+for the full list of components that declare and query it.
+
 ### Alignment is per `FormSection`
 
 Labels align within a section, not across the whole Form — each `FormSection`
@@ -101,7 +106,7 @@ always stacked (label above field) at every width.
 
 ### Current limitation
 
-Only `Input` honors the fluid width today. `Select`, `SearchInput`, `TextArea`
-and other size-driven content still render at their fixed `size` width inside a
-responsive Form (tracked in **CUI-36**). Prefer `Input`-based fields when building
-a form that needs to shrink cleanly, until the other inputs opt in.
+`Input` and `Select` honor the fluid width. `SearchInput`, `TextArea` and other
+size-driven content still render at their fixed `size` width inside a responsive
+Form. Prefer `Input`- and `Select`-based fields when building a form that needs to
+shrink cleanly, until the rest opt in.

--- a/stories/guideline/responsive.mdx
+++ b/stories/guideline/responsive.mdx
@@ -1,0 +1,97 @@
+import { Meta, Canvas } from '@storybook/addon-docs/blocks';
+import * as ResponsiveStories from './responsive.stories';
+
+<Meta title="Guidelines/Responsive" />
+
+<style>{`
+  .sbdocs-content h2 { margin-top: 5rem; }
+  .sbdocs-content h3 { margin-top: 3rem; }
+  .sbdocs-content .sb-story { margin-bottom: 0.5rem; }
+  .sbdocs-content .sbdocs-preview { margin-bottom: 1.5rem; }
+`}</style>
+
+# Responsive
+
+Several core-ui components can adapt to **the width they are given** rather than
+the width of the browser. This page covers what that takes: the container every
+responsive component queries, how to declare it, and the per-component props that
+make use of it.
+
+The viewport is usually the wrong box to measure. A panel opening beside the
+content, a split view, a drawer — each narrows what a component actually has to
+work with while `window.innerWidth` never moves. A `@media` query cannot see
+that; a CSS container query can. So responsive components here query a container
+named `responsive`, and it is opt-in: **nothing declares it by default.**
+
+## Declaring the container
+
+Three components declare it, each behind an explicit prop:
+
+| Component        | Prop                                |
+| ---------------- | ----------------------------------- |
+| `Form`           | `responsive`                        |
+| `Box`            | `container`                         |
+| `TwoPanelLayout` | `container="left \| right \| both"` |
+
+A responsive component with no declaring ancestor is **inert and silent** — it
+renders at its full size and nothing reports a problem. That is the failure to
+look for first when a responsive prop appears to do nothing.
+
+### Put it on the box whose width should drive the reaction
+
+Not as high up as possible. The query resolves against the _nearest_ declaring
+ancestor, so a container on the page wrapper makes everything inside it react to
+the page — which is usually the viewport again under another name.
+
+- A toolbar that should condense when its own column gets tight → `<Box container>`
+  on that column.
+- Fields that should stack when the panel holding them is narrow →
+  `<TwoPanelLayout container="right">`, so they follow the panel and not the page.
+- A form that should reflow inside whatever it is dropped into →
+  `<Form responsive>`, which declares and queries in one component.
+
+### Containment needs a width from the parent
+
+Declaring a container sets `container-type: inline-size`, and that takes the
+element's contents **out of its own intrinsic width**. The width has to arrive
+from the parent instead — a flex grow factor, a grid track, or ordinary block
+layout. As a content-sized flex item, a container would otherwise resolve to zero
+width and everything inside it would overflow.
+
+`Form` and the `TwoPanelLayout` panels pair the containment with `flex: 1 1 auto`
+and `min-width: 0` themselves. `Box` sets `min-width: 0` but stays deliberately
+unopinionated about where its width comes from, so a `<Box container>` used as a
+bare flex item needs a `flex` value from you.
+
+## Responsive components
+
+### `Button` — `iconOnly`
+
+`iconOnly={360}` drops the button's visible label below 360px of container width,
+leaving the icon. It is the container-query form, so it needs a declaring
+ancestor.
+
+<Canvas of={ResponsiveStories.WithAndWithoutContainer} sourceState="none" />
+
+Both frames above hold the same two `iconOnly={360}` buttons. Drag either right
+edge below 360px: only the frame whose content is wrapped in `<Box container>`
+collapses its buttons to icons. The other one never will, at any width.
+
+`iconOnly` on its own — or `iconOnly={true}` — collapses at every width, needs no
+container, and is the right choice for a button that is icon-only by design
+rather than under pressure.
+
+<Canvas of={ResponsiveStories.AlwaysCollapsed} sourceState="none" />
+
+Either way the label is kept as the accessible name and shown as a tooltip on
+hover, so a collapsed button stays findable by its label.
+
+### `Form` — `responsive`
+
+`Form` is both halves at once: `responsive` declares the container _and_ makes
+the form query it, so fields become fluid and each `FormSection` flips from a
+two-column row layout to a stacked one when it runs out of room. A collapsing
+`Button` placed inside a `responsive` Form therefore works with no extra wrapper.
+
+See the **Form → Guideline** page for the flip thresholds and the label-column
+rules.

--- a/stories/guideline/responsive.stories.tsx
+++ b/stories/guideline/responsive.stories.tsx
@@ -1,0 +1,92 @@
+import React from 'react';
+import { Box } from '../../src/lib/components/box/Box';
+import { Button } from '../../src/lib/components/buttonv2/Buttonv2.component';
+import { Icon } from '../../src/lib/components/icon/Icon.component';
+
+export default {
+  title: 'Guidelines/ResponsiveOverview',
+  tags: ['!dev', '!autodocs'],
+};
+
+const frameStyle: React.CSSProperties = {
+  resize: 'horizontal',
+  overflow: 'auto',
+  width: '30rem',
+  minWidth: '12rem',
+  maxWidth: '100%',
+  border: '1px dashed #666',
+  padding: '1rem',
+};
+
+const captionStyle: React.CSSProperties = {
+  fontSize: '0.75rem',
+  textTransform: 'uppercase',
+  letterSpacing: '0.05em',
+  opacity: 0.5,
+  marginBottom: '0.5rem',
+};
+
+const Actions = () => (
+  <div style={{ display: 'flex', gap: '0.5rem' }}>
+    <Button
+      variant="secondary"
+      icon={<Icon name="Save" />}
+      label="Save"
+      iconOnly={360}
+    />
+    <Button
+      variant="outline"
+      icon={<Icon name="Delete" />}
+      label="Delete"
+      iconOnly={360}
+    />
+  </div>
+);
+
+/**
+ * Both frames hold the same two `iconOnly={360}` buttons. Drag each right edge
+ * below 360px: only the framed content that declares the container collapses.
+ */
+export const WithAndWithoutContainer = {
+  render: () => (
+    <div style={{ display: 'flex', flexDirection: 'column', gap: '2rem' }}>
+      <div>
+        <div style={captionStyle}>Box container — collapses below 360px</div>
+        <div style={frameStyle}>
+          <Box container>
+            <Actions />
+          </Box>
+        </div>
+      </div>
+      <div>
+        <div style={captionStyle}>
+          No container ancestor — never collapses, at any width
+        </div>
+        <div style={frameStyle}>
+          <Box>
+            <Actions />
+          </Box>
+        </div>
+      </div>
+    </div>
+  ),
+};
+
+export const AlwaysCollapsed = {
+  render: () => (
+    <div style={{ display: 'flex', gap: '0.5rem' }}>
+      <Button
+        variant="secondary"
+        icon={<Icon name="Save" />}
+        label="Save"
+        iconOnly
+      />
+      <Button
+        variant="outline"
+        icon={<Icon name="Delete" />}
+        label="Delete"
+        iconOnly
+      />
+    </div>
+  ),
+};


### PR DESCRIPTION
**TL;DR** — Documents core-ui's responsive capabilities in one guideline page: which three props declare the `responsive` CSS container, and which components query it — starting with `Button`'s `iconOnly`.

### Context / Why

Several components adapt to the width they are given by querying a container named `responsive`, and **nothing declares that container by default**. A component with no declaring ancestor is inert and silent: it renders at full size and nothing reports a problem.

That made it a documentation gap on both sides. The `iconOnly` prop said it "needs a `responsive` container ancestor" without naming a single way to get one, and none of the three components that declare the container mentioned that they do — so there was no way in from either end.

### 🧩 Approach

A `Guidelines/Responsive` page in two parts, shaped so it grows as more components become responsive:

**Part 1 — declaring the container.** The three props that do it, why it belongs on the box whose width should actually drive the reaction rather than as high up as possible (the query resolves against the *nearest* declaring ancestor, so a container on the page wrapper is the viewport again under another name), and why containment needs a width from the parent.

| Component | Prop |
| --- | --- |
| `Form` | `responsive` |
| `Box` | `container` |
| `TwoPanelLayout` | `container="left \| right \| both"` |

**Part 2 — one section per responsive component**, starting with `Button`'s `iconOnly` and `Form`'s `responsive`. Adding the next component means adding a section, not restructuring the page.

The prop docs now point both ways: `iconOnly` names the three establishers, and each establisher names what queries the container it declares.

### 📷 Screenshots

The new page:

![responsive-containers-guideline-page](https://github.com/user-attachments/assets/6b550122-7908-4fa9-8050-4665b1511f27)

The `iconOnly` section's demo, which the default width cannot show — both frames narrowed to **the same 300px**. The top one declares the container, so its buttons collapse; the bottom one does not, so they never will:

![container-vs-no-container-at-300px](https://github.com/user-attachments/assets/ad2c4838-568a-49a1-ac2c-1e3dd6b3bc1a)

### 🔍 Review focus

- ⚪ **Minor** — `stories/guideline/responsive.mdx` — content accuracy, and whether the two-part split is the right shape to hang the next responsive component off. Everything else here is JSDoc.
- ⚪ **Minor** — `stories/form.guideline.mdx` — the "Current limitation" paragraph still claimed only `Input` honors the fluid width. `Select` opted in with **CUI-36** and the prop's own JSDoc already said so, so the two contradicted each other; corrected because the new page would inherit the contradiction.

### 🧪 How to test

1. `npm run storybook`, open **Guidelines → Responsive**.
2. Drag the right edge of each dashed frame in the `iconOnly` section below 360px. Only the top frame — the one wrapped in `<Box container>` — collapses its buttons to icons; the bottom frame keeps its labels at any width.
3. Hover a collapsed button: the label is still the accessible name and still appears as a tooltip.
4. Check the cross-links resolve — **Form → Guideline** points here, and this page points back.

<details><summary>What changed</summary>

No behavioural change: `Buttonv2.component.tsx`, `Box.ts`, `Form.component.tsx` and `layout/v2/panels.tsx` are JSDoc only.

`stories/guideline/responsive.mdx` is the new page, following the existing `Guidelines/*` pattern, backed by `responsive.stories.tsx` — tagged `['!dev', '!autodocs']` like `selection-controls-overview.stories.tsx` so its stories render inside the page rather than as separate sidebar entries.

</details>
