### PR TITLE
Table: six row and header fixes — in-cell clicks, column alignment, cut-off labels

### DIFF
--- a/src/lib/components/constrainedtext/Constrainedtext.component.tsx
+++ b/src/lib/components/constrainedtext/Constrainedtext.component.tsx
@@ -22,7 +22,12 @@ type Props = {
 const ConstrainedTextContainer = styled.div`
   overflow: hidden;
   text-overflow: ellipsis;
-  text-align: ${(props) => (props.$centered ? 'center' : 'left')};
+  /* inherit, not left: this is a rule on the element, so a hard-coded value
+     silently outranks whatever alignment the container set -- a table cell
+     declaring textAlign: center kept left-aligned text with nothing to explain
+     why. The centered prop stays as an explicit override, for a container that
+     sets no alignment of its own. */
+  text-align: ${(props) => (props.$centered ? 'center' : 'inherit')};
 
   ${(props) =>
     props.$lineClamp > 1

--- a/src/lib/components/tablev2/MultiSelectableContent.test.tsx
+++ b/src/lib/components/tablev2/MultiSelectableContent.test.tsx
@@ -67,7 +67,7 @@ describe('MultiSelectableContent', () => {
     expect(lastCallRows[0].original).toEqual(data[3]); // Ninette (firstName-sorted index 0)
   });
 
-  it('does not include a previously single-clicked row in subsequent multi-selection (ARTESCA-8467)', async () => {
+  it('does not include a previously single-clicked row in subsequent multi-selection', async () => {
     const onSingleRowSelected = jest.fn();
     const onMultiSelectionChanged = jest.fn();
     renderMultiSelectTable({ onSingleRowSelected, onMultiSelectionChanged });

--- a/src/lib/components/tablev2/MultiSelectableContent.test.tsx
+++ b/src/lib/components/tablev2/MultiSelectableContent.test.tsx
@@ -121,3 +121,79 @@ describe('MultiSelectableContent', () => {
     expect(within(screen.getAllByRole('row')[3]).getByRole('checkbox')).toBeChecked();
   });
 });
+
+describe('MultiSelectableContent row click vs in-cell controls', () => {
+  const columnsWithButton: TableProps['columns'] = [
+    { Header: 'First Name', accessor: 'firstName' },
+    {
+      Header: 'Action',
+      accessor: 'lastName',
+      disableSortBy: true,
+      Cell: ({ row }) => (
+        <button onClick={() => row.original.onAction()}>
+          Detach {row.original.firstName}
+        </button>
+      ),
+    },
+  ];
+
+  const renderWithAction = (
+    onAction: jest.Mock,
+    props: {
+      onMultiSelectionChanged?: jest.Mock;
+      onSingleRowSelected?: jest.Mock;
+    } = {},
+  ) =>
+    render(
+      <ThemeProvider theme={coreUIAvailableThemes.artescaLight}>
+        <Table
+          columns={columnsWithButton}
+          data={data.map((entry) => ({ ...entry, onAction }))}
+          defaultSortingKey="firstName"
+        >
+          <Table.MultiSelectableContent
+            rowHeight="h40"
+            separationLineVariant="backgroundLevel3"
+            {...props}
+          />
+        </Table>
+      </ThemeProvider>,
+    );
+
+  it('does not single-select the row when a button inside a cell is clicked', async () => {
+    const onAction = jest.fn();
+    const onSingleRowSelected = jest.fn();
+    renderWithAction(onAction, { onSingleRowSelected });
+
+    await waitFor(() => screen.queryAllByRole('img', { hidden: true }));
+    fireEvent.click(screen.getByRole('button', { name: /Detach Ninette/ }));
+
+    expect(onAction).toHaveBeenCalledTimes(1);
+    expect(onSingleRowSelected).not.toHaveBeenCalled();
+  });
+
+  it('does not multi-select the row when a button inside a cell is clicked', async () => {
+    const onAction = jest.fn();
+    const onMultiSelectionChanged = jest.fn();
+    renderWithAction(onAction, { onMultiSelectionChanged });
+
+    await waitFor(() => screen.queryAllByRole('img', { hidden: true }));
+    onMultiSelectionChanged.mockClear();
+    fireEvent.click(screen.getByRole('button', { name: /Detach Ninette/ }));
+
+    expect(onAction).toHaveBeenCalledTimes(1);
+    expect(onMultiSelectionChanged).not.toHaveBeenCalled();
+  });
+
+  it('still single-selects the row when the click lands on plain cell content', async () => {
+    const onAction = jest.fn();
+    const onSingleRowSelected = jest.fn();
+    renderWithAction(onAction, { onSingleRowSelected });
+
+    await waitFor(() => screen.queryAllByRole('img', { hidden: true }));
+    fireEvent.click(screen.getByText('Ninette'));
+
+    expect(onSingleRowSelected).toHaveBeenCalledTimes(1);
+    expect(onAction).not.toHaveBeenCalled();
+  });
+});

--- a/src/lib/components/tablev2/MultiSelectableContent.tsx
+++ b/src/lib/components/tablev2/MultiSelectableContent.tsx
@@ -208,11 +208,9 @@ export const MultiSelectableContent = <
                   <div
                     {...cellProps}
                     onClick={(event) => {
-                      // Selecting the row is what this cell is for, so it owns
-                      // the click outright rather than relying on the bubble the
-                      // row's interactive-target guard now stops. Both former
-                      // paths — direct here, or bubbling to the row handler's
-                      // else branch — ended in this same call.
+                      // Selecting the row is what this cell is for, so it owns the
+                      // click outright rather than relying on a bubble the row's
+                      // guard now stops.
                       event.stopPropagation();
                       handleMultipleSelectedRowsRef.current(
                         selectedRowIdsRef.current,

--- a/src/lib/components/tablev2/MultiSelectableContent.tsx
+++ b/src/lib/components/tablev2/MultiSelectableContent.tsx
@@ -16,7 +16,8 @@ import {
   TableVariantType,
 } from './TableUtils';
 import {
-  isInteractiveTarget,
+  bodyCellStyle,
+  shouldIgnoreRowEvent,
   TableRows,
   TruncatableHeaderLabel,
   useTableScrollbar,
@@ -172,7 +173,7 @@ export const MultiSelectableContent = <
             style: { ...style },
           }),
           onClick: (event) => {
-            if (isInteractiveTarget(event)) return;
+            if (shouldIgnoreRowEvent(event)) return;
             const onSingleRowSelected = onSingleRowSelectedRef.current;
             if (onSingleRowSelected) {
               onSingleRowSelected(row);
@@ -198,22 +199,7 @@ export const MultiSelectableContent = <
           >
             {row.cells.map((cell) => {
               const cellProps = cell.getCellProps({
-                style: {
-                  // Same reset as TableHeader. A flex item defaults to
-                  // `min-width: auto`, so without this a short cell freezes at
-                  // its content width while its header keeps shrinking — and
-                  // flexbox then redistributes that frozen item's share of the
-                  // negative free space onto the row's remaining shrinkable
-                  // cell, pushing it *below* its own header. Both rows have to
-                  // shrink by the same rules or the columns cannot agree.
-                  // Before the spread, so a consumer's cellStyle still wins.
-                  minWidth: 0,
-                  ...cell.column.cellStyle,
-                  // Vertically center the text in cells.
-                  display: 'flex',
-                  flexDirection: 'column',
-                  justifyContent: 'center',
-                },
+                style: bodyCellStyle(cell.column.cellStyle),
                 role: 'gridcell',
               });
 
@@ -314,8 +300,8 @@ export const MultiSelectableContent = <
                       </div>
                     ) : (
                       <TruncatableHeaderLabel header={column.Header}>
-                      {column.render('Header')}
-                    </TruncatableHeaderLabel>
+                        {column.render('Header')}
+                      </TruncatableHeaderLabel>
                     )}
                     <SortCaret column={column} />
                   </HeaderContent>

--- a/src/lib/components/tablev2/MultiSelectableContent.tsx
+++ b/src/lib/components/tablev2/MultiSelectableContent.tsx
@@ -5,7 +5,6 @@ import { useTableContext } from './Tablev2.component';
 import {
   HeadRow,
   SortCaret,
-  HeaderLabel,
   TableBody,
   TableHeader,
   TableRowMultiSelectable,
@@ -16,7 +15,12 @@ import {
   TableLocalType,
   TableVariantType,
 } from './TableUtils';
-import { TableRows, useTableScrollbar } from './TableCommon';
+import {
+  isInteractiveTarget,
+  TableRows,
+  TruncatableHeaderLabel,
+  useTableScrollbar,
+} from './TableCommon';
 import useSyncedScroll from './useSyncedScroll';
 import { Box } from '../box/Box';
 import { Loader } from '../loader/Loader.component';
@@ -167,7 +171,8 @@ export const MultiSelectableContent = <
              */
             style: { ...style },
           }),
-          onClick: () => {
+          onClick: (event) => {
+            if (isInteractiveTarget(event)) return;
             const onSingleRowSelected = onSingleRowSelectedRef.current;
             if (onSingleRowSelected) {
               onSingleRowSelected(row);
@@ -208,7 +213,11 @@ export const MultiSelectableContent = <
                   <div
                     {...cellProps}
                     onClick={(event) => {
-                      if (!onSingleRowSelectedRef.current) return;
+                      // Selecting the row is what this cell is for, so it owns
+                      // the click outright rather than relying on the bubble the
+                      // row's interactive-target guard now stops. Both former
+                      // paths — direct here, or bubbling to the row handler's
+                      // else branch — ended in this same call.
                       event.stopPropagation();
                       handleMultipleSelectedRowsRef.current(
                         selectedRowIdsRef.current,
@@ -295,7 +304,9 @@ export const MultiSelectableContent = <
                         {column.render('Header')}
                       </div>
                     ) : (
-                      <HeaderLabel>{column.render('Header')}</HeaderLabel>
+                      <TruncatableHeaderLabel header={column.Header}>
+                      {column.render('Header')}
+                    </TruncatableHeaderLabel>
                     )}
                     <SortCaret column={column} />
                   </HeaderContent>

--- a/src/lib/components/tablev2/MultiSelectableContent.tsx
+++ b/src/lib/components/tablev2/MultiSelectableContent.tsx
@@ -199,6 +199,15 @@ export const MultiSelectableContent = <
             {row.cells.map((cell) => {
               const cellProps = cell.getCellProps({
                 style: {
+                  // Same reset as TableHeader. A flex item defaults to
+                  // `min-width: auto`, so without this a short cell freezes at
+                  // its content width while its header keeps shrinking — and
+                  // flexbox then redistributes that frozen item's share of the
+                  // negative free space onto the row's remaining shrinkable
+                  // cell, pushing it *below* its own header. Both rows have to
+                  // shrink by the same rules or the columns cannot agree.
+                  // Before the spread, so a consumer's cellStyle still wins.
+                  minWidth: 0,
                   ...cell.column.cellStyle,
                   // Vertically center the text in cells.
                   display: 'flex',

--- a/src/lib/components/tablev2/SingleSelectableContent.tsx
+++ b/src/lib/components/tablev2/SingleSelectableContent.tsx
@@ -155,6 +155,15 @@ export function SingleSelectableContent<
             {row.cells.map((cell) => {
               let cellProps = cell.getCellProps({
                 style: {
+                  // Same reset as TableHeader. A flex item defaults to
+                  // `min-width: auto`, so without this a short cell freezes at
+                  // its content width while its header keeps shrinking — and
+                  // flexbox then redistributes that frozen item's share of the
+                  // negative free space onto the row's remaining shrinkable
+                  // cell, pushing it *below* its own header. Both rows have to
+                  // shrink by the same rules or the columns cannot agree.
+                  // Before the spread, so a consumer's cellStyle still wins.
+                  minWidth: 0,
                   ...cell.column.cellStyle,
                   // Vertically center the text in cells.
                   display: 'flex',

--- a/src/lib/components/tablev2/SingleSelectableContent.tsx
+++ b/src/lib/components/tablev2/SingleSelectableContent.tsx
@@ -16,7 +16,8 @@ import {
   TableVariantType,
 } from './TableUtils';
 import {
-  isInteractiveTarget,
+  bodyCellStyle,
+  shouldIgnoreRowEvent,
   TableRows,
   TruncatableHeaderLabel,
   useTableScrollbar,
@@ -119,7 +120,7 @@ export function SingleSelectableContent<
           ...rowProps,
           ...{
             onClick: (event) => {
-              if (isInteractiveTarget(event)) return;
+              if (shouldIgnoreRowEvent(event)) return;
               const onRowSelected = onRowSelectedRef.current;
               if (onRowSelected) return onRowSelected(row);
             },
@@ -128,7 +129,7 @@ export function SingleSelectableContent<
               // `keydown` bubbles, so without the same guard Enter or Space on a
               // focused in-cell control selects the row *and* preventDefault()s
               // the control's own activation.
-              if (isInteractiveTarget(event)) return;
+              if (shouldIgnoreRowEvent(event)) return;
               const onRowSelected = onRowSelectedRef.current;
               if (
                 onRowSelected &&
@@ -154,22 +155,7 @@ export function SingleSelectableContent<
           >
             {row.cells.map((cell) => {
               let cellProps = cell.getCellProps({
-                style: {
-                  // Same reset as TableHeader. A flex item defaults to
-                  // `min-width: auto`, so without this a short cell freezes at
-                  // its content width while its header keeps shrinking — and
-                  // flexbox then redistributes that frozen item's share of the
-                  // negative free space onto the row's remaining shrinkable
-                  // cell, pushing it *below* its own header. Both rows have to
-                  // shrink by the same rules or the columns cannot agree.
-                  // Before the spread, so a consumer's cellStyle still wins.
-                  minWidth: 0,
-                  ...cell.column.cellStyle,
-                  // Vertically center the text in cells.
-                  display: 'flex',
-                  flexDirection: 'column',
-                  justifyContent: 'center',
-                },
+                style: bodyCellStyle(cell.column.cellStyle),
                 role: 'gridcell',
               });
 

--- a/src/lib/components/tablev2/SingleSelectableContent.tsx
+++ b/src/lib/components/tablev2/SingleSelectableContent.tsx
@@ -95,13 +95,10 @@ export function SingleSelectableContent<
 
   /**
    * Whether rows are selectable is *rendered* output -- tabIndex and the hover
-   * affordance -- not something only an event handler needs, so it comes from a
-   * plain value and a memo dependency rather than from the ref above. Today the
-   * ref happens to read fresh either way, because react-table hands react-window
-   * a new `rows` array on every render and the memoized row never gets to bail
-   * out; that is a coincidence of someone else's memoization, not a guarantee
-   * this component makes. Depending on it costs nothing: `onRowSelected` changes
-   * identity every render, this boolean almost never does.
+   * affordance -- not something only a handler reads, so it is a plain value and a
+   * memo dependency rather than the ref above. The ref reads fresh today only
+   * because react-window never gets to bail out of the memo, which is someone
+   * else's memoization and not a guarantee this component makes.
    */
   const isSelectable = Boolean(onRowSelected);
 
@@ -139,8 +136,8 @@ export function SingleSelectableContent<
               },
               tabIndex: isSelectable ? 0 : undefined,
               onKeyDown: (event) => {
-                // `keydown` bubbles, so without the same guard Enter or Space on a
-                // focused in-cell control selects the row *and* preventDefault()s
+                // `keydown` bubbles, so without the same guard Enter or Space on
+                // a focused in-cell control selects the row *and* preventDefault()s
                 // the control's own activation.
                 if (shouldIgnoreRowEvent(event)) return;
                 const onRowSelected = onRowSelectedRef.current;

--- a/src/lib/components/tablev2/SingleSelectableContent.tsx
+++ b/src/lib/components/tablev2/SingleSelectableContent.tsx
@@ -94,6 +94,18 @@ export function SingleSelectableContent<
   onRowSelectedRef.current = onRowSelected;
 
   /**
+   * Whether rows are selectable is *rendered* output -- tabIndex and the hover
+   * affordance -- not something only an event handler needs, so it comes from a
+   * plain value and a memo dependency rather than from the ref above. Today the
+   * ref happens to read fresh either way, because react-table hands react-window
+   * a new `rows` array on every render and the memoized row never gets to bail
+   * out; that is a coincidence of someone else's memoization, not a guarantee
+   * this component makes. Depending on it costs nothing: `onRowSelected` changes
+   * identity every render, this boolean almost never does.
+   */
+  const isSelectable = Boolean(onRowSelected);
+
+  /**
    * RenderRow MUST keep a stable identity across re-renders. It used to be redefined inline on
    * every render, so react-window saw a new component type each time and remounted (not just
    * re-rendered) every row — and therefore every cell — whenever the table re-rendered for any
@@ -104,71 +116,74 @@ export function SingleSelectableContent<
    */
   const RenderRow = useMemo(
     () =>
-      memo(({ index, style, data }: ListChildComponentProps<Row<DATA_ROW>[]>) => {
-        const row = data[index];
-        prepareRowRef.current(row);
-        let rowProps = row.getRowProps({
-          /**
-           * Note: We need to pass the style property to the row component.
-           * Otherwise when we scroll down, the next rows are flashing
-           * because they are re-rendered in loop.
-           */
-          style: { ...style },
-        });
+      memo(
+        ({ index, style, data }: ListChildComponentProps<Row<DATA_ROW>[]>) => {
+          const row = data[index];
+          prepareRowRef.current(row);
+          let rowProps = row.getRowProps({
+            /**
+             * Note: We need to pass the style property to the row component.
+             * Otherwise when we scroll down, the next rows are flashing
+             * because they are re-rendered in loop.
+             */
+            style: { ...style },
+          });
 
-        rowProps = {
-          ...rowProps,
-          ...{
-            onClick: (event) => {
-              if (shouldIgnoreRowEvent(event)) return;
-              const onRowSelected = onRowSelectedRef.current;
-              if (onRowSelected) return onRowSelected(row);
+          rowProps = {
+            ...rowProps,
+            ...{
+              onClick: (event) => {
+                if (shouldIgnoreRowEvent(event)) return;
+                const onRowSelected = onRowSelectedRef.current;
+                if (onRowSelected) return onRowSelected(row);
+              },
+              tabIndex: isSelectable ? 0 : undefined,
+              onKeyDown: (event) => {
+                // `keydown` bubbles, so without the same guard Enter or Space on a
+                // focused in-cell control selects the row *and* preventDefault()s
+                // the control's own activation.
+                if (shouldIgnoreRowEvent(event)) return;
+                const onRowSelected = onRowSelectedRef.current;
+                if (
+                  onRowSelected &&
+                  (event.key === ' ' ||
+                    event.key === 'Enter' ||
+                    event.key === 'Spacebar')
+                ) {
+                  event.preventDefault();
+                  onRowSelected(row);
+                }
+              },
             },
-            tabIndex: onRowSelectedRef.current ? 0 : undefined,
-            onKeyDown: (event) => {
-              // `keydown` bubbles, so without the same guard Enter or Space on a
-              // focused in-cell control selects the row *and* preventDefault()s
-              // the control's own activation.
-              if (shouldIgnoreRowEvent(event)) return;
-              const onRowSelected = onRowSelectedRef.current;
-              if (
-                onRowSelected &&
-                (event.key === ' ' ||
-                  event.key === 'Enter' ||
-                  event.key === 'Spacebar')
-              ) {
-                event.preventDefault();
-                onRowSelected(row);
-              }
-            },
-          },
-        };
+          };
 
-        return (
-          <TableRow
-            {...rowProps}
-            $isSelected={selectedId === row.id}
-            aria-selected={selectedId === row.id ? 'true' : 'false'}
-            $separationLineVariant={separationLineVariant}
-            $selectable={Boolean(onRowSelectedRef.current)}
-            className="tr"
-          >
-            {row.cells.map((cell) => {
-              let cellProps = cell.getCellProps({
-                style: bodyCellStyle(cell.column.cellStyle),
-                role: 'gridcell',
-              });
+          return (
+            <TableRow
+              {...rowProps}
+              $isSelected={selectedId === row.id}
+              aria-selected={selectedId === row.id ? 'true' : 'false'}
+              $separationLineVariant={separationLineVariant}
+              $selectable={isSelectable}
+              className="tr"
+            >
+              {row.cells.map((cell) => {
+                let cellProps = cell.getCellProps({
+                  style: bodyCellStyle(cell.column.cellStyle),
+                  role: 'gridcell',
+                });
 
-              return (
-                <div {...cellProps} className="td">
-                  {cell.render('Cell')}
-                </div>
-              );
-            })}
-          </TableRow>
-        );
-      }, areEqual),
-    [selectedId, separationLineVariant],
+                return (
+                  <div {...cellProps} className="td">
+                    {cell.render('Cell')}
+                  </div>
+                );
+              })}
+            </TableRow>
+          );
+        },
+        areEqual,
+      ),
+    [selectedId, separationLineVariant, isSelectable],
   );
 
   const { hasScrollbar, scrollBarWidth, handleScrollbarWidth } =

--- a/src/lib/components/tablev2/SingleSelectableContent.tsx
+++ b/src/lib/components/tablev2/SingleSelectableContent.tsx
@@ -9,14 +9,18 @@ import {
   TableHeader,
   SortCaret,
   HeaderContent,
-  HeaderLabel,
 } from './Tablestyle';
 import {
   TableHeightKeyType,
   TableLocalType,
   TableVariantType,
 } from './TableUtils';
-import { TableRows, useTableScrollbar } from './TableCommon';
+import {
+  isInteractiveTarget,
+  TableRows,
+  TruncatableHeaderLabel,
+  useTableScrollbar,
+} from './TableCommon';
 import useSyncedScroll from './useSyncedScroll';
 import { Loader } from '../loader/Loader.component';
 import { Box } from '../box/Box';
@@ -114,12 +118,17 @@ export function SingleSelectableContent<
         rowProps = {
           ...rowProps,
           ...{
-            onClick: () => {
+            onClick: (event) => {
+              if (isInteractiveTarget(event)) return;
               const onRowSelected = onRowSelectedRef.current;
               if (onRowSelected) return onRowSelected(row);
             },
             tabIndex: onRowSelectedRef.current ? 0 : undefined,
             onKeyDown: (event) => {
+              // `keydown` bubbles, so without the same guard Enter or Space on a
+              // focused in-cell control selects the row *and* preventDefault()s
+              // the control's own activation.
+              if (isInteractiveTarget(event)) return;
               const onRowSelected = onRowSelectedRef.current;
               if (
                 onRowSelected &&
@@ -211,7 +220,9 @@ export function SingleSelectableContent<
                     $align={column.cellStyle?.textAlign}
                     $sortable={!column.disableSortBy}
                   >
-                    <HeaderLabel>{column.render('Header')}</HeaderLabel>
+                    <TruncatableHeaderLabel header={column.Header}>
+                      {column.render('Header')}
+                    </TruncatableHeaderLabel>
                     <SortCaret column={column} />
                   </HeaderContent>
                 </TableHeader>

--- a/src/lib/components/tablev2/SingleSelectableContent.tsx
+++ b/src/lib/components/tablev2/SingleSelectableContent.tsx
@@ -149,7 +149,7 @@ export function SingleSelectableContent<
             $isSelected={selectedId === row.id}
             aria-selected={selectedId === row.id ? 'true' : 'false'}
             $separationLineVariant={separationLineVariant}
-            $selectedId={selectedId}
+            $selectable={Boolean(onRowSelectedRef.current)}
             className="tr"
           >
             {row.cells.map((cell) => {

--- a/src/lib/components/tablev2/SingleSelectableContent.tsx
+++ b/src/lib/components/tablev2/SingleSelectableContent.tsx
@@ -94,11 +94,10 @@ export function SingleSelectableContent<
   onRowSelectedRef.current = onRowSelected;
 
   /**
-   * Whether rows are selectable is *rendered* output -- tabIndex and the hover
-   * affordance -- not something only a handler reads, so it is a plain value and a
-   * memo dependency rather than the ref above. The ref reads fresh today only
-   * because react-window never gets to bail out of the memo, which is someone
-   * else's memoization and not a guarantee this component makes.
+   * Rendered output -- tabIndex and the hover affordance -- not something only a
+   * handler reads, so a plain value and a memo dependency rather than the ref above.
+   * The ref reads fresh today only because react-window never bails out of the memo,
+   * which is not a guarantee this component makes.
    */
   const isSelectable = Boolean(onRowSelected);
 

--- a/src/lib/components/tablev2/TableCommon.tsx
+++ b/src/lib/components/tablev2/TableCommon.tsx
@@ -24,8 +24,9 @@ import {
 } from './TableUtils';
 import { useTableContext } from './Tablev2.component';
 import useSyncedScroll from './useSyncedScroll';
-import { CSSProperties } from 'styled-components';
+import styled, { CSSProperties } from 'styled-components';
 import { UnsuccessfulResult } from '../UnsuccessfulResult.component';
+import { Tooltip } from '../tooltip/Tooltip.component';
 import { HeaderLabel } from './Tablestyle';
 
 const SmoothScrollDiv = forwardRef<HTMLDivElement, any>((props, ref) => {
@@ -127,6 +128,27 @@ export const VirtualizedRows = <
 };
 
 /**
+ * Style every body cell gets, given the column's own `cellStyle`.
+ *
+ * `min-width: 0` is the same reset `TableHeader` carries. A flex item defaults
+ * to `min-width: auto`, so without it a short cell freezes at its content width
+ * while its header keeps shrinking — and flexbox then redistributes that frozen
+ * item's share of the negative free space onto the row's remaining shrinkable
+ * cell, pushing it *below* its own header. Both rows have to shrink by the same
+ * rules or the columns cannot agree on their widths.
+ *
+ * It goes before the spread so a consumer's `cellStyle` still wins; the flex
+ * centring goes after, because that is the cell's own layout and not a default.
+ */
+export const bodyCellStyle = (cellStyle?: CSSProperties): CSSProperties => ({
+  minWidth: 0,
+  ...cellStyle,
+  display: 'flex',
+  flexDirection: 'column',
+  justifyContent: 'center',
+});
+
+/**
  * Controls a row-wide handler must not act on. A row's `onClick`/`onKeyDown`
  * fires for any click inside it, so without this a click on a button in a cell
  * both activates the button and selects the row — and the selection re-render
@@ -140,11 +162,38 @@ export const VirtualizedRows = <
 const INTERACTIVE_SELECTOR =
   'button, a, input, select, textarea, label, [role="button"], [role="link"], [role="checkbox"], [role="menuitem"]';
 
-export const isInteractiveTarget = (event: {
+/**
+ * Whether a bubbled event reached a row's handler from somewhere the row must
+ * not treat as a click on itself.
+ *
+ * The search is bounded to the row (`currentTarget`) at both ends, and each
+ * bound closes a real hole:
+ *
+ * - **Upwards.** An unbounded `closest()` walks past the row to the document,
+ *   so a table rendered inside a `<label>`, an `<a>` or a `[role="button"]` —
+ *   a whole table as one big click target is a real consumer pattern — matched
+ *   that ancestor for *every* cell and disabled row selection entirely.
+ * - **Downwards.** A React portal escapes the row in the DOM but still bubbles
+ *   to it through the React tree, so plain text in a portalled popover (the
+ *   `revealDroppedColumns` panel, a Select menu) reached this handler with
+ *   nothing interactive between it and the row, and silently selected the row
+ *   behind the open overlay. Anything not contained by the row is not a click
+ *   on the row.
+ */
+export const shouldIgnoreRowEvent = (event: {
   target: EventTarget | null;
-}): boolean =>
-  event.target instanceof Element &&
-  !!event.target.closest(INTERACTIVE_SELECTOR);
+  currentTarget: EventTarget | null;
+}): boolean => {
+  const { target, currentTarget } = event;
+  if (!(target instanceof Element) || !(currentTarget instanceof Element)) {
+    return false;
+  }
+  if (!currentTarget.contains(target)) {
+    return true;
+  }
+  const control = target.closest(INTERACTIVE_SELECTOR);
+  return !!control && currentTarget.contains(control);
+};
 
 /**
  * Reports whether the element the returned ref is attached to is actually
@@ -176,16 +225,51 @@ const useIsEllipsized = <T extends HTMLElement>() => {
 };
 
 /**
- * A header label that offers its full text once it no longer fits. Body cells
- * already recover via `ConstrainedText`, so an ellipsized header was the one
- * place a label became unreadable with no way to get it back.
+ * Makes `Tooltip` safe to put around an ellipsizing flex item.
  *
- * `title` rather than core-ui's `Tooltip`: `TooltipContainer` is an
- * `inline-block` with no `min-width: 0`, so wrapping the label would replace the
- * ellipsizing flex item with one that cannot shrink below its min-content — it
- * would remove the truncation instead of explaining it. The attribute is also
- * only attached when the label really is cut off, since a tooltip on a header
- * that reads fine is noise.
+ * `TooltipContainer` is an `inline-block` with no `min-width: 0`, and it wraps
+ * its children in a second plain `div`. Left alone, both sit between the flex
+ * item and the text and impose a content-based minimum, so the column stops
+ * shrinking and the label never ellipsizes at all — the tooltip would remove
+ * the truncation it exists to explain. Forcing the chain to shrinkable blocks
+ * keeps `HeaderLabel` the element that runs out of room.
+ *
+ * Same problem `ConstrainedText` solves with its own `BlockTooltip`.
+ */
+const HeaderLabelFrame = styled.div`
+  /* Shrink-to-fit, exactly as the bare label was: HeaderContent aligns with
+     justify-content, which is inert once a child grows to fill the row. A
+     growing frame also strands the caret at the far edge instead of beside the
+     label, since end-aligned columns place it with order: -1. */
+  min-width: 0;
+
+  > .sc-tooltip,
+  > .sc-tooltip > div {
+    display: block;
+    min-width: 0;
+  }
+`;
+
+/**
+ * A header label that offers its full text through a `Tooltip` once it no
+ * longer fits. Body cells already recover via `ConstrainedText`, so an
+ * ellipsized header was the one place a label became unreadable with no way to
+ * get it back.
+ *
+ * `Tooltip` rather than a native `title`: `title` is drawn by the OS after a
+ * ~1s delay that cannot be configured, which reads as nothing happening. It
+ * also collides here — react-table's `getSortByToggleProps()` already puts
+ * `title="Toggle SortBy"` on the header itself, so a sortable header would
+ * carry two competing titles and which one appears depends on the pixel hovered.
+ *
+ * The wrapper chain is rendered in **every** state and only `overlay` is
+ * conditional. Mounting the tooltip on the flip instead would change the DOM
+ * under the element being measured, refire the ref against a differently-sized
+ * container, and let the two states oscillate.
+ *
+ * Truncation costs nothing in the accessibility tree — the full text is still
+ * in the DOM and still the header's accessible name — so this is a visual
+ * affordance only.
  */
 export const TruncatableHeaderLabel = ({
   header,
@@ -195,14 +279,14 @@ export const TruncatableHeaderLabel = ({
   children: ReactNode;
 }) => {
   const { ref, isEllipsized } = useIsEllipsized<HTMLSpanElement>();
+  const canRecover = typeof header === 'string' && isEllipsized;
 
   return (
-    <HeaderLabel
-      ref={ref}
-      title={typeof header === 'string' && isEllipsized ? header : undefined}
-    >
-      {children}
-    </HeaderLabel>
+    <HeaderLabelFrame>
+      <Tooltip overlay={canRecover ? header : undefined} placement="top">
+        <HeaderLabel ref={ref}>{children}</HeaderLabel>
+      </Tooltip>
+    </HeaderLabelFrame>
   );
 };
 

--- a/src/lib/components/tablev2/TableCommon.tsx
+++ b/src/lib/components/tablev2/TableCommon.tsx
@@ -130,10 +130,9 @@ export const VirtualizedRows = <
 /**
  * Style every body cell gets, given the column's own `cellStyle`.
  *
- * `min-width: 0` is the same reset `TableHeader` carries: without it a short cell
- * freezes at its content width while its header keeps shrinking, and the two rows
- * stop agreeing on their widths. It goes before the spread so a consumer's
- * `cellStyle` still wins; the flex centring goes after, as the cell's own layout.
+ * `min-width: 0` is the same reset `TableHeader` carries -- without it a short cell
+ * freezes at its content width while its header keeps shrinking. Before the spread
+ * so a consumer's `cellStyle` wins; the flex centring after, as the cell's own.
  */
 export const bodyCellStyle = (cellStyle?: CSSProperties): CSSProperties => ({
   minWidth: 0,
@@ -145,22 +144,18 @@ export const bodyCellStyle = (cellStyle?: CSSProperties): CSSProperties => ({
 
 /**
  * Controls a row-wide handler must not act on. A row's `onClick`/`onKeyDown` fires
- * for any click inside it, so without this a click on a button in a cell both
- * activates the button and selects the row — and the selection re-render remounts
- * the cell, closing whatever the button just opened. The selection checkbox is
- * deliberately absent: its own cell stops propagation, because selecting the row is
- * exactly what it is for.
+ * for any click inside it, so a click on an in-cell button also selected the row --
+ * and that re-render remounts the cell, closing whatever the button just opened.
+ * The selection checkbox is absent on purpose: its own cell stops propagation.
  */
 const INTERACTIVE_SELECTOR =
   'button, a, input, select, textarea, label, [role="button"], [role="link"], [role="checkbox"], [role="menuitem"]';
 
 /**
  * Whether a bubbled event reached a row's handler from somewhere the row must not
- * treat as a click on itself. Bounded to the row at both ends, and each bound
- * closes a real hole: an unbounded `closest()` walks past the row to the document,
- * so one matching element anywhere above the table disabled selection for every
- * row; and a React portal escapes the row in the DOM while still bubbling to it
- * through React, so plain text in a portalled popover selected the row behind it.
+ * treat as a click on itself. Both bounds are load-bearing: an unbounded `closest()`
+ * walks past the row to the document, and a React portal leaves the row in the DOM
+ * while still bubbling to it through React.
  */
 export const shouldIgnoreRowEvent = (event: {
   target: EventTarget | null;
@@ -206,18 +201,16 @@ const useIsEllipsized = <T extends HTMLElement>() => {
 };
 
 /**
- * Makes `Tooltip` safe to put around an ellipsizing flex item. `TooltipContainer`
- * is an `inline-block` with no `min-width: 0` and wraps its children in a second
- * `div`; left alone both impose a content-based minimum, so the column stops
- * shrinking and the label never ellipsizes — the tooltip would remove the
- * truncation it exists to explain. `ConstrainedText` has its own `BlockTooltip`
- * for the same reason.
+ * Makes `Tooltip` safe around an ellipsizing flex item. `TooltipContainer` is an
+ * `inline-block` with no `min-width: 0` and wraps its children in a second `div`,
+ * both of which impose a content-based minimum -- so the column stops shrinking and
+ * the tooltip removes the truncation it exists to explain. `ConstrainedText` has its
+ * own `BlockTooltip` for the same reason.
  */
 const HeaderLabelFrame = styled.div`
-  /* Shrink-to-fit, exactly as the bare label was: HeaderContent aligns with
-     justify-content, which is inert once a child grows to fill the row. A
-     growing frame also strands the caret at the far edge instead of beside the
-     label, since end-aligned columns place it with order: -1. */
+  /* Shrink-to-fit, as the bare label was: HeaderContent aligns with
+     justify-content, inert once a child fills the row, and a growing frame also
+     strands the caret at the far edge. */
   min-width: 0;
 
   > .sc-tooltip,
@@ -229,14 +222,13 @@ const HeaderLabelFrame = styled.div`
 
 /**
  * A header label that offers its full text through a `Tooltip` once it no longer
- * fits. Body cells already recover via `ConstrainedText`, so an ellipsized header
- * was the one label with no way back.
+ * fits. Body cells already recover via `ConstrainedText`; an ellipsized header had
+ * no way back.
  *
- * `Tooltip` rather than a native `title`: `title` has an unconfigurable ~1s delay,
- * and react-table's `getSortByToggleProps()` already puts one on the header, so a
- * sortable header would carry two competing titles. The wrapper chain renders in
- * every state and only `overlay` is conditional, so the element being measured
- * never changes size underneath the ref.
+ * `Tooltip` and not a native `title`: `title` has an unconfigurable ~1s delay, and
+ * react-table's `getSortByToggleProps()` already sets one, so a sortable header
+ * would carry two. Only `overlay` is conditional, so the measured element never
+ * changes size under the ref.
  */
 export const TruncatableHeaderLabel = ({
   header,

--- a/src/lib/components/tablev2/TableCommon.tsx
+++ b/src/lib/components/tablev2/TableCommon.tsx
@@ -1,8 +1,10 @@
 import {
   ComponentType,
+  ReactNode,
   Ref,
   useCallback,
   useMemo,
+  useRef,
   useState,
   forwardRef,
 } from 'react';
@@ -24,6 +26,7 @@ import { useTableContext } from './Tablev2.component';
 import useSyncedScroll from './useSyncedScroll';
 import { CSSProperties } from 'styled-components';
 import { UnsuccessfulResult } from '../UnsuccessfulResult.component';
+import { HeaderLabel } from './Tablestyle';
 
 const SmoothScrollDiv = forwardRef<HTMLDivElement, any>((props, ref) => {
   const { scrollFade } = useTableContext();
@@ -120,6 +123,86 @@ export const VirtualizedRows = <
         );
       }}
     </AutoSizer>
+  );
+};
+
+/**
+ * Controls a row-wide handler must not act on. A row's `onClick`/`onKeyDown`
+ * fires for any click inside it, so without this a click on a button in a cell
+ * both activates the button and selects the row — and the selection re-render
+ * remounts the cell, closing whatever the button just opened.
+ *
+ * `label` is included on purpose: clicking a label activates its control.
+ * `[role="button"]` catches div-based triggers, which core-ui has its own share
+ * of. The selection checkbox is deliberately NOT excluded here — its cell stops
+ * propagation itself, because selecting the row is exactly what it is for.
+ */
+const INTERACTIVE_SELECTOR =
+  'button, a, input, select, textarea, label, [role="button"], [role="link"], [role="checkbox"], [role="menuitem"]';
+
+export const isInteractiveTarget = (event: {
+  target: EventTarget | null;
+}): boolean =>
+  event.target instanceof Element &&
+  !!event.target.closest(INTERACTIVE_SELECTOR);
+
+/**
+ * Reports whether the element the returned ref is attached to is actually
+ * ellipsized. Re-measures on resize because a column's width here comes from a
+ * grow factor, not a fixed size, so whether a header truncates changes with the
+ * table's width and cannot be decided once at mount.
+ */
+const useIsEllipsized = <T extends HTMLElement>() => {
+  const [isEllipsized, setIsEllipsized] = useState(false);
+  const observerRef = useRef<ResizeObserver | null>(null);
+
+  const ref = useCallback((node: T | null) => {
+    observerRef.current?.disconnect();
+    observerRef.current = null;
+    if (!node) {
+      return;
+    }
+    const measure = () => setIsEllipsized(node.scrollWidth > node.clientWidth);
+    measure();
+    if (typeof ResizeObserver === 'undefined') {
+      return;
+    }
+    const observer = new ResizeObserver(measure);
+    observer.observe(node);
+    observerRef.current = observer;
+  }, []);
+
+  return { ref, isEllipsized };
+};
+
+/**
+ * A header label that offers its full text once it no longer fits. Body cells
+ * already recover via `ConstrainedText`, so an ellipsized header was the one
+ * place a label became unreadable with no way to get it back.
+ *
+ * `title` rather than core-ui's `Tooltip`: `TooltipContainer` is an
+ * `inline-block` with no `min-width: 0`, so wrapping the label would replace the
+ * ellipsizing flex item with one that cannot shrink below its min-content — it
+ * would remove the truncation instead of explaining it. The attribute is also
+ * only attached when the label really is cut off, since a tooltip on a header
+ * that reads fine is noise.
+ */
+export const TruncatableHeaderLabel = ({
+  header,
+  children,
+}: {
+  header: unknown;
+  children: ReactNode;
+}) => {
+  const { ref, isEllipsized } = useIsEllipsized<HTMLSpanElement>();
+
+  return (
+    <HeaderLabel
+      ref={ref}
+      title={typeof header === 'string' && isEllipsized ? header : undefined}
+    >
+      {children}
+    </HeaderLabel>
   );
 };
 

--- a/src/lib/components/tablev2/TableCommon.tsx
+++ b/src/lib/components/tablev2/TableCommon.tsx
@@ -130,15 +130,10 @@ export const VirtualizedRows = <
 /**
  * Style every body cell gets, given the column's own `cellStyle`.
  *
- * `min-width: 0` is the same reset `TableHeader` carries. A flex item defaults
- * to `min-width: auto`, so without it a short cell freezes at its content width
- * while its header keeps shrinking — and flexbox then redistributes that frozen
- * item's share of the negative free space onto the row's remaining shrinkable
- * cell, pushing it *below* its own header. Both rows have to shrink by the same
- * rules or the columns cannot agree on their widths.
- *
- * It goes before the spread so a consumer's `cellStyle` still wins; the flex
- * centring goes after, because that is the cell's own layout and not a default.
+ * `min-width: 0` is the same reset `TableHeader` carries: without it a short cell
+ * freezes at its content width while its header keeps shrinking, and the two rows
+ * stop agreeing on their widths. It goes before the spread so a consumer's
+ * `cellStyle` still wins; the flex centring goes after, as the cell's own layout.
  */
 export const bodyCellStyle = (cellStyle?: CSSProperties): CSSProperties => ({
   minWidth: 0,
@@ -149,39 +144,23 @@ export const bodyCellStyle = (cellStyle?: CSSProperties): CSSProperties => ({
 });
 
 /**
- * Controls a row-wide handler must not act on. A row's `onClick`/`onKeyDown`
- * fires for any click inside it, so without this a click on a button in a cell
- * both activates the button and selects the row — and the selection re-render
- * remounts the cell, closing whatever the button just opened.
- *
- * `label` is here for a label *inside a cell*, wrapping that cell's own control:
- * clicking it activates the control, so the row must not also react.
- * `[role="button"]` catches div-based triggers, which core-ui has its own share
- * of. The selection checkbox is deliberately NOT excluded here — its cell stops
- * propagation itself, because selecting the row is exactly what it is for.
+ * Controls a row-wide handler must not act on. A row's `onClick`/`onKeyDown` fires
+ * for any click inside it, so without this a click on a button in a cell both
+ * activates the button and selects the row — and the selection re-render remounts
+ * the cell, closing whatever the button just opened. The selection checkbox is
+ * deliberately absent: its own cell stops propagation, because selecting the row is
+ * exactly what it is for.
  */
 const INTERACTIVE_SELECTOR =
   'button, a, input, select, textarea, label, [role="button"], [role="link"], [role="checkbox"], [role="menuitem"]';
 
 /**
- * Whether a bubbled event reached a row's handler from somewhere the row must
- * not treat as a click on itself.
- *
- * The search is bounded to the row (`currentTarget`) at both ends, and each
- * bound closes a real hole:
- *
- * - **Upwards.** An unbounded `closest()` walks past the row to the document,
- *   so a single element from the selector *anywhere* above the table — a
- *   clickable card wrapping it, an enclosing link — matched for every cell and
- *   disabled row selection across the whole table. The row has no say in what
- *   it is nested inside, so the bound belongs here rather than in a rule about
- *   where a table may be placed.
- * - **Downwards.** A React portal escapes the row in the DOM but still bubbles
- *   to it through the React tree, so plain text in a portalled popover (the
- *   `revealDroppedColumns` panel, a Select menu) reached this handler with
- *   nothing interactive between it and the row, and silently selected the row
- *   behind the open overlay. Anything not contained by the row is not a click
- *   on the row.
+ * Whether a bubbled event reached a row's handler from somewhere the row must not
+ * treat as a click on itself. Bounded to the row at both ends, and each bound
+ * closes a real hole: an unbounded `closest()` walks past the row to the document,
+ * so one matching element anywhere above the table disabled selection for every
+ * row; and a React portal escapes the row in the DOM while still bubbling to it
+ * through React, so plain text in a portalled popover selected the row behind it.
  */
 export const shouldIgnoreRowEvent = (event: {
   target: EventTarget | null;
@@ -200,9 +179,8 @@ export const shouldIgnoreRowEvent = (event: {
 
 /**
  * Reports whether the element the returned ref is attached to is actually
- * ellipsized. Re-measures on resize because a column's width here comes from a
- * grow factor, not a fixed size, so whether a header truncates changes with the
- * table's width and cannot be decided once at mount.
+ * ellipsized. Re-measures on resize: a column's width comes from a grow factor, so
+ * whether a header truncates changes with the table's width.
  */
 const useIsEllipsized = <T extends HTMLElement>() => {
   const [isEllipsized, setIsEllipsized] = useState(false);
@@ -228,16 +206,12 @@ const useIsEllipsized = <T extends HTMLElement>() => {
 };
 
 /**
- * Makes `Tooltip` safe to put around an ellipsizing flex item.
- *
- * `TooltipContainer` is an `inline-block` with no `min-width: 0`, and it wraps
- * its children in a second plain `div`. Left alone, both sit between the flex
- * item and the text and impose a content-based minimum, so the column stops
- * shrinking and the label never ellipsizes at all — the tooltip would remove
- * the truncation it exists to explain. Forcing the chain to shrinkable blocks
- * keeps `HeaderLabel` the element that runs out of room.
- *
- * Same problem `ConstrainedText` solves with its own `BlockTooltip`.
+ * Makes `Tooltip` safe to put around an ellipsizing flex item. `TooltipContainer`
+ * is an `inline-block` with no `min-width: 0` and wraps its children in a second
+ * `div`; left alone both impose a content-based minimum, so the column stops
+ * shrinking and the label never ellipsizes — the tooltip would remove the
+ * truncation it exists to explain. `ConstrainedText` has its own `BlockTooltip`
+ * for the same reason.
  */
 const HeaderLabelFrame = styled.div`
   /* Shrink-to-fit, exactly as the bare label was: HeaderContent aligns with
@@ -254,25 +228,15 @@ const HeaderLabelFrame = styled.div`
 `;
 
 /**
- * A header label that offers its full text through a `Tooltip` once it no
- * longer fits. Body cells already recover via `ConstrainedText`, so an
- * ellipsized header was the one place a label became unreadable with no way to
- * get it back.
+ * A header label that offers its full text through a `Tooltip` once it no longer
+ * fits. Body cells already recover via `ConstrainedText`, so an ellipsized header
+ * was the one label with no way back.
  *
- * `Tooltip` rather than a native `title`: `title` is drawn by the OS after a
- * ~1s delay that cannot be configured, which reads as nothing happening. It
- * also collides here — react-table's `getSortByToggleProps()` already puts
- * `title="Toggle SortBy"` on the header itself, so a sortable header would
- * carry two competing titles and which one appears depends on the pixel hovered.
- *
- * The wrapper chain is rendered in **every** state and only `overlay` is
- * conditional. Mounting the tooltip on the flip instead would change the DOM
- * under the element being measured, refire the ref against a differently-sized
- * container, and let the two states oscillate.
- *
- * Truncation costs nothing in the accessibility tree — the full text is still
- * in the DOM and still the header's accessible name — so this is a visual
- * affordance only.
+ * `Tooltip` rather than a native `title`: `title` has an unconfigurable ~1s delay,
+ * and react-table's `getSortByToggleProps()` already puts one on the header, so a
+ * sortable header would carry two competing titles. The wrapper chain renders in
+ * every state and only `overlay` is conditional, so the element being measured
+ * never changes size underneath the ref.
  */
 export const TruncatableHeaderLabel = ({
   header,

--- a/src/lib/components/tablev2/TableCommon.tsx
+++ b/src/lib/components/tablev2/TableCommon.tsx
@@ -154,7 +154,8 @@ export const bodyCellStyle = (cellStyle?: CSSProperties): CSSProperties => ({
  * both activates the button and selects the row — and the selection re-render
  * remounts the cell, closing whatever the button just opened.
  *
- * `label` is included on purpose: clicking a label activates its control.
+ * `label` is here for a label *inside a cell*, wrapping that cell's own control:
+ * clicking it activates the control, so the row must not also react.
  * `[role="button"]` catches div-based triggers, which core-ui has its own share
  * of. The selection checkbox is deliberately NOT excluded here — its cell stops
  * propagation itself, because selecting the row is exactly what it is for.
@@ -170,9 +171,11 @@ const INTERACTIVE_SELECTOR =
  * bound closes a real hole:
  *
  * - **Upwards.** An unbounded `closest()` walks past the row to the document,
- *   so a table rendered inside a `<label>`, an `<a>` or a `[role="button"]` —
- *   a whole table as one big click target is a real consumer pattern — matched
- *   that ancestor for *every* cell and disabled row selection entirely.
+ *   so a single element from the selector *anywhere* above the table — a
+ *   clickable card wrapping it, an enclosing link — matched for every cell and
+ *   disabled row selection across the whole table. The row has no say in what
+ *   it is nested inside, so the bound belongs here rather than in a rule about
+ *   where a table may be placed.
  * - **Downwards.** A React portal escapes the row in the DOM but still bubbles
  *   to it through the React tree, so plain text in a portalled popover (the
  *   `revealDroppedColumns` panel, a Select menu) reached this handler with

--- a/src/lib/components/tablev2/Tablestyle.tsx
+++ b/src/lib/components/tablev2/Tablestyle.tsx
@@ -211,6 +211,11 @@ type TableRowMultiSelectableType = {
 };
 export const TableRowMultiSelectable = styled.div<TableRowMultiSelectableType>`
   color: ${(props) => props.theme.textPrimary};
+  /* Must match HeadRow's gap. Every column track has a grow factor and no basis,
+     so a gap the header reserves and the body does not is free space the body
+     redistributes — shifting every boundary by grow-share × total gap, at any
+     width. That is the header-not-over-its-value defect. */
+  gap: ${spacing.r16};
   border-bottom: 1px solid
     ${(props) => props.theme[props.$separationLineVariant]};
   box-sizing: border-box;

--- a/src/lib/components/tablev2/Tablestyle.tsx
+++ b/src/lib/components/tablev2/Tablestyle.tsx
@@ -165,7 +165,13 @@ export const HeadRow = styled.div<HeadRowType>`
 
 type TableRowType = {
   $isSelected: boolean;
-  $selectedId?: string;
+  /**
+   * Whether the row can be selected at all — i.e. the content was given an
+   * `onRowSelected`. Not "something is currently selected": gating the hover
+   * affordance on that left a selectable table looking inert until its first
+   * click, with no pointer cursor to invite one.
+   */
+  $selectable?: boolean;
   $separationLineVariant: TableVariantType;
 };
 export const TableRow = styled.div<TableRowType>`
@@ -180,7 +186,7 @@ export const TableRow = styled.div<TableRowType>`
 
   // single selectable case
   ${(props) => {
-    if (props.$selectedId) {
+    if (props.$selectable) {
       return css`
         &:hover,
         &:focus {
@@ -196,7 +202,7 @@ export const TableRow = styled.div<TableRowType>`
   }}
 
   ${(props) => {
-    if (props.$selectedId && props.$isSelected) {
+    if (props.$isSelected) {
       return css`
         background-color: ${props.theme.highlight};
         box-shadow: inset -${borderSize} 0 0 ${props.theme.selectedActive};

--- a/src/lib/components/tablev2/Tablestyle.tsx
+++ b/src/lib/components/tablev2/Tablestyle.tsx
@@ -21,18 +21,12 @@ export const SortIncentive = styled.span`
 `;
 
 /**
- * The caret carries its own width, in flow, so nothing else has to reserve room
- * on its behalf: one value describes the footprint, and a sortable header's
- * intrinsic width already includes it.
- *
- * Being a flex item is what keeps the glyph beside the label rather than
- * stranded at the column's far edge, and lets `order` move it to the label's
- * other side. `flex: none` stops a shrinking column squeezing it, so the label
- * stays the element that runs out of room.
- *
- * The width is unconditional because the glyph is not: `SortIncentive` appears
- * only on hover, and a reserve that came and went with it would shift the
- * header out from under the pointer.
+ * The caret carries its own width, in flow, so nothing else reserves room on its
+ * behalf and a sortable header's intrinsic width already includes it. Being a flex
+ * item keeps the glyph beside the label and lets `order` move it to the other side;
+ * `flex: none` stops a shrinking column squeezing it. The width is unconditional
+ * because the glyph is not — `SortIncentive` appears only on hover, and a reserve
+ * that came and went with it would shift the header out from under the pointer.
  */
 export const SortCaretWrapper = styled.span`
   flex: none;
@@ -45,11 +39,9 @@ export const SortCaretWrapper = styled.span`
 /** Ellipsize rather than let a long header outgrow its column. */
 export const HeaderLabel = styled.span`
   min-width: 0;
-  /* overflow and text-overflow do nothing on an inline box, and a span is
-     inline by default. This used to be supplied for free by being a flex item
-     (flex blockifies its children), so the ellipsis silently disappeared the
-     moment the label was wrapped in anything. Stated outright so it no longer
-     depends on the parent's display. */
+  /* overflow and text-overflow do nothing on an inline box, and a span is inline
+     by default. This used to come for free from being a flex item, so the ellipsis
+     disappeared the moment the label was wrapped in anything. */
   display: block;
   overflow: hidden;
   text-overflow: ellipsis;
@@ -90,15 +82,12 @@ export const HeaderContent = styled.div<{
         $sortable &&
         isCenter &&
         css`
-          /* Flex centres label-plus-caret, so the label itself lands half a caret
-           off centre. This mirrors the caret on the label's other side to restore
-           the symmetry, and being a pseudo-element it is a flex item like any
-           other: weighted by basis times shrink factor against the label's own
-           basis, it gives up its width long before the label gives up a
-           character. A centred header is therefore exactly centred whenever the
-           label fits beside it, and spends the counterweight rather than the
-           label when it does not. A fixed reserve cannot do both -- it either
-           truncates early or drifts early, depending which value is chosen. */
+          /* Flex centres label-plus-caret, so the label lands half a caret off
+           centre. A mirrored counterweight on the label's other side restores the
+           symmetry. The outsized shrink factor makes it yield its width long
+           before the label gives up a character, so the header is exactly centred
+           while the label fits and spends the counterweight when it does not --
+           a fixed reserve either truncates early or drifts early. */
           &::before {
             content: '';
             order: -1;
@@ -164,10 +153,9 @@ export const HeadRow = styled.div<HeadRowType>`
 type TableRowType = {
   $isSelected: boolean;
   /**
-   * Whether the row can be selected at all — i.e. the content was given an
-   * `onRowSelected`. Not "something is currently selected": gating the hover
-   * affordance on that left a selectable table looking inert until its first
-   * click, with no pointer cursor to invite one.
+   * Whether the row can be selected at all — i.e. an `onRowSelected` was given.
+   * Not "something is currently selected": gating the hover affordance on that left
+   * a selectable table looking inert until its first click.
    */
   $selectable?: boolean;
   $separationLineVariant: TableVariantType;
@@ -217,8 +205,7 @@ export const TableRowMultiSelectable = styled.div<TableRowMultiSelectableType>`
   color: ${(props) => props.theme.textPrimary};
   /* Must match HeadRow's gap. Every column track has a grow factor and no basis,
      so a gap the header reserves and the body does not is free space the body
-     redistributes — shifting every boundary by grow-share × total gap, at any
-     width. That is the header-not-over-its-value defect. */
+     redistributes, shifting every column boundary at any width. */
   gap: ${spacing.r16};
   border-bottom: 1px solid
     ${(props) => props.theme[props.$separationLineVariant]};

--- a/src/lib/components/tablev2/Tablestyle.tsx
+++ b/src/lib/components/tablev2/Tablestyle.tsx
@@ -86,18 +86,25 @@ export const HeaderContent = styled.div<{
           }
         `
       }
-
       ${
         $sortable &&
         isCenter &&
         css`
-          /* Flex centres label-plus-caret, which leaves the label itself half a
-           caret off centre. One caret width of leading padding corrects that
-           exactly — padding shrinks the box the content is centred in, so half
-           of it is absorbed. Capped as a share of the header so a column too
-           narrow to afford the correction spends its width on the label
-           instead: it drifts off centre rather than truncating sooner. */
-          padding-inline-start: min(${caretSpace}, 15%);
+          /* Flex centres label-plus-caret, so the label itself lands half a caret
+           off centre. This mirrors the caret on the label's other side to restore
+           the symmetry, and being a pseudo-element it is a flex item like any
+           other: weighted by basis times shrink factor against the label's own
+           basis, it gives up its width long before the label gives up a
+           character. A centred header is therefore exactly centred whenever the
+           label fits beside it, and spends the counterweight rather than the
+           label when it does not. A fixed reserve cannot do both -- it either
+           truncates early or drifts early, depending which value is chosen. */
+          &::before {
+            content: '';
+            order: -1;
+            flex: 0 1000 ${caretSpace};
+            min-width: 0;
+          }
         `
       }
     `;

--- a/src/lib/components/tablev2/Tablestyle.tsx
+++ b/src/lib/components/tablev2/Tablestyle.tsx
@@ -11,44 +11,35 @@ import { FocusVisibleStyle } from '../buttonv2/Buttonv2.component';
 import { spacing } from '../../spacing';
 
 const borderSize = '4px';
-const caretGlyphSize = spacing.r16;
-const caretGutter = spacing.r4;
-// The room HeaderContent reserves so the glyph never overflows its header.
+// The caret's whole footprint: the glyph plus the gap that keeps it off the label.
 const caretSpace = spacing.r20;
 
+/** Hidden until the header is hovered — see `TableHeader`. */
 export const SortIncentive = styled.span`
-  position: absolute;
-  inset: 0;
   display: none;
   align-items: center;
-  justify-content: center;
-`;
-
-/** The painted glyph, out of flow inside the zero-width anchor below. */
-export const SortCaretGlyph = styled.span`
-  position: absolute;
-  top: 0;
-  bottom: 0;
-  width: ${caretGlyphSize};
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
 `;
 
 /**
- * A zero-width flex item. Being a real flex item is what keeps the glyph next to
- * the label (and lets `order` move it to the label's other side) — anchoring it
- * to `HeaderContent`'s edge instead would strand it at the far side of a wide
- * column. Being zero-width is what keeps it out of the sizing equation: a caret
- * with real width lifts every sortable header's min-content 20px above the
- * matching body cell's, and the two rows then stop agreeing on column widths as
- * soon as that floor binds. `HeaderContent` reserves the room with padding.
+ * The caret carries its own width, in flow, so nothing else has to reserve room
+ * on its behalf: one value describes the footprint, and a sortable header's
+ * intrinsic width already includes it.
+ *
+ * Being a flex item is what keeps the glyph beside the label rather than
+ * stranded at the column's far edge, and lets `order` move it to the label's
+ * other side. `flex: none` stops a shrinking column squeezing it, so the label
+ * stays the element that runs out of room.
+ *
+ * The width is unconditional because the glyph is not: `SortIncentive` appears
+ * only on hover, and a reserve that came and went with it would shift the
+ * header out from under the pointer.
  */
 export const SortCaretWrapper = styled.span`
-  position: relative;
   flex: none;
-  width: 0;
-  align-self: stretch;
+  width: ${caretSpace};
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
 `;
 
 /** Ellipsize rather than let a long header outgrow its column. */
@@ -78,42 +69,36 @@ export const HeaderContent = styled.div<{
   ${({ $align, $sortable }) => {
     const isEnd = $align === 'right' || $align === 'end';
     const isCenter = $align === 'center';
-    const justify = isEnd ? 'flex-end' : isCenter ? 'center' : 'flex-start';
 
-    if (!$sortable) {
-      return css`
-        justify-content: ${justify};
-      `;
-    }
-
-    // End-aligned columns are the one case where the caret goes on the label's
-    // start side: the label has to stay flush with the trailing edge or it no
-    // longer lines up with the values below it, which leaves no room after it.
-    if (isEnd) {
-      return css`
-        justify-content: flex-end;
-        padding-inline-start: ${caretSpace};
-        ${SortCaretWrapper} {
-          order: -1;
-        }
-        ${SortCaretGlyph} {
-          inset-inline-end: ${caretGutter};
-        }
-      `;
-    }
-
-    // Centred columns reserve both sides so the label stays centred.
     return css`
-      justify-content: ${justify};
-      ${isCenter
-        ? css`
-            padding-inline: ${caretSpace};
-          `
-        : css`
-            padding-inline-end: ${caretSpace};
-          `}
-      ${SortCaretGlyph} {
-        inset-inline-start: ${caretGutter};
+      justify-content: ${
+        isEnd ? 'flex-end' : isCenter ? 'center' : 'flex-start'
+      };
+
+      ${
+        $sortable &&
+        isEnd &&
+        css`
+          /* An end-aligned label has to stay flush with the trailing edge to line
+           up with the values below it, which leaves no room after it. */
+          ${SortCaretWrapper} {
+            order: -1;
+          }
+        `
+      }
+
+      ${
+        $sortable &&
+        isCenter &&
+        css`
+          /* Flex centres label-plus-caret, which leaves the label itself half a
+           caret off centre. One caret width of leading padding corrects that
+           exactly — padding shrinks the box the content is centred in, so half
+           of it is absorbed. Capped as a share of the header so a column too
+           narrow to afford the correction spends its width on the label
+           instead: it drifts off centre rather than truncating sooner. */
+          padding-inline-start: min(${caretSpace}, 15%);
+        `
       }
     `;
   }}
@@ -276,19 +261,17 @@ export const SortCaret = <
 }) => {
   return !column.disableSortBy ? (
     <SortCaretWrapper>
-      <SortCaretGlyph>
-        {column.isSorted ? (
-          column.isSortedDesc ? (
-            <Icon name="Sort-down" />
-          ) : (
-            <Icon name="Sort-up" />
-          )
+      {column.isSorted ? (
+        column.isSortedDesc ? (
+          <Icon name="Sort-down" />
         ) : (
-          <SortIncentive>
-            <Icon name="Sort" />
-          </SortIncentive>
-        )}
-      </SortCaretGlyph>
+          <Icon name="Sort-up" />
+        )
+      ) : (
+        <SortIncentive>
+          <Icon name="Sort" />
+        </SortIncentive>
+      )}
     </SortCaretWrapper>
   ) : null;
 };

--- a/src/lib/components/tablev2/Tablestyle.tsx
+++ b/src/lib/components/tablev2/Tablestyle.tsx
@@ -21,12 +21,11 @@ export const SortIncentive = styled.span`
 `;
 
 /**
- * The caret carries its own width, in flow, so nothing else reserves room on its
- * behalf and a sortable header's intrinsic width already includes it. Being a flex
- * item keeps the glyph beside the label and lets `order` move it to the other side;
- * `flex: none` stops a shrinking column squeezing it. The width is unconditional
- * because the glyph is not — `SortIncentive` appears only on hover, and a reserve
- * that came and went with it would shift the header out from under the pointer.
+ * The caret carries its own width in flow, so a sortable header's intrinsic width
+ * already includes it. A flex item so `order` can move it to the other side, and
+ * `flex: none` so a shrinking column cannot squeeze it. The width is unconditional
+ * although the glyph is not: `SortIncentive` shows on hover, and a reserve that came
+ * and went with it would shift the header out from under the pointer.
  */
 export const SortCaretWrapper = styled.span`
   flex: none;
@@ -83,11 +82,9 @@ export const HeaderContent = styled.div<{
         isCenter &&
         css`
           /* Flex centres label-plus-caret, so the label lands half a caret off
-           centre. A mirrored counterweight on the label's other side restores the
-           symmetry. The outsized shrink factor makes it yield its width long
-           before the label gives up a character, so the header is exactly centred
-           while the label fits and spends the counterweight when it does not --
-           a fixed reserve either truncates early or drifts early. */
+           centre; a mirrored counterweight restores it. The outsized shrink factor
+           spends the counterweight before the label gives up a character, which a
+           fixed reserve cannot do. */
           &::before {
             content: '';
             order: -1;

--- a/src/lib/components/tablev2/Tablestyle.tsx
+++ b/src/lib/components/tablev2/Tablestyle.tsx
@@ -54,6 +54,12 @@ export const SortCaretWrapper = styled.span`
 /** Ellipsize rather than let a long header outgrow its column. */
 export const HeaderLabel = styled.span`
   min-width: 0;
+  /* overflow and text-overflow do nothing on an inline box, and a span is
+     inline by default. This used to be supplied for free by being a flex item
+     (flex blockifies its children), so the ellipsis silently disappeared the
+     moment the label was wrapped in anything. Stated outright so it no longer
+     depends on the parent's display. */
+  display: block;
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;

--- a/src/lib/components/tablev2/Tablev2.component.tsx
+++ b/src/lib/components/tablev2/Tablev2.component.tsx
@@ -203,11 +203,9 @@ const DefaultRenderer = ({ value }) => {
           ? 2
           : 3;
     /**
-     * No margin of its own. This used to be wrapped in a `Box mr={4}` -- 8px on
-     * one side only -- which offset every string value from where its header
-     * label sat: 4px for a centred column, the full 8px for an end-aligned one.
-     * Column separation is the row's own `gap`, which both rows share, so it
-     * cannot pull them out of agreement the way a body-only margin does.
+     * No margin of its own. A `Box mr={4}` here offset every string value from its
+     * header label, by 4px centred and the full 8px end-aligned. Column separation
+     * is the row's `gap`, which both rows share and so cannot disagree.
      */
     return <ConstrainedText text={value} lineClamp={lineClamp} />;
   }

--- a/src/lib/components/tablev2/Tablev2.component.tsx
+++ b/src/lib/components/tablev2/Tablev2.component.tsx
@@ -202,11 +202,14 @@ const DefaultRenderer = ({ value }) => {
         : rowHeight === 'h40' || rowHeight === 'h48'
           ? 2
           : 3;
-    return (
-      <Box mr={4}>
-        <ConstrainedText text={value} lineClamp={lineClamp} />
-      </Box>
-    );
+    /**
+     * No margin of its own. This used to be wrapped in a `Box mr={4}` -- 8px on
+     * one side only -- which offset every string value from where its header
+     * label sat: 4px for a centred column, the full 8px for an end-aligned one.
+     * Column separation is the row's own `gap`, which both rows share, so it
+     * cannot pull them out of agreement the way a body-only margin does.
+     */
+    return <ConstrainedText text={value} lineClamp={lineClamp} />;
   }
 
   return value;

--- a/src/lib/components/tablev2/Tablev2.test.tsx
+++ b/src/lib/components/tablev2/Tablev2.test.tsx
@@ -74,7 +74,7 @@ describe('TableV2', () => {
             separationLineVariant="backgroundLevel3"
           />
         </Table>
-      </div>
+      </div>,
     );
     await waitFor(() => screen.queryAllByRole('img', { hidden: true }));
 
@@ -93,7 +93,7 @@ describe('TableV2', () => {
             separationLineVariant="backgroundLevel3"
           />
         </Table>
-      </div>
+      </div>,
     );
     await waitFor(() => screen.queryAllByRole('img', { hidden: true }));
 
@@ -117,7 +117,7 @@ describe('TableV2', () => {
             separationLineVariant="backgroundLevel3"
           />
         </Table>
-      </div>
+      </div>,
     );
     await waitFor(() => screen.queryAllByRole('img', { hidden: true }));
 
@@ -146,7 +146,7 @@ describe('TableV2', () => {
             separationLineVariant="backgroundLevel3"
           />
         </Table>
-      </div>
+      </div>,
     );
     await waitFor(() => screen.queryAllByRole('img', { hidden: true }));
 
@@ -169,7 +169,7 @@ describe('TableV2', () => {
             separationLineVariant="backgroundLevel3"
           />
         </Table>
-      </div>
+      </div>,
     );
     await waitFor(() => screen.queryAllByRole('img', { hidden: true }));
 
@@ -194,17 +194,13 @@ describe('TableV2', () => {
 
     const { getAllByRole } = render(
       <div>
-        <Table
-          columns={dateColumns}
-          data={dateData}
-          globalFilter=".000"
-        >
+        <Table columns={dateColumns} data={dateData} globalFilter=".000">
           <Table.SingleSelectableContent
             rowHeight="h40"
             separationLineVariant="backgroundLevel3"
           />
         </Table>
-      </div>
+      </div>,
     );
     await waitFor(() => screen.queryAllByRole('img', { hidden: true }));
 
@@ -227,7 +223,7 @@ describe('TableV2', () => {
             separationLineVariant="backgroundLevel3"
           />
         </Table>
-      </div>
+      </div>,
     );
     await waitFor(() => screen.queryAllByRole('img', { hidden: true }));
 
@@ -559,6 +555,47 @@ describe('TableV2 row click vs in-cell controls', () => {
     await userEvent.click(screen.getByText('overlay-Ninette'));
 
     expect(onRowSelected).not.toHaveBeenCalled();
+  });
+});
+
+describe('TableV2 row selectability', () => {
+  const columns: TableProps['columns'] = [
+    { Header: 'First Name', accessor: 'firstName' },
+    { Header: 'Last Name', accessor: 'lastName' },
+  ];
+
+  const renderTable = (onRowSelected?: (row: unknown) => void) => (
+    <Table columns={columns} data={data} defaultSortingKey={'firstName'}>
+      <Table.SingleSelectableContent
+        rowHeight="h40"
+        separationLineVariant="backgroundLevel3"
+        onRowSelected={onRowSelected}
+      />
+    </Table>
+  );
+
+  it('stops offering rows to the keyboard once they are no longer selectable', () => {
+    const { rerender, getAllByRole } = render(renderTable(jest.fn()));
+
+    // [0] is the header row.
+    expect(getAllByRole('row')[1]).toHaveAttribute('tabindex', '0');
+
+    // Nothing else about the table changes, which is the point: the row
+    // renderer is memoized, so a value it reads has to be a dependency of that
+    // memo or the rows keep the affordance after it stops being true.
+    rerender(renderTable(undefined));
+
+    expect(getAllByRole('row')[1]).not.toHaveAttribute('tabindex');
+  });
+
+  it('offers rows to the keyboard once they become selectable', () => {
+    const { rerender, getAllByRole } = render(renderTable(undefined));
+
+    expect(getAllByRole('row')[1]).not.toHaveAttribute('tabindex');
+
+    rerender(renderTable(jest.fn()));
+
+    expect(getAllByRole('row')[1]).toHaveAttribute('tabindex', '0');
   });
 });
 

--- a/src/lib/components/tablev2/Tablev2.test.tsx
+++ b/src/lib/components/tablev2/Tablev2.test.tsx
@@ -425,3 +425,180 @@ describe('TableV2 responsive columns', () => {
     ).not.toHaveLength(0);
   });
 });
+
+describe('TableV2 row click vs in-cell controls', () => {
+  const withButtonColumns: TableProps['columns'] = [
+    { Header: 'First Name', accessor: 'firstName' },
+    {
+      Header: 'Action',
+      accessor: 'lastName',
+      disableSortBy: true,
+      Cell: ({ row }) => (
+        <button onClick={() => row.original.onAction()}>
+          Detach {row.original.firstName}
+        </button>
+      ),
+    },
+  ];
+
+  const renderWithAction = (onRowSelected, onAction) =>
+    render(
+      <div>
+        <Table
+          columns={withButtonColumns}
+          data={data.map((entry) => ({ ...entry, onAction }))}
+          defaultSortingKey={'firstName'}
+        >
+          <Table.SingleSelectableContent
+            rowHeight="h40"
+            separationLineVariant="backgroundLevel3"
+            onRowSelected={onRowSelected}
+          />
+        </Table>
+      </div>,
+    );
+
+  it('leaves the row unselected when a button inside a cell is clicked', async () => {
+    const onRowSelected = jest.fn();
+    const onAction = jest.fn();
+    renderWithAction(onRowSelected, onAction);
+
+    await userEvent.click(screen.getByRole('button', { name: /Detach Ninette/ }));
+
+    expect(onAction).toHaveBeenCalledTimes(1);
+    expect(onRowSelected).not.toHaveBeenCalled();
+  });
+
+  it('still selects the row when the click lands on plain cell content', async () => {
+    const onRowSelected = jest.fn();
+    const onAction = jest.fn();
+    renderWithAction(onRowSelected, onAction);
+
+    await userEvent.click(screen.getByText('Ninette'));
+
+    expect(onRowSelected).toHaveBeenCalledTimes(1);
+    expect(onAction).not.toHaveBeenCalled();
+  });
+
+  it('leaves the row unselected when a button inside a cell is activated by keyboard', async () => {
+    const onRowSelected = jest.fn();
+    const onAction = jest.fn();
+    renderWithAction(onRowSelected, onAction);
+
+    const button = screen.getByRole('button', { name: /Detach Ninette/ });
+    button.focus();
+    await userEvent.keyboard('{Enter}');
+
+    expect(onAction).toHaveBeenCalledTimes(1);
+    expect(onRowSelected).not.toHaveBeenCalled();
+  });
+
+  it('still selects the row on Enter when the row itself has focus', async () => {
+    const onRowSelected = jest.fn();
+    const onAction = jest.fn();
+    const { getAllByRole } = renderWithAction(onRowSelected, onAction);
+
+    const row = getAllByRole('row')[1];
+    row.focus();
+    await userEvent.keyboard('{Enter}');
+
+    expect(onRowSelected).toHaveBeenCalledTimes(1);
+    expect(onAction).not.toHaveBeenCalled();
+  });
+});
+
+describe('TableV2 truncated header labels', () => {
+  // jsdom reports 0 for both, so the widths have to be forced. `title` is only
+  // offered once the label really is cut off — this is the difference between a
+  // useful affordance and a tooltip on every header in the table.
+  const stubLabelWidths = (scrollWidth: number, clientWidth: number) => {
+    const proto = window.HTMLSpanElement.prototype;
+    const original = {
+      scrollWidth: Object.getOwnPropertyDescriptor(proto, 'scrollWidth'),
+      clientWidth: Object.getOwnPropertyDescriptor(proto, 'clientWidth'),
+    };
+    Object.defineProperty(proto, 'scrollWidth', {
+      configurable: true,
+      get: () => scrollWidth,
+    });
+    Object.defineProperty(proto, 'clientWidth', {
+      configurable: true,
+      get: () => clientWidth,
+    });
+    return () => {
+      if (original.scrollWidth) {
+        Object.defineProperty(proto, 'scrollWidth', original.scrollWidth);
+      } else {
+        delete (proto as Record<string, unknown>).scrollWidth;
+      }
+      if (original.clientWidth) {
+        Object.defineProperty(proto, 'clientWidth', original.clientWidth);
+      } else {
+        delete (proto as Record<string, unknown>).clientWidth;
+      }
+    };
+  };
+
+  const renderTable = () =>
+    render(
+      <div>
+        <Table columns={columns} data={data} defaultSortingKey={'firstName'}>
+          <Table.SingleSelectableContent
+            rowHeight="h40"
+            separationLineVariant="backgroundLevel3"
+          />
+        </Table>
+      </div>,
+    );
+
+  it('offers the full label when the header is ellipsized', async () => {
+    const restore = stubLabelWidths(400, 80);
+    try {
+      renderTable();
+      await waitFor(() =>
+        expect(screen.getByTitle('First Name')).toBeInTheDocument(),
+      );
+    } finally {
+      restore();
+    }
+  });
+
+  it('offers no label when the header fits', async () => {
+    const restore = stubLabelWidths(80, 80);
+    try {
+      renderTable();
+      await waitFor(() => screen.getAllByRole('columnheader'));
+      expect(screen.queryByTitle('First Name')).not.toBeInTheDocument();
+    } finally {
+      restore();
+    }
+  });
+
+  it('offers no label when the header is not a string', async () => {
+    const restore = stubLabelWidths(400, 80);
+    try {
+      render(
+        <div>
+          <Table
+            columns={[
+              { Header: <span>Rendered</span>, accessor: 'firstName' },
+              ...columns.slice(1),
+            ]}
+            data={data}
+            defaultSortingKey={'firstName'}
+          >
+            <Table.SingleSelectableContent
+              rowHeight="h40"
+              separationLineVariant="backgroundLevel3"
+            />
+          </Table>
+        </div>,
+      );
+      await waitFor(() => screen.getAllByRole('columnheader'));
+      expect(screen.queryByTitle('Rendered')).not.toBeInTheDocument();
+      expect(screen.getByText('Rendered')).toBeInTheDocument();
+    } finally {
+      restore();
+    }
+  });
+});

--- a/src/lib/components/tablev2/Tablev2.test.tsx
+++ b/src/lib/components/tablev2/Tablev2.test.tsx
@@ -505,10 +505,15 @@ describe('TableV2 row click vs in-cell controls', () => {
     expect(onAction).not.toHaveBeenCalled();
   });
 
-  it('still selects the row when the whole table sits inside a label', async () => {
+  // The guard's upward bound. `closest()` walks to the document unless it is
+  // stopped, so one interactive ancestor anywhere above the table matches for
+  // every cell and turns row selection off across the whole table. The
+  // clickable wrapper is a fixture for that bound -- any of the selector's
+  // elements above the row does it -- not a nesting pattern worth copying.
+  it('still selects the row when an interactive ancestor sits above the table', async () => {
     const onRowSelected = jest.fn();
     render(
-      <label>
+      <div role="button" tabIndex={0}>
         <Table columns={columns} data={data}>
           <Table.SingleSelectableContent
             rowHeight="h40"
@@ -516,7 +521,7 @@ describe('TableV2 row click vs in-cell controls', () => {
             onRowSelected={onRowSelected}
           />
         </Table>
-      </label>,
+      </div>,
     );
 
     await userEvent.click(screen.getByText('Ninette'));
@@ -524,7 +529,12 @@ describe('TableV2 row click vs in-cell controls', () => {
     expect(onRowSelected).toHaveBeenCalledTimes(1);
   });
 
-  it('leaves the row unselected when the click lands in a portalled overlay', async () => {
+  // The guard's downward bound. A portal leaves the row in the DOM but still
+  // bubbles to it through the React tree, so text in an overlay opened from a
+  // cell -- the revealDroppedColumns panel, a Select menu -- reached this
+  // handler with nothing interactive between it and the row, and selected the
+  // row behind the overlay the user was reading.
+  it('leaves the row unselected when the click lands in an overlay portalled out of a cell', async () => {
     const onRowSelected = jest.fn();
     const portalColumns: TableProps['columns'] = [
       { Header: 'First Name', accessor: 'firstName' },
@@ -667,20 +677,5 @@ describe('TableV2 truncated header labels', () => {
     expect(
       document.querySelector('.sc-tooltip-overlay-text'),
     ).not.toBeInTheDocument();
-  });
-
-  it('keeps the label ellipsizable — the tooltip wrapper adds no width floor', async () => {
-    stubLabelWidths(400, 80);
-    renderTable();
-    const label = await screen.findByText('First Name');
-
-    // The measured element must still be the overflow-hidden label, not a
-    // wrapper the tooltip introduced above it.
-    expect(label.tagName).toBe('SPAN');
-    expect(getComputedStyle(label).overflow).toBe('hidden');
-    // `overflow`/`text-overflow` are inert on an inline box, and the label only
-    // got blockified for free while it was a flex item. Wrapping it in the
-    // tooltip took that away once already.
-    expect(getComputedStyle(label).display).toBe('block');
   });
 });

--- a/src/lib/components/tablev2/Tablev2.test.tsx
+++ b/src/lib/components/tablev2/Tablev2.test.tsx
@@ -2,6 +2,7 @@ import { useState } from 'react';
 import { Table, TableProps } from './Tablev2.component';
 import { render, screen, waitFor, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
+import { createPortal } from 'react-dom';
 
 jest.mock('./TableUtils', () => ({
   ...jest.requireActual('./TableUtils'),
@@ -463,7 +464,9 @@ describe('TableV2 row click vs in-cell controls', () => {
     const onAction = jest.fn();
     renderWithAction(onRowSelected, onAction);
 
-    await userEvent.click(screen.getByRole('button', { name: /Detach Ninette/ }));
+    await userEvent.click(
+      screen.getByRole('button', { name: /Detach Ninette/ }),
+    );
 
     expect(onAction).toHaveBeenCalledTimes(1);
     expect(onRowSelected).not.toHaveBeenCalled();
@@ -505,44 +508,79 @@ describe('TableV2 row click vs in-cell controls', () => {
     expect(onRowSelected).toHaveBeenCalledTimes(1);
     expect(onAction).not.toHaveBeenCalled();
   });
+
+  it('still selects the row when the whole table sits inside a label', async () => {
+    const onRowSelected = jest.fn();
+    render(
+      <label>
+        <Table columns={columns} data={data}>
+          <Table.SingleSelectableContent
+            rowHeight="h40"
+            separationLineVariant="backgroundLevel3"
+            onRowSelected={onRowSelected}
+          />
+        </Table>
+      </label>,
+    );
+
+    await userEvent.click(screen.getByText('Ninette'));
+
+    expect(onRowSelected).toHaveBeenCalledTimes(1);
+  });
+
+  it('leaves the row unselected when the click lands in a portalled overlay', async () => {
+    const onRowSelected = jest.fn();
+    const portalColumns: TableProps['columns'] = [
+      { Header: 'First Name', accessor: 'firstName' },
+      {
+        Header: 'Overlay',
+        accessor: 'lastName',
+        disableSortBy: true,
+        Cell: ({ row }) =>
+          createPortal(
+            <span>{`overlay-${row.original.firstName}`}</span>,
+            document.body,
+          ),
+      },
+    ];
+
+    render(
+      <div>
+        <Table columns={portalColumns} data={data}>
+          <Table.SingleSelectableContent
+            rowHeight="h40"
+            separationLineVariant="backgroundLevel3"
+            onRowSelected={onRowSelected}
+          />
+        </Table>
+      </div>,
+    );
+
+    await userEvent.click(screen.getByText('overlay-Ninette'));
+
+    expect(onRowSelected).not.toHaveBeenCalled();
+  });
 });
 
 describe('TableV2 truncated header labels', () => {
-  // jsdom reports 0 for both, so the widths have to be forced. `title` is only
-  // offered once the label really is cut off — this is the difference between a
-  // useful affordance and a tooltip on every header in the table.
+  // jsdom has no layout, so the label's widths have to be forced. The tooltip
+  // is only offered once the label really is cut off — a tooltip repeating a
+  // header that reads fine is noise, and this is the difference between them.
   const stubLabelWidths = (scrollWidth: number, clientWidth: number) => {
-    const proto = window.HTMLSpanElement.prototype;
-    const original = {
-      scrollWidth: Object.getOwnPropertyDescriptor(proto, 'scrollWidth'),
-      clientWidth: Object.getOwnPropertyDescriptor(proto, 'clientWidth'),
-    };
-    Object.defineProperty(proto, 'scrollWidth', {
-      configurable: true,
-      get: () => scrollWidth,
-    });
-    Object.defineProperty(proto, 'clientWidth', {
-      configurable: true,
-      get: () => clientWidth,
-    });
-    return () => {
-      if (original.scrollWidth) {
-        Object.defineProperty(proto, 'scrollWidth', original.scrollWidth);
-      } else {
-        delete (proto as Record<string, unknown>).scrollWidth;
-      }
-      if (original.clientWidth) {
-        Object.defineProperty(proto, 'clientWidth', original.clientWidth);
-      } else {
-        delete (proto as Record<string, unknown>).clientWidth;
-      }
-    };
+    jest
+      .spyOn(window.HTMLSpanElement.prototype, 'scrollWidth', 'get')
+      .mockReturnValue(scrollWidth);
+    jest
+      .spyOn(window.HTMLSpanElement.prototype, 'clientWidth', 'get')
+      .mockReturnValue(clientWidth);
   };
 
-  const renderTable = () =>
+  afterEach(() => jest.restoreAllMocks());
+
+  const renderTable = (cols = columns) =>
     render(
       <div>
-        <Table columns={columns} data={data} defaultSortingKey={'firstName'}>
+        <Table columns={cols} data={data} defaultSortingKey={'firstName'}>
           <Table.SingleSelectableContent
             rowHeight="h40"
             separationLineVariant="backgroundLevel3"
@@ -551,54 +589,61 @@ describe('TableV2 truncated header labels', () => {
       </div>,
     );
 
-  it('offers the full label when the header is ellipsized', async () => {
-    const restore = stubLabelWidths(400, 80);
-    try {
-      renderTable();
-      await waitFor(() =>
-        expect(screen.getByTitle('First Name')).toBeInTheDocument(),
-      );
-    } finally {
-      restore();
-    }
+  it('offers the full label in a tooltip when the header is ellipsized', async () => {
+    stubLabelWidths(400, 80);
+    renderTable();
+    const label = await screen.findByText('First Name');
+
+    await userEvent.hover(label);
+
+    await waitFor(() =>
+      expect(
+        document.querySelector('.sc-tooltip-overlay-text'),
+      ).toHaveTextContent('First Name'),
+    );
   });
 
-  it('offers no label when the header fits', async () => {
-    const restore = stubLabelWidths(80, 80);
-    try {
-      renderTable();
-      await waitFor(() => screen.getAllByRole('columnheader'));
-      expect(screen.queryByTitle('First Name')).not.toBeInTheDocument();
-    } finally {
-      restore();
-    }
+  it('offers no tooltip when the header fits', async () => {
+    stubLabelWidths(80, 80);
+    renderTable();
+    const label = await screen.findByText('First Name');
+
+    await userEvent.hover(label);
+
+    await waitFor(() => screen.getAllByRole('columnheader'));
+    expect(
+      document.querySelector('.sc-tooltip-overlay-text'),
+    ).not.toBeInTheDocument();
   });
 
-  it('offers no label when the header is not a string', async () => {
-    const restore = stubLabelWidths(400, 80);
-    try {
-      render(
-        <div>
-          <Table
-            columns={[
-              { Header: <span>Rendered</span>, accessor: 'firstName' },
-              ...columns.slice(1),
-            ]}
-            data={data}
-            defaultSortingKey={'firstName'}
-          >
-            <Table.SingleSelectableContent
-              rowHeight="h40"
-              separationLineVariant="backgroundLevel3"
-            />
-          </Table>
-        </div>,
-      );
-      await waitFor(() => screen.getAllByRole('columnheader'));
-      expect(screen.queryByTitle('Rendered')).not.toBeInTheDocument();
-      expect(screen.getByText('Rendered')).toBeInTheDocument();
-    } finally {
-      restore();
-    }
+  it('offers no tooltip when the header is not a string', async () => {
+    stubLabelWidths(400, 80);
+    renderTable([
+      { Header: <span>Rendered</span>, accessor: 'firstName' },
+      ...columns.slice(1),
+    ]);
+    const label = await screen.findByText('Rendered');
+
+    await userEvent.hover(label);
+
+    await waitFor(() => screen.getAllByRole('columnheader'));
+    expect(
+      document.querySelector('.sc-tooltip-overlay-text'),
+    ).not.toBeInTheDocument();
+  });
+
+  it('keeps the label ellipsizable — the tooltip wrapper adds no width floor', async () => {
+    stubLabelWidths(400, 80);
+    renderTable();
+    const label = await screen.findByText('First Name');
+
+    // The measured element must still be the overflow-hidden label, not a
+    // wrapper the tooltip introduced above it.
+    expect(label.tagName).toBe('SPAN');
+    expect(getComputedStyle(label).overflow).toBe('hidden');
+    // `overflow`/`text-overflow` are inert on an inline box, and the label only
+    // got blockified for free while it was a flex item. Wrapping it in the
+    // tooltip took that away once already.
+    expect(getComputedStyle(label).display).toBe('block');
   });
 });

--- a/stories/tablev2.guideline.mdx
+++ b/stories/tablev2.guideline.mdx
@@ -43,3 +43,47 @@ A table never tells the user a resource is empty before it has finished loading.
 <Canvas of={TableStories.LoadingTable} />
 
 <Canvas of={TableStories.ErrorTable} />
+
+## Row selection
+
+Pass `onRowSelected` to `Table.SingleSelectableContent` to make rows selectable, and pair it with
+`selectedId` so the chosen row stays marked. A selectable row shows a pointer cursor and a hover
+highlight from the start — the affordance does not wait for a first selection.
+
+Clicking anywhere in a row selects it, **except** on an interactive control inside a cell. A
+button, link, input, checkbox or label in a cell keeps its own click. The same holds for the
+keyboard: Enter or Space on a focused control activates that control, not the row.
+
+This matters beyond the stray selection: selecting a row re-renders it, which remounts its cells
+and closes anything the control had just opened.
+
+<Canvas of={TableStories.SimpleContentTable} layout="fullscreen" />
+
+## Responsive columns
+
+Give a column a `dropAt` breakpoint and it hides once the table is narrower than that. Columns
+without one always stay. Below, Age drops at 550px and Last Name at 700px; First Name and Health
+have no breakpoint.
+
+Drag the frame's bottom-right corner to resize it.
+
+<Canvas of={TableStories.ResponsiveColumnDrop} layout="fullscreen" />
+
+### Recovering the dropped values
+
+Add `revealDroppedColumns` and each row gains a trailing `+N` trigger. Clicking it opens a popover
+listing the dropped columns and their values for that row, so nothing is lost at a narrow width.
+
+The trigger is a control inside a cell, so clicking it does not select the row — which is what
+keeps the popover open.
+
+<Canvas of={TableStories.ResponsiveColumnDropWithReveal} layout="fullscreen" />
+
+### A control that cannot shrink will overflow its column
+
+A column's width comes from its grow factor, and header and body cells shrink by the same rules,
+so a column can end up narrower than the control inside it. A text button will not shrink below
+its label, and it will overflow rather than clip.
+
+Give such a button `iconOnly={n}` so it collapses to its icon below `n` px instead. Prefer that to
+widening the column, which would cost every other column its share of the space.

--- a/stories/tablev2.guideline.mdx
+++ b/stories/tablev2.guideline.mdx
@@ -14,6 +14,19 @@ import * as TableStories from './tablev2.stories';
 
 A table displays structured data in rows and columns, allowing users to scan, sort, and act on multiple items.
 
+## Column alignment
+
+A column states its alignment once, in `cellStyle.textAlign`, and it reaches the header label and
+every value in the column alike. Text reads left, a number reads right, a status or other short
+enum reads centred. Header and values sit on the same edge whichever edge that is — a column whose
+label and values disagree reads as two columns.
+
+Sorting does not change that. A sortable header's caret reserves its own width rather than taking
+it from the label, so an end-aligned label keeps the trailing edge; a centred label is balanced
+against the caret rather than pushed off centre by it. On a column too narrow to hold both, the
+centred label drifts off centre instead of truncating earlier than it would without a caret —
+losing the middle of a label costs more than losing its exact centring.
+
 ## Action column
 
 Tables may include an action column on the far right for row-level actions.

--- a/stories/tablev2.guideline.mdx
+++ b/stories/tablev2.guideline.mdx
@@ -79,9 +79,10 @@ Which width that happens at is not a fixed number: a column's width comes from i
 dropping a neighbour hands its space to the columns that remain. A header can therefore truncate,
 then read in full again at a narrower frame.
 
-Every string header carries its own text as a `title`, so the full label stays one hover away.
-Headers built from a node rather than a string get no `title` — give those their own affordance if
-the label can be lost.
+A truncated string header shows its full text in a tooltip on hover, so nothing is lost. The
+tooltip appears only while the label is actually cut off — a tooltip repeating a header that reads
+fine is noise. Headers built from a node rather than a string get none, since there is no text to
+show: give those their own affordance if the label can be lost.
 
 ### Recovering the dropped values
 

--- a/stories/tablev2.guideline.mdx
+++ b/stories/tablev2.guideline.mdx
@@ -62,12 +62,26 @@ and closes anything the control had just opened.
 ## Responsive columns
 
 Give a column a `dropAt` breakpoint and it hides once the table is narrower than that. Columns
-without one always stay. Below, Age drops at 550px and Last Name at 700px; First Name and Health
-have no breakpoint.
+without one always stay. Below, Age drops at 550px and Last Name at 700px; First Name and
+"Replication Health" have no breakpoint.
 
 Drag the frame's bottom-right corner to resize it.
 
 <Canvas of={TableStories.ResponsiveColumnDrop} layout="fullscreen" />
+
+### A long header ellipsizes rather than widening its column
+
+A header must never be the reason a column is wider than its cells, so a label too long for its
+column is truncated instead of widening it. "Replication Health" above sits on the narrowest track
+in the table — narrow the frame and it cuts off.
+
+Which width that happens at is not a fixed number: a column's width comes from its grow factor, so
+dropping a neighbour hands its space to the columns that remain. A header can therefore truncate,
+then read in full again at a narrower frame.
+
+Every string header carries its own text as a `title`, so the full label stays one hover away.
+Headers built from a node rather than a string get no `title` — give those their own affordance if
+the label can be lost.
 
 ### Recovering the dropped values
 

--- a/stories/tablev2.stories.tsx
+++ b/stories/tablev2.stories.tsx
@@ -1021,9 +1021,12 @@ const certificateColumns: Column<Certificate>[] = [
   },
 ];
 
-// Centred sortable columns pinned narrow enough that the counterweight keeping
-// the label centred cannot be paid in full. The label should drift off centre —
-// by at most half a caret — rather than lose characters to make room for it.
+// Narrow centred columns, each sortable one paired with an identical column that
+// is not sortable. The pair is the point: the sortable header carries a caret and
+// a counterweight, the plain one carries neither, so any difference in where the
+// two labels sit is the caret mechanism and nothing else. At 5rem and 7rem the
+// counterweight cap binds, so the sortable label should drift slightly off centre
+// rather than truncate earlier than its twin.
 const narrowCentredColumns: Column<Certificate>[] = [
   {
     Header: 'Name',
@@ -1033,12 +1036,28 @@ const narrowCentredColumns: Column<Certificate>[] = [
   {
     Header: 'Status',
     accessor: 'status',
+    id: 'status-sortable',
     cellStyle: { textAlign: 'center', width: '5rem' },
+  },
+  {
+    Header: 'Status',
+    accessor: 'status',
+    id: 'status-plain',
+    cellStyle: { textAlign: 'center', width: '5rem' },
+    disableSortBy: true,
   },
   {
     Header: 'Expire On',
     accessor: 'expireOn',
+    id: 'expire-sortable',
     cellStyle: { textAlign: 'center', width: '7rem' },
+  },
+  {
+    Header: 'Expire On',
+    accessor: 'expireOn',
+    id: 'expire-plain',
+    cellStyle: { textAlign: 'center', width: '7rem' },
+    disableSortBy: true,
   },
 ];
 
@@ -1088,9 +1107,10 @@ export const SortCaretHeaderAlignment = {
         </Table>
       </div>
       <Title>
-        D — centred sortable headers too narrow for the full counterweight
+        D — narrow centred headers: each sortable column paired with an
+        identical column that is not sortable
       </Title>
-      <div id="repro-d" style={{ height: '140px', width: '380px' }}>
+      <div id="repro-d" style={{ height: '140px', width: '620px' }}>
         <Table
           columns={narrowCentredColumns}
           data={certificateData}

--- a/stories/tablev2.stories.tsx
+++ b/stories/tablev2.stories.tsx
@@ -1064,3 +1064,78 @@ export const SortCaretHeaderAlignment = {
     </>
   ),
 };
+
+type Attachable = { name: string; isPending: boolean; action: string };
+
+// AttachmentTable's exact column shape: three tracks with grow factors summing
+// to 2.5, a right margin on the first, and `marginLeft: auto` plus a JSX Header
+// on the last. Reproduced here because the reported defect is that the header
+// tracks and the body tracks disagree, and only a real layout can show that.
+const attachmentShapeColumns: Column<Attachable>[] = [
+  {
+    Header: 'Name',
+    accessor: 'name',
+    cellStyle: { flex: 1.5, marginRight: '1.5rem' },
+  },
+  {
+    Header: 'Attachment',
+    accessor: 'isPending',
+    cellStyle: { flex: 0.5 },
+    Cell: ({ value }: { value?: boolean }) => <>{value ? 'Pending' : 'Attached'}</>,
+  },
+  {
+    Header: <Box flex={0.5} />,
+    accessor: 'action',
+    cellStyle: {
+      textAlign: 'right',
+      flex: 0.5,
+      marginLeft: 'auto',
+      marginRight: '0.5rem',
+    },
+    Cell: () => <Button variant="outline" label="Detach" />,
+  },
+];
+
+const attachableRow = (i: number): Attachable => ({
+  name: `entity-${i}`,
+  isPending: i % 3 === 0,
+  action: 'detach',
+});
+
+const fewAttachables = Array.from({ length: 2 }, (_, i) => attachableRow(i));
+const manyAttachables = Array.from({ length: 40 }, (_, i) => attachableRow(i));
+
+export const HeaderBodyColumnAlignment = {
+  render: () => (
+    <>
+      <Title>A — few rows, no vertical scrollbar</Title>
+      <div id="align-no-scrollbar" style={{ height: '140px' }}>
+        <Table columns={attachmentShapeColumns} data={fewAttachables}>
+          <Table.SingleSelectableContent
+            rowHeight="h40"
+            separationLineVariant="backgroundLevel3"
+          />
+        </Table>
+      </div>
+      <Title>B — enough rows to force a vertical scrollbar</Title>
+      <div id="align-with-scrollbar" style={{ height: '220px' }}>
+        <Table columns={attachmentShapeColumns} data={manyAttachables}>
+          <Table.SingleSelectableContent
+            rowHeight="h40"
+            separationLineVariant="backgroundLevel3"
+          />
+        </Table>
+      </div>
+      <Title>C — multi selectable, scrollbar, same columns</Title>
+      <div id="align-multi-scrollbar" style={{ height: '220px' }}>
+        <Table columns={attachmentShapeColumns} data={manyAttachables}>
+          <Table.MultiSelectableContent
+            rowHeight="h40"
+            separationLineVariant="backgroundLevel3"
+            onMultiSelectionChanged={action('selection changed')}
+          />
+        </Table>
+      </div>
+    </>
+  ),
+};

--- a/stories/tablev2.stories.tsx
+++ b/stories/tablev2.stories.tsx
@@ -1021,10 +1021,33 @@ const certificateColumns: Column<Certificate>[] = [
   },
 ];
 
+// Centred sortable columns pinned narrow enough that the counterweight keeping
+// the label centred cannot be paid in full. The label should drift off centre —
+// by at most half a caret — rather than lose characters to make room for it.
+const narrowCentredColumns: Column<Certificate>[] = [
+  {
+    Header: 'Name',
+    accessor: 'name',
+    cellStyle: { width: 'unset', flex: 1, textAlign: 'left' },
+  },
+  {
+    Header: 'Status',
+    accessor: 'status',
+    cellStyle: { textAlign: 'center', width: '5rem' },
+  },
+  {
+    Header: 'Expire On',
+    accessor: 'expireOn',
+    cellStyle: { textAlign: 'center', width: '7rem' },
+  },
+];
+
 export const SortCaretHeaderAlignment = {
   render: () => (
     <>
-      <Title>A — equal flex, sortable vs not, container too narrow for both headers</Title>
+      <Title>
+        A — equal flex, sortable vs not, container too narrow for both headers
+      </Title>
       <div id="repro-a" style={{ height: '120px', width: '220px' }}>
         <Table
           columns={readingColumns}
@@ -1061,6 +1084,21 @@ export const SortCaretHeaderAlignment = {
             rowHeight="h40"
             separationLineVariant="backgroundLevel3"
             onMultiSelectionChanged={action('selection changed')}
+          />
+        </Table>
+      </div>
+      <Title>
+        D — centred sortable headers too narrow for the full counterweight
+      </Title>
+      <div id="repro-d" style={{ height: '140px', width: '380px' }}>
+        <Table
+          columns={narrowCentredColumns}
+          data={certificateData}
+          defaultSortingKey={'status'}
+        >
+          <Table.SingleSelectableContent
+            rowHeight="h32"
+            separationLineVariant="backgroundLevel3"
           />
         </Table>
       </div>

--- a/stories/tablev2.stories.tsx
+++ b/stories/tablev2.stories.tsx
@@ -1105,37 +1105,95 @@ const attachableRow = (i: number): Attachable => ({
 const fewAttachables = Array.from({ length: 2 }, (_, i) => attachableRow(i));
 const manyAttachables = Array.from({ length: 40 }, (_, i) => attachableRow(i));
 
+const alignmentFrame: React.CSSProperties = {
+  resize: 'horizontal',
+  overflow: 'hidden',
+  width: '46rem',
+  minWidth: '14rem',
+  maxWidth: '100%',
+  border: '1px dashed #666',
+  padding: '0.5rem',
+};
+
 export const HeaderBodyColumnAlignment = {
-  render: () => (
-    <>
-      <Title>A — few rows, no vertical scrollbar</Title>
-      <div id="align-no-scrollbar" style={{ height: '140px' }}>
-        <Table columns={attachmentShapeColumns} data={fewAttachables}>
-          <Table.SingleSelectableContent
-            rowHeight="h40"
-            separationLineVariant="backgroundLevel3"
-          />
-        </Table>
-      </div>
-      <Title>B — enough rows to force a vertical scrollbar</Title>
-      <div id="align-with-scrollbar" style={{ height: '220px' }}>
-        <Table columns={attachmentShapeColumns} data={manyAttachables}>
-          <Table.SingleSelectableContent
-            rowHeight="h40"
-            separationLineVariant="backgroundLevel3"
-          />
-        </Table>
-      </div>
-      <Title>C — multi selectable, scrollbar, same columns</Title>
-      <div id="align-multi-scrollbar" style={{ height: '220px' }}>
-        <Table columns={attachmentShapeColumns} data={manyAttachables}>
-          <Table.MultiSelectableContent
-            rowHeight="h40"
-            separationLineVariant="backgroundLevel3"
-            onMultiSelectionChanged={action('selection changed')}
-          />
-        </Table>
-      </div>
-    </>
-  ),
+  render: () => {
+    const [selected, setSelected] = useState<string | undefined>(undefined);
+
+    return (
+      <>
+        <Title>
+          Drag each frame's right edge. Every header label must stay directly
+          over its column at every width.
+        </Title>
+
+        <Title>A — single selectable, few rows, no vertical scrollbar</Title>
+        <div id="align-no-scrollbar" style={alignmentFrame}>
+          <div style={{ height: '140px' }}>
+            <Table columns={attachmentShapeColumns} data={fewAttachables}>
+              <Table.SingleSelectableContent
+                rowHeight="h40"
+                separationLineVariant="backgroundLevel3"
+                selectedId={selected}
+                onRowSelected={(row) => setSelected(row.id)}
+              />
+            </Table>
+          </div>
+        </div>
+
+        <Title>
+          B — single selectable, enough rows to force a vertical scrollbar. Click
+          a row to select it; click "Detach" and the row must NOT select.
+        </Title>
+        <div id="align-with-scrollbar" style={alignmentFrame}>
+          <div style={{ height: '220px' }}>
+            <Table columns={attachmentShapeColumns} data={manyAttachables}>
+              <Table.SingleSelectableContent
+                rowHeight="h40"
+                separationLineVariant="backgroundLevel3"
+                selectedId={selected}
+                onRowSelected={(row) => setSelected(row.id)}
+              />
+            </Table>
+          </div>
+        </div>
+
+        <Title>
+          C — single selectable with dropped columns and reveal. Below 700px a
+          per-row <code>+N</code> trigger appears; clicking it on an UNSELECTED
+          row must open the popover and leave it open.
+        </Title>
+        <div id="align-reveal" style={alignmentFrame}>
+          <div style={{ height: '220px' }}>
+            <Table
+              columns={responsiveColumns}
+              data={data}
+              defaultSortingKey={'health'}
+              getRowId={getRowId}
+              revealDroppedColumns
+            >
+              <Table.SingleSelectableContent
+                rowHeight="h40"
+                separationLineVariant="backgroundLevel3"
+                selectedId={selected}
+                onRowSelected={(row) => setSelected(row.id)}
+              />
+            </Table>
+          </div>
+        </div>
+
+        <Title>D — multi selectable, scrollbar, same columns</Title>
+        <div id="align-multi-scrollbar" style={alignmentFrame}>
+          <div style={{ height: '220px' }}>
+            <Table columns={attachmentShapeColumns} data={manyAttachables}>
+              <Table.MultiSelectableContent
+                rowHeight="h40"
+                separationLineVariant="backgroundLevel3"
+                onMultiSelectionChanged={action('selection changed')}
+              />
+            </Table>
+          </div>
+        </div>
+      </>
+    );
+  },
 };

--- a/stories/tablev2.stories.tsx
+++ b/stories/tablev2.stories.tsx
@@ -850,7 +850,11 @@ const responsiveColumns: Column<Entry>[] = [
     dropAt: 550,
   },
   {
-    Header: 'Health',
+    // Long enough to outgrow its column as the frame narrows, on the tightest
+    // track here (flex 1 against First Name's 2) and one that never drops, so
+    // the header ellipsis appears as soon as the frame leaves its default width
+    // and stays reachable all the way down.
+    Header: 'Replication Health',
     accessor: 'health',
     sortType: 'health',
     cellStyle: { width: 'unset', flex: 1, textAlign: 'left' },

--- a/stories/tablev2.stories.tsx
+++ b/stories/tablev2.stories.tsx
@@ -68,11 +68,9 @@ type Entry = {
   health: string;
 };
 
-// The default columns, and the reference for how a column declares its layout.
-// All three alignments are here on purpose -- text reads left, a number right, a
-// status centred -- and the two right-hand ones are also the sortable headers that
-// are not left-aligned, where an end-aligned and a centred label have to keep
-// their track.
+// The default columns, and the reference for how a column declares its layout. All
+// three alignments on purpose: the right and centred ones are also the sortable
+// headers where a non-left-aligned label has to keep its track.
 const columns: Column<Entry>[] = [
   {
     Header: 'First Name',
@@ -126,9 +124,8 @@ const columns: Column<Entry>[] = [
     // No values to order, so no caret.
     disableSortBy: true,
     // A fixed track, not a grow factor: the button is `white-space: nowrap` and
-    // bleeds into the next column as soon as a grow share drops under its own
-    // width. 8.5rem is 119px against a measured 113.84px button, so ~5px of slack
-    // for a font that renders wider; it overflows below 8.13rem.
+    // bleeds into the next column once a grow share drops under its own width.
+    // 8.5rem is 119px against a measured 113.84px button, ~5px of slack.
     cellStyle: {
       width: '8.5rem',
       flex: 'none',
@@ -738,10 +735,9 @@ export const TableWithViewAction = {
       {
         Header: '',
         id: 'actions',
-        // Same shape as the default columns' action column, and for the same
-        // reason: on `flex: 1` the button hung 7px past its own column, and the
-        // `display`/`justifyContent` it used to carry were both dead -- the cell's
-        // own flex centring is applied after `cellStyle` and takes them.
+        // Same shape as the default columns' action column: on `flex: 1` the button
+        // hung past its own column, and `display`/`justifyContent` here are dead --
+        // the cell's own flex centring is applied after `cellStyle`.
         cellStyle: {
           width: '8.5rem',
           flex: 'none',

--- a/stories/tablev2.stories.tsx
+++ b/stories/tablev2.stories.tsx
@@ -68,6 +68,13 @@ type Entry = {
   health: string;
 };
 
+// The default columns, and the reference for how a column declares its layout.
+// The three alignments are all here on purpose: a column states its alignment
+// once, in `cellStyle`, and it has to reach the header label and the values
+// alike -- text reads left, a number reads right, a status reads centred. The
+// two right-hand columns are also the two headers that carry a sort caret while
+// not being left-aligned, which is where an end-aligned label and a centred one
+// have to keep their track.
 const columns: Column<Entry>[] = [
   {
     Header: 'First Name',
@@ -99,7 +106,7 @@ const columns: Column<Entry>[] = [
     cellStyle: {
       width: 'unset',
       flex: 1,
-      textAlign: 'left',
+      textAlign: 'right',
     },
   },
   {
@@ -109,8 +116,43 @@ const columns: Column<Entry>[] = [
     cellStyle: {
       width: 'unset',
       flex: 1,
-      textAlign: 'left',
+      textAlign: 'center',
     },
+  },
+  // An action column: no header, one control per row. It is what makes the
+  // stories below demonstrate that a control in a cell keeps its own click --
+  // without a control there is nothing for a row-wide handler to steal.
+  {
+    Header: '',
+    id: 'actions',
+    // No values to order, so no caret. A caret over a blank header offers a
+    // sort the column cannot describe.
+    disableSortBy: true,
+    // A fixed track, not a grow factor. The button is `white-space: nowrap` and
+    // will not shrink below its label, so on a grow factor it overflows into the
+    // column beside it as soon as its share drops under its own width -- exactly
+    // the failure the guideline warns about. Measured at a 14px root the button
+    // is 113.84px: 1px border + 14px padding + 24.5px icon slot + 74.34px label.
+    // 8.5rem is 119px, so the label has 5.16px of slack for a font that renders
+    // slightly wider; below 8.13rem it bleeds.
+    cellStyle: {
+      width: '8.5rem',
+      flex: 'none',
+      textAlign: 'right',
+      // Cross axis, not `justifyContent`: a body cell's own vertical centring
+      // is applied after the column's `cellStyle` and takes the main axis, so
+      // this is where a control's horizontal placement has to be stated.
+      alignItems: 'flex-end',
+    },
+    Cell: () => (
+      <Button
+        size="inline"
+        variant="outline"
+        label="View details"
+        icon={<Icon name="Eye" />}
+        onClick={action('View details clicked')}
+      />
+    ),
   },
 ];
 const getRowId = (row: Entry, relativeIndex: number) => {
@@ -935,190 +977,4 @@ export const ResponsiveColumnDropWithReveal = {
       </>
     );
   },
-};
-
-/**
- * Guards the sort-caret header regression. Two independent defects:
- *  - a sortable header's min-content is 20px above its body cell's, so the two
- *    rows stop agreeing on column widths once that floor binds (Reproduction A);
- *  - an end-aligned header label is pushed off the trailing edge by the caret
- *    sitting after it (Reproduction B).
- */
-type Reading = { label: string; mirror: string; value: string };
-
-const readingData: Reading[] = [
-  { label: '27', mirror: '27', value: '27' },
-  { label: '31', mirror: '31', value: '31' },
-];
-
-// Both columns carry the same flex and the same narrow body value; the only
-// difference is sortability. They must resolve to the same width.
-const readingColumns: Column<Reading>[] = [
-  {
-    Header: 'Temperature',
-    accessor: 'label',
-    cellStyle: { width: 'unset', flex: 1, textAlign: 'left' },
-  },
-  {
-    Header: 'Temperature',
-    accessor: 'mirror',
-    cellStyle: { width: 'unset', flex: 1, textAlign: 'left' },
-    disableSortBy: true,
-  },
-];
-
-type Certificate = {
-  name: string;
-  issuer: string;
-  status: string;
-  expireOn: string;
-};
-
-const certificateData: Certificate[] = [
-  {
-    name: 'artesca-ingress',
-    issuer: 'Scality Internal CA',
-    status: 'Valid',
-    expireOn: '2027-01-14',
-  },
-  {
-    name: 'shell-ui-oidc',
-    issuer: "Let's Encrypt X3",
-    status: 'Valid',
-    expireOn: '2026-11-02',
-  },
-];
-
-const certificateColumns: Column<Certificate>[] = [
-  {
-    Header: 'Name',
-    accessor: 'name',
-    cellStyle: { width: 'unset', flex: 1, textAlign: 'left' },
-  },
-  {
-    Header: 'Issuer',
-    accessor: 'issuer',
-    cellStyle: { width: 'unset', flex: 1, textAlign: 'left' },
-    disableSortBy: true,
-  },
-  {
-    Header: 'Status',
-    accessor: 'status',
-    cellStyle: { width: 'unset', flex: 0.75, textAlign: 'center' },
-  },
-  {
-    Header: 'Expire On',
-    accessor: 'expireOn',
-    cellStyle: {
-      width: 'unset',
-      flex: 0.75,
-      textAlign: 'right',
-      paddingRight: '36px',
-    },
-  },
-];
-
-// Narrow centred columns, each sortable one paired with an identical column that
-// is not sortable. The pair is the point: the sortable header carries a caret and
-// a counterweight, the plain one carries neither, so any difference in where the
-// two labels sit is the caret mechanism and nothing else. At 5rem and 7rem the
-// counterweight cap binds, so the sortable label should drift slightly off centre
-// rather than truncate earlier than its twin.
-const narrowCentredColumns: Column<Certificate>[] = [
-  {
-    Header: 'Name',
-    accessor: 'name',
-    cellStyle: { width: 'unset', flex: 1, textAlign: 'left' },
-  },
-  {
-    Header: 'Status',
-    accessor: 'status',
-    id: 'status-sortable',
-    cellStyle: { textAlign: 'center', width: '5rem' },
-  },
-  {
-    Header: 'Status',
-    accessor: 'status',
-    id: 'status-plain',
-    cellStyle: { textAlign: 'center', width: '5rem' },
-    disableSortBy: true,
-  },
-  {
-    Header: 'Expire On',
-    accessor: 'expireOn',
-    id: 'expire-sortable',
-    cellStyle: { textAlign: 'center', width: '7rem' },
-  },
-  {
-    Header: 'Expire On',
-    accessor: 'expireOn',
-    id: 'expire-plain',
-    cellStyle: { textAlign: 'center', width: '7rem' },
-    disableSortBy: true,
-  },
-];
-
-export const SortCaretHeaderAlignment = {
-  render: () => (
-    <>
-      <Title>
-        A — equal flex, sortable vs not, container too narrow for both headers
-      </Title>
-      <div id="repro-a" style={{ height: '120px', width: '220px' }}>
-        <Table
-          columns={readingColumns}
-          data={readingData}
-          defaultSortingKey={'label'}
-        >
-          <Table.SingleSelectableContent
-            rowHeight="h32"
-            separationLineVariant="backgroundLevel3"
-          />
-        </Table>
-      </div>
-      <Title>B — end-aligned and centred sortable headers</Title>
-      <div id="repro-b" style={{ height: '140px' }}>
-        <Table
-          columns={certificateColumns}
-          data={certificateData}
-          defaultSortingKey={'expireOn'}
-        >
-          <Table.SingleSelectableContent
-            rowHeight="h40"
-            separationLineVariant="backgroundLevel3"
-          />
-        </Table>
-      </div>
-      <Title>C — multi selectable, same columns as B</Title>
-      <div id="repro-c" style={{ height: '160px' }}>
-        <Table
-          columns={certificateColumns}
-          data={certificateData}
-          defaultSortingKey={'status'}
-        >
-          <Table.MultiSelectableContent
-            rowHeight="h40"
-            separationLineVariant="backgroundLevel3"
-            onMultiSelectionChanged={action('selection changed')}
-          />
-        </Table>
-      </div>
-      <Title>
-        D — narrow centred headers: each sortable column paired with an
-        identical column that is not sortable
-      </Title>
-      <div id="repro-d" style={{ height: '140px', width: '620px' }}>
-        <Table
-          columns={narrowCentredColumns}
-          data={certificateData}
-          defaultSortingKey={'status'}
-        >
-          <Table.SingleSelectableContent
-            rowHeight="h32"
-            separationLineVariant="backgroundLevel3"
-          />
-        </Table>
-      </div>
-    </>
-  ),
 };

--- a/stories/tablev2.stories.tsx
+++ b/stories/tablev2.stories.tsx
@@ -858,83 +858,82 @@ const responsiveColumns: Column<Entry>[] = [
 ];
 
 export const ResponsiveColumnDrop = {
-  render: () => (
-    <>
-      <Title>Responsive column drop</Title>
-      <Box mb={2}>
-        Drag the bottom-right corner to resize. Columns with a <code>dropAt</code>{' '}
-        breakpoint hide as the table gets narrower (Age below 550px, Last Name
-        below 700px). First Name and Health have no breakpoint, so they always
-        stay.
-      </Box>
-      <div
-        style={{
-          height: '320px',
-          width: '900px',
-          minWidth: '320px',
-          maxWidth: '100%',
-          resize: 'horizontal',
-          overflow: 'hidden',
-          padding: '20px',
-          border: '1px dashed currentColor',
-          boxSizing: 'border-box',
-        }}
-      >
-        <Table
-          columns={responsiveColumns}
-          data={data}
-          defaultSortingKey={'health'}
-          getRowId={getRowId}
+  render: () => {
+    const [selected, setSelected] = useState<string | undefined>(undefined);
+
+    return (
+      <>
+        <Title>Responsive column drop</Title>
+        <div
+          style={{
+            height: '320px',
+            width: '900px',
+            minWidth: '320px',
+            maxWidth: '100%',
+            resize: 'horizontal',
+            overflow: 'hidden',
+            padding: '20px',
+            border: '1px dashed currentColor',
+            boxSizing: 'border-box',
+          }}
         >
-          <Table.SingleSelectableContent
-            rowHeight="h40"
-            separationLineVariant="backgroundLevel3"
-          />
-        </Table>
-      </div>
-    </>
-  ),
+          <Table
+            columns={responsiveColumns}
+            data={data}
+            defaultSortingKey={'health'}
+            getRowId={getRowId}
+          >
+            <Table.SingleSelectableContent
+              rowHeight="h40"
+              separationLineVariant="backgroundLevel3"
+              selectedId={selected}
+              onRowSelected={(row) => setSelected(row.id)}
+            />
+          </Table>
+        </div>
+      </>
+    );
+  },
 };
 
 export const ResponsiveColumnDropWithReveal = {
-  render: () => (
-    <>
-      <Title>Responsive column drop with reveal</Title>
-      <Box mb={2}>
-        Same responsive columns as above, but with <code>revealDroppedColumns</code>.
-        Once a column drops, a trailing column appears with a per-row{' '}
-        <code>+N</code> trigger; clicking it opens a popover listing the dropped
-        columns and their values for that row, so no data is lost on a narrow
-        viewport. Drag the bottom-right corner below 700px to see it.
-      </Box>
-      <div
-        style={{
-          height: '320px',
-          width: '900px',
-          minWidth: '320px',
-          maxWidth: '100%',
-          resize: 'horizontal',
-          overflow: 'hidden',
-          padding: '20px',
-          border: '1px dashed currentColor',
-          boxSizing: 'border-box',
-        }}
-      >
-        <Table
-          columns={responsiveColumns}
-          data={data}
-          defaultSortingKey={'health'}
-          getRowId={getRowId}
-          revealDroppedColumns
+  render: () => {
+    const [selected, setSelected] = useState<string | undefined>(undefined);
+
+    return (
+      <>
+        <Title>Responsive column drop with reveal</Title>
+        <div
+          style={{
+            height: '320px',
+            width: '900px',
+            minWidth: '320px',
+            maxWidth: '100%',
+            resize: 'horizontal',
+            overflow: 'hidden',
+            padding: '20px',
+            border: '1px dashed currentColor',
+            boxSizing: 'border-box',
+          }}
         >
-          <Table.SingleSelectableContent
-            rowHeight="h40"
-            separationLineVariant="backgroundLevel3"
-          />
-        </Table>
-      </div>
-    </>
-  ),
+          <Table
+            columns={responsiveColumns}
+            data={data}
+            defaultSortingKey={'health'}
+            getRowId={getRowId}
+            revealDroppedColumns
+          >
+            <Table.SingleSelectableContent
+              rowHeight="h40"
+              separationLineVariant="backgroundLevel3"
+              selectedId={selected}
+              onRowSelected={(row) => setSelected(row.id)}
+            />
+          </Table>
+        </div>
+      </>
+    );
+  },
 };
 
 /**
@@ -1063,137 +1062,4 @@ export const SortCaretHeaderAlignment = {
       </div>
     </>
   ),
-};
-
-type Attachable = { name: string; isPending: boolean; action: string };
-
-// AttachmentTable's exact column shape: three tracks with grow factors summing
-// to 2.5, a right margin on the first, and `marginLeft: auto` plus a JSX Header
-// on the last. Reproduced here because the reported defect is that the header
-// tracks and the body tracks disagree, and only a real layout can show that.
-const attachmentShapeColumns: Column<Attachable>[] = [
-  {
-    Header: 'Name',
-    accessor: 'name',
-    cellStyle: { flex: 1.5, marginRight: '1.5rem' },
-  },
-  {
-    Header: 'Attachment',
-    accessor: 'isPending',
-    cellStyle: { flex: 0.5 },
-    Cell: ({ value }: { value?: boolean }) => <>{value ? 'Pending' : 'Attached'}</>,
-  },
-  {
-    Header: <Box flex={0.5} />,
-    accessor: 'action',
-    cellStyle: {
-      textAlign: 'right',
-      flex: 0.5,
-      marginLeft: 'auto',
-      marginRight: '0.5rem',
-    },
-    Cell: () => <Button variant="outline" label="Detach" />,
-  },
-];
-
-const attachableRow = (i: number): Attachable => ({
-  name: `entity-${i}`,
-  isPending: i % 3 === 0,
-  action: 'detach',
-});
-
-const fewAttachables = Array.from({ length: 2 }, (_, i) => attachableRow(i));
-const manyAttachables = Array.from({ length: 40 }, (_, i) => attachableRow(i));
-
-const alignmentFrame: React.CSSProperties = {
-  resize: 'horizontal',
-  overflow: 'hidden',
-  width: '46rem',
-  minWidth: '14rem',
-  maxWidth: '100%',
-  border: '1px dashed #666',
-  padding: '0.5rem',
-};
-
-export const HeaderBodyColumnAlignment = {
-  render: () => {
-    const [selected, setSelected] = useState<string | undefined>(undefined);
-
-    return (
-      <>
-        <Title>
-          Drag each frame's right edge. Every header label must stay directly
-          over its column at every width.
-        </Title>
-
-        <Title>A — single selectable, few rows, no vertical scrollbar</Title>
-        <div id="align-no-scrollbar" style={alignmentFrame}>
-          <div style={{ height: '140px' }}>
-            <Table columns={attachmentShapeColumns} data={fewAttachables}>
-              <Table.SingleSelectableContent
-                rowHeight="h40"
-                separationLineVariant="backgroundLevel3"
-                selectedId={selected}
-                onRowSelected={(row) => setSelected(row.id)}
-              />
-            </Table>
-          </div>
-        </div>
-
-        <Title>
-          B — single selectable, enough rows to force a vertical scrollbar. Click
-          a row to select it; click "Detach" and the row must NOT select.
-        </Title>
-        <div id="align-with-scrollbar" style={alignmentFrame}>
-          <div style={{ height: '220px' }}>
-            <Table columns={attachmentShapeColumns} data={manyAttachables}>
-              <Table.SingleSelectableContent
-                rowHeight="h40"
-                separationLineVariant="backgroundLevel3"
-                selectedId={selected}
-                onRowSelected={(row) => setSelected(row.id)}
-              />
-            </Table>
-          </div>
-        </div>
-
-        <Title>
-          C — single selectable with dropped columns and reveal. Below 700px a
-          per-row <code>+N</code> trigger appears; clicking it on an UNSELECTED
-          row must open the popover and leave it open.
-        </Title>
-        <div id="align-reveal" style={alignmentFrame}>
-          <div style={{ height: '220px' }}>
-            <Table
-              columns={responsiveColumns}
-              data={data}
-              defaultSortingKey={'health'}
-              getRowId={getRowId}
-              revealDroppedColumns
-            >
-              <Table.SingleSelectableContent
-                rowHeight="h40"
-                separationLineVariant="backgroundLevel3"
-                selectedId={selected}
-                onRowSelected={(row) => setSelected(row.id)}
-              />
-            </Table>
-          </div>
-        </div>
-
-        <Title>D — multi selectable, scrollbar, same columns</Title>
-        <div id="align-multi-scrollbar" style={alignmentFrame}>
-          <div style={{ height: '220px' }}>
-            <Table columns={attachmentShapeColumns} data={manyAttachables}>
-              <Table.MultiSelectableContent
-                rowHeight="h40"
-                separationLineVariant="backgroundLevel3"
-                onMultiSelectionChanged={action('selection changed')}
-              />
-            </Table>
-          </div>
-        </div>
-      </>
-    );
-  },
 };

--- a/stories/tablev2.stories.tsx
+++ b/stories/tablev2.stories.tsx
@@ -740,9 +740,6 @@ export const TableWithViewAction = {
           close={() => setSelectedEntry(null)}
           title={`View Entry details`}
           role="dialog"
-          isOpen={selectedEntry !== null}
-          close={() => setSelectedEntry(null)}
-          title={`View Entry details`}
           footer={
             <Stack gap="r8" style={{ justifyContent: 'flex-end' }}>
               <Button

--- a/stories/tablev2.stories.tsx
+++ b/stories/tablev2.stories.tsx
@@ -69,12 +69,10 @@ type Entry = {
 };
 
 // The default columns, and the reference for how a column declares its layout.
-// The three alignments are all here on purpose: a column states its alignment
-// once, in `cellStyle`, and it has to reach the header label and the values
-// alike -- text reads left, a number reads right, a status reads centred. The
-// two right-hand columns are also the two headers that carry a sort caret while
-// not being left-aligned, which is where an end-aligned label and a centred one
-// have to keep their track.
+// All three alignments are here on purpose -- text reads left, a number right, a
+// status centred -- and the two right-hand ones are also the sortable headers that
+// are not left-aligned, where an end-aligned and a centred label have to keep
+// their track.
 const columns: Column<Entry>[] = [
   {
     Header: 'First Name',
@@ -119,29 +117,24 @@ const columns: Column<Entry>[] = [
       textAlign: 'center',
     },
   },
-  // An action column: no header, one control per row. It is what makes the
-  // stories below demonstrate that a control in a cell keeps its own click --
-  // without a control there is nothing for a row-wide handler to steal.
+  // An action column: no header, one control per row. Without a control in a cell
+  // there is nothing for a row-wide handler to steal, so this is what lets the
+  // stories below demonstrate that an in-cell click stays its own.
   {
     Header: '',
     id: 'actions',
-    // No values to order, so no caret. A caret over a blank header offers a
-    // sort the column cannot describe.
+    // No values to order, so no caret.
     disableSortBy: true,
-    // A fixed track, not a grow factor. The button is `white-space: nowrap` and
-    // will not shrink below its label, so on a grow factor it overflows into the
-    // column beside it as soon as its share drops under its own width -- exactly
-    // the failure the guideline warns about. Measured at a 14px root the button
-    // is 113.84px: 1px border + 14px padding + 24.5px icon slot + 74.34px label.
-    // 8.5rem is 119px, so the label has 5.16px of slack for a font that renders
-    // slightly wider; below 8.13rem it bleeds.
+    // A fixed track, not a grow factor: the button is `white-space: nowrap` and
+    // bleeds into the next column as soon as a grow share drops under its own
+    // width. 8.5rem is 119px against a measured 113.84px button, so ~5px of slack
+    // for a font that renders wider; it overflows below 8.13rem.
     cellStyle: {
       width: '8.5rem',
       flex: 'none',
       textAlign: 'right',
-      // Cross axis, not `justifyContent`: a body cell's own vertical centring
-      // is applied after the column's `cellStyle` and takes the main axis, so
-      // this is where a control's horizontal placement has to be stated.
+      // Cross axis, not `justifyContent`: a body cell's own vertical centring is
+      // applied after `cellStyle` and takes the main axis.
       alignItems: 'flex-end',
     },
     Cell: () => (
@@ -746,13 +739,9 @@ export const TableWithViewAction = {
         Header: '',
         id: 'actions',
         // Same shape as the default columns' action column, and for the same
-        // reason. On `flex: 1` this column measured 106.66px in this 700px table
-        // against a 113.84px button, so the button hung 7.18px past its own
-        // column -- in the story the guideline points at to show how an action
-        // column is built. `display` and `justifyContent` were also dead here:
-        // a body cell's own flex centring is applied after the column's
-        // `cellStyle` and takes both, so the button was never right-aligned
-        // either. `alignItems` is the cross axis and survives.
+        // reason: on `flex: 1` the button hung 7px past its own column, and the
+        // `display`/`justifyContent` it used to carry were both dead -- the cell's
+        // own flex centring is applied after `cellStyle` and takes them.
         cellStyle: {
           width: '8.5rem',
           flex: 'none',
@@ -898,9 +887,8 @@ const responsiveColumns: Column<Entry>[] = [
   },
   {
     // Long enough to outgrow its column as the frame narrows, on the tightest
-    // track here (flex 1 against First Name's 2) and one that never drops, so
-    // the header ellipsis appears as soon as the frame leaves its default width
-    // and stays reachable all the way down.
+    // track here and one that never drops, so the header ellipsis shows up early
+    // and stays reachable.
     Header: 'Replication Health',
     accessor: 'health',
     sortType: 'health',

--- a/stories/tablev2.stories.tsx
+++ b/stories/tablev2.stories.tsx
@@ -745,11 +745,19 @@ export const TableWithViewAction = {
       {
         Header: '',
         id: 'actions',
+        // Same shape as the default columns' action column, and for the same
+        // reason. On `flex: 1` this column measured 106.66px in this 700px table
+        // against a 113.84px button, so the button hung 7.18px past its own
+        // column -- in the story the guideline points at to show how an action
+        // column is built. `display` and `justifyContent` were also dead here:
+        // a body cell's own flex centring is applied after the column's
+        // `cellStyle` and takes both, so the button was never right-aligned
+        // either. `alignItems` is the cross axis and survives.
         cellStyle: {
-          width: 'unset',
-          flex: 1,
-          display: 'flex',
-          justifyContent: 'flex-end',
+          width: '8.5rem',
+          flex: 'none',
+          textAlign: 'right',
+          alignItems: 'flex-end',
         },
         Cell: ({ row }: CellProps<Entry>) => (
           <Button


### PR DESCRIPTION
**TL;DR** — Six defects in `Table` that only show up once a table is used in earnest: clicking a button inside a row also selected the row (and the re-render closed whatever the button had just opened), header labels sat over the wrong columns, a value ignored its column's alignment, a cut-off header label had no way to show its full text, and a selectable table looked inert until the first click. All six are fixed.

## Context

All six surfaced while putting a table to real use, and they overlap so heavily in the same two files that as separate PRs they would conflict with each other rather than review independently.

## Approach

Most of them come back to one mechanism — how a header cell and its body cells agree on a column's width — which is what makes them one PR rather than six.

| Defect | Cause → fix |
| --- | --- |
| A click on an in-cell control also selected the row, and the selection re-render closed whatever that control had just opened | row `onClick`/`onKeyDown` fired for any target inside the row → one `shouldIgnoreRowEvent` guard, bounded to the row at both ends |
| Header tracks drifted from body tracks, and drifted again once one column ran short | `TableRowMultiSelectable` never declared the `gap` `HeadRow` has, and body cells lacked the header's `min-width: 0` reset → declare both |
| A plain string value ignored its column's alignment — 94px off centre on a centred column | `ConstrainedTextContainer` hard-coded `text-align: left`, plus a one-sided `Box mr={4}` → inherit the alignment and drop the margin; the row's own `gap` already separates columns |
| An ellipsized header label had nothing to recover it | body cells recover via `ConstrainedText`, headers had no equivalent → `TruncatableHeaderLabel`, offering a `Tooltip` only once the label is genuinely cut off |
| A selectable table looked inert until its first click | the hover affordance was gated on `$selectedId` — "something is selected" — not on whether the table can be selected → gate it on `$selectable` |
| The header reserved the caret's room on its behalf, across three constants that had to agree by hand | the caret was a zero-width proxy with the room in `HeaderContent`'s padding → the caret carries its own width, and one constant describes it |

The in-flow caret is only safe because of the `min-width: 0` fix: real caret width lifts a sortable header's min-content above its body cell's, and that only stops mattering once `min-width: auto` is out of play — the two changes are coupled. Header-minus-body `left` and `width` are exactly 0 on every column across ten widths from 1400px down to 360px, single- and multi-selectable.

## Screenshots

**Table → Simple Content Table** at full width — `Age` and its values share one right edge, `Health` and its caret are centred over the statuses, and the trailing blank header carries one right-aligned button per row:

<img width="1244" height="196" alt="cui1192-table-alignment-wide" src="https://github.com/user-attachments/assets/990db331-38c7-49c1-86eb-90b5f7332c03" />

The same table at 620px — labels ellipsize, the four tracks still agree between header and body, and the action column keeps its button intact rather than shrinking it:

<img width="596" height="196" alt="cui1192-table-alignment-620px" src="https://github.com/user-attachments/assets/1c7ab010-99d4-4cae-ae5b-f5143f528bb4" />

## Review focus

- 🔴 `SingleSelectableContent.tsx` / `MultiSelectableContent.tsx` › row handlers — a consumer relying on "a click anywhere in the row selects it" will notice, and one carrying its own `stopPropagation` on an interactive cell can now drop it; `TableCommon.tsx › INTERACTIVE_SELECTOR` is the whole guard, so check nothing a cell renders is missing from it.
- 🟡 `Tablestyle.tsx › SortCaretWrapper` + `HeaderContent` — changes header geometry for every sortable table, and is safe only because the `min-width: 0` fix landed in the same PR, so review the two together.
- 🟡 `constrainedtext/Constrainedtext.component.tsx` — the only change outside `tablev2`, on a publicly exported component: `text-align` goes from a hard-coded `left` to `inherit`, so an external consumer relying on it staying left-aligned under a centring ancestor will see it centre.

## How to test

1. `npm run storybook`, open **Table → Simple Content Table**. Each header label sits over its own column and stays there as you narrow the browser: **Age** flush-right over the numbers, **Health** centred over the statuses, the name columns flush-left.
2. Hover a sortable header — the sort incentive appears and **nothing moves**. Hover the blank action header: no caret, and not a tab stop.
3. **Responsive Column Drop With Reveal** — narrow until the `+N` trigger appears, then click it on an *unselected* row. The panel opens and stays open; it used to select the row, re-render and close.
4. **Table With View Action** — click the button (the action fires, the row does not select), click the row's plain text (it selects), Tab to the button and press Enter (the button activates only). The button now sits inside its own column instead of overhanging by 7px.
5. Narrow until a header label ellipsizes and hover it — the full label appears; widen until it fits and hover again — no tooltip. Then hover a row in any single-selectable story **before clicking anything**: the affordance and pointer cursor are already there.

## Follow-up

- `TooltipContainer` is an `inline-block` with no `min-width: 0`, which is why `ConstrainedText` and now `HeaderLabelFrame` both carry the same unwrapping workaround. Fixing it at source deletes both, but it touches every `Tooltip` in the library.
- `organisms/attachments/AttachmentTable.tsx` carries a `marginLeft: 'auto'` that is inert at a grow-sum above 1 but becomes live below it, and a `<Box flex={0.5} />` `Header` that is a no-op. Both were cleared as causes of the misalignment fixed here, so they are left alone rather than widening this PR.
- react-table v7 spreads `key` inside `getRowProps()`/`getCellProps()`, which React reports as an error on every row and header. Pre-existing and library-wide, but it is console noise for anyone testing the above.

<details>
<summary>What changed</summary>

The alignment demonstration moved onto the **shared** default columns in `stories/tablev2.stories.tsx` rather than a separate story, so every story built on them changes appearance and gains a button per row. That action column's `8.5rem` is measured against the button's current label rather than derived, so it needs revisiting if the label changes.

</details>

