### PR TITLE
Form: let the label column share the squeeze with the field

### DIFF
--- a/src/lib/components/form/Form.component.tsx
+++ b/src/lib/components/form/Form.component.tsx
@@ -430,12 +430,16 @@ type FormSectionProps = {
   title?: { name: string; icon?: IconName; helpTooltip?: string };
   /**
    * Caps the label column at this width: labels wider than it wrap rather than
-   * widening the column. A number is pixels; a string is any CSS length, so
-   * `'15rem'` follows the document's root font size where a px value computed once
-   * cannot. In a `responsive` Form the column keeps this width while there is
-   * room but shrinks below it (down to the longest word) as the field track is
-   * squeezed, so rows stay aligned; otherwise it is pinned to this exact width.
-   * When unset, the column auto-sizes to the widest label.
+   * widening the column. A number is pixels; a string is an **absolute** length
+   * (`px`, `rem`, `em`, `ch`), so `'15rem'` follows the document's root font size
+   * where a px value computed once cannot. A percentage or a keyword such as
+   * `max-content` is not usable: the width is also fed to the container query
+   * that decides when the section stacks, and neither is valid there, so the rule
+   * is dropped whole and the section silently stops stacking. In a `responsive`
+   * Form the column keeps this width while there is room but shrinks below it
+   * (down to the longest word) as the field track is squeezed, so rows stay
+   * aligned; otherwise it is pinned to this exact width. When unset, the column
+   * auto-sizes to the widest label.
    */
   forceLabelWidth?: number | string;
   rightActions?: ReactNode;

--- a/src/lib/components/form/Form.component.tsx
+++ b/src/lib/components/form/Form.component.tsx
@@ -57,16 +57,29 @@ type TabFormProps = { layout: { kind: 'tab' } } & FormProps;
 
 // In a `responsive` Form a FormSection lays its FormGroups out as a two-column
 // CSS grid (label track + field track) and each FormGroup is a `subgrid` row, so
-// labels align per section from content alone — no measurement. Below STACK_BELOW
-// the grid collapses to a single column (fields stack under their labels) via a
-// `@container` query, so a field never shrinks small enough to truncate.
+// labels align per section from content alone — no measurement. Below the section's
+// own stacking width the grid collapses to a single column (fields stack under
+// their labels) via a `@container` query, so a field never shrinks small enough to
+// truncate.
 // Both floors are a readability policy, not component-derived: fluid fields carry
 // `min-width: 0`, so there is no intrinsic minimum to read.
 // - field floor: the `1/2` Input size (10rem) — below this a field stacks.
 // - label floor: ~24ch — long labels wrap to about two lines before stacking.
 const FIELD_MIN_REM = 10;
 const LABEL_MIN_CH = 24;
-const STACK_BELOW = `calc(${LABEL_MIN_CH}ch + ${FIELD_MIN_REM}rem + ${spacing.r32})`;
+// Share of the container the label column may claim once there is not enough room
+// for its full cap. A grid track satisfies its max before the flexible field track
+// flexes, so a constant cap makes the label take its full width while the field
+// walks down to FIELD_MIN_REM and the row stacks earlier than it needs to. Capping
+// the label as a fraction of the container instead makes the two give ground
+// together; above ~2.5x the cap the fraction is the larger of the two and the
+// column is sized exactly as before.
+const LABEL_MAX_CQI = 40;
+// The width below which a section stacks: its own label column plus the field
+// floor plus the column gap. Derived per section rather than fixed, or a section
+// with a label cap wider than LABEL_MIN_CH overflows in the band between the two.
+const stackBelow = (labelFloor: string) =>
+  `calc(${labelFloor} + ${FIELD_MIN_REM}rem + ${spacing.r32})`;
 
 const StyledForm = styled.form<{
   $layout: PageFormProps['layout'] | TabFormProps['layout'];
@@ -154,13 +167,15 @@ const ScrollArea = styled(BasicPageLayout)`
 //     requires each row to be a direct grid item.
 // Either way, non-FormGroup children (an InfoMessage, a Banner) stack full-width.
 // `responsive` makes the field track fluid (minmax(10rem, 1fr)) and lets each row
-// flip to a stacked single column below STACK_BELOW via an `@container` query.
+// flip to a stacked single column below the section's stacking width via an
+// `@container` query.
 const SectionGrid = styled.div<{
   $labelTrack: string;
   $responsive: boolean;
   $fixedLabel: boolean;
+  $stackBelow: string;
 }>`
-  ${({ $labelTrack, $responsive, $fixedLabel }) =>
+  ${({ $labelTrack, $responsive, $fixedLabel, $stackBelow }) =>
     $fixedLabel
       ? css`
           display: flex;
@@ -169,7 +184,7 @@ const SectionGrid = styled.div<{
           ${
             $responsive &&
             css`
-              @container responsive (max-width: ${STACK_BELOW}) {
+              @container responsive (max-width: ${$stackBelow}) {
                 gap: ${spacing.r20};
               }
             `
@@ -199,7 +214,7 @@ const SectionGrid = styled.div<{
           ${
             $responsive &&
             css`
-              @container responsive (max-width: ${STACK_BELOW}) {
+              @container responsive (max-width: ${$stackBelow}) {
                 grid-template-columns: 1fr;
                 /* Stacked groups need more separation than side-by-side rows: each
                  group is now two lines (label over field), so widen the gap. */
@@ -227,11 +242,12 @@ const FieldSubgridRow = styled.div<{
   $responsive: boolean;
   $labelTrack: string;
   $fixedLabel: boolean;
+  $stackBelow: string;
 }>`
   display: grid;
   grid-column: 1 / -1;
   row-gap: ${spacing.r4};
-  ${({ $direction, $responsive, $labelTrack, $fixedLabel }) => {
+  ${({ $direction, $responsive, $labelTrack, $fixedLabel, $stackBelow }) => {
     if ($direction === 'vertical') {
       return css`
         grid-template-columns: 1fr;
@@ -249,7 +265,7 @@ const FieldSubgridRow = styled.div<{
       ${
         $responsive &&
         css`
-          @container responsive (max-width: ${STACK_BELOW}) {
+          @container responsive (max-width: ${$stackBelow}) {
             grid-template-columns: 1fr;
             align-items: stretch;
           }
@@ -276,6 +292,7 @@ const GridLabelCell = styled.div<{ $hasHelpTooltip: boolean }>`
 type SectionLabelConfig = {
   labelTrack: string;
   fixedLabel: boolean;
+  stackBelow: string;
 };
 const FormSectionContext = createContext<SectionLabelConfig | null>(null);
 
@@ -397,6 +414,7 @@ const FormGroup = ({
         $responsive={responsive}
         $labelTrack={sectionLabel.labelTrack}
         $fixedLabel={sectionLabel.fixedLabel}
+        $stackBelow={sectionLabel.stackBelow}
       >
         <GridLabelCell $hasHelpTooltip={!!labelHelpTooltip}>
           {labelContent}
@@ -411,13 +429,15 @@ type FormSectionProps = {
   children: ReactElement<FormGroupProps> | ReactElement<FormGroupProps>[];
   title?: { name: string; icon?: IconName; helpTooltip?: string };
   /**
-   * Caps the label column at this pixel width: labels wider than it wrap rather
-   * than widening the column. In a `responsive` Form the column keeps this width
-   * while there is room but shrinks below it (down to the longest word) as the
-   * field track is squeezed, so rows stay aligned; otherwise it is pinned to this
-   * exact width. When unset, the column auto-sizes to the widest label.
+   * Caps the label column at this width: labels wider than it wrap rather than
+   * widening the column. A number is pixels; a string is any CSS length, so
+   * `'15rem'` follows the document's root font size where a px value computed once
+   * cannot. In a `responsive` Form the column keeps this width while there is
+   * room but shrinks below it (down to the longest word) as the field track is
+   * squeezed, so rows stay aligned; otherwise it is pinned to this exact width.
+   * When unset, the column auto-sizes to the widest label.
    */
-  forceLabelWidth?: number;
+  forceLabelWidth?: number | string;
   rightActions?: ReactNode;
 };
 
@@ -442,13 +462,28 @@ const FormSection = ({
   // longest word (`min-content`) up to that cap before the section flips;
   // non-responsive pins it to the cap.
   const fixedLabel = forceLabelWidth != null;
-  const labelWidthCap = fixedLabel ? `${forceLabelWidth}px` : 'max-content';
+  const labelWidth =
+    typeof forceLabelWidth === 'number'
+      ? `${forceLabelWidth}px`
+      : forceLabelWidth;
+  const labelWidthCap = labelWidth ?? 'max-content';
+  // Responsive clamps the cap to a share of the container so the label and the
+  // field give ground together (see LABEL_MAX_CQI). `min()` needs two lengths, so
+  // the clamp only applies to an explicit cap; an auto column's cap is its own
+  // text, which is its own limit.
   const labelTrack = responsive
-    ? `minmax(min-content, ${labelWidthCap})`
+    ? `minmax(min-content, ${
+        labelWidth ? `min(${labelWidth}, ${LABEL_MAX_CQI}cqi)` : labelWidthCap
+      })`
     : labelWidthCap;
+  // The auto column has no length to derive from, so it keeps the readability
+  // floor it has always used.
+  const sectionStackBelow = stackBelow(labelWidth ?? `${LABEL_MIN_CH}ch`);
 
   return (
-    <FormSectionContext.Provider value={{ labelTrack, fixedLabel }}>
+    <FormSectionContext.Provider
+      value={{ labelTrack, fixedLabel, stackBelow: sectionStackBelow }}
+    >
       <Stack direction="vertical" gap="r12">
         {title && (
           <Wrap>
@@ -473,6 +508,7 @@ const FormSection = ({
           $labelTrack={labelTrack}
           $responsive={responsive}
           $fixedLabel={fixedLabel}
+          $stackBelow={sectionStackBelow}
         >
           {children}
         </SectionGrid>

--- a/stories/form.stories.tsx
+++ b/stories/form.stories.tsx
@@ -958,3 +958,66 @@ export const ResponsivePageFormInFlexRow = {
   ),
   args: { requireMode: 'partial', responsive: true },
 };
+
+// A detail-page shape: a `responsive` page form whose section
+// forces a label width, with labels long enough to actually need it. A grid track
+// satisfies its max before the flexible field track flexes, so with a constant cap
+// the label kept its full width while the field walked down to its 10rem floor and
+// the row stacked while there was still room for both. Drag the frame in and watch
+// the label column give ground with the field instead.
+// `forceLabelWidth` is an arg: 224 is a value in real use, 265 is the case whose
+// stacking threshold used to sit ~70px below the width it actually needs.
+export const ResponsiveLabelSqueeze = {
+  render: ({ forceLabelWidth, requireMode }) => (
+    <div
+      data-testid="squeeze-frame"
+      style={{
+        resize: 'horizontal',
+        overflow: 'auto',
+        width: '60rem',
+        minWidth: '20rem',
+        maxWidth: '100%',
+        border: '1px dashed #666',
+        height: '30rem',
+      }}
+    >
+      <div style={{ display: 'flex', height: '100%' }}>
+        <Form
+          layout={{ kind: 'page', title: 'User' }}
+          requireMode={requireMode}
+          responsive
+          rightActions={<Button variant="primary" label="Save" />}
+        >
+          <FormSection
+            title={{ name: 'Identity', icon: 'Account' }}
+            forceLabelWidth={forceLabelWidth}
+          >
+            <FormGroup
+              direction="horizontal"
+              label="User name"
+              id="sq-name"
+              content={<Input id="sq-name" />}
+              required
+            />
+            <FormGroup
+              direction="horizontal"
+              label="Multi-factor authentication"
+              id="sq-mfa"
+              content={<Input id="sq-mfa" />}
+            />
+            <FormGroup
+              direction="horizontal"
+              label="Account creation date"
+              id="sq-created"
+              content={<Input id="sq-created" />}
+            />
+          </FormSection>
+        </Form>
+      </div>
+    </div>
+  ),
+  args: { forceLabelWidth: 224, requireMode: 'partial' },
+  argTypes: {
+    forceLabelWidth: { control: { type: 'number' } },
+  },
+};

--- a/stories/form.stories.tsx
+++ b/stories/form.stories.tsx
@@ -1021,3 +1021,12 @@ export const ResponsiveLabelSqueeze = {
     forceLabelWidth: { control: { type: 'number' } },
   },
 };
+
+// The same shape with a rem cap instead of a px one. A px value computed once at
+// module load cannot follow a root font size that changes with the viewport; a
+// string cap is resolved by the browser, so it tracks it.
+export const ResponsiveLabelSqueezeRemCap = {
+  ...ResponsiveLabelSqueeze,
+  args: { ...ResponsiveLabelSqueeze.args, forceLabelWidth: '15rem' },
+  argTypes: { forceLabelWidth: { control: { type: 'text' } } },
+};


### PR DESCRIPTION
## TL;DR

In a `responsive` Form, a label column with an explicit width now gives ground at the same time as the field beside it, instead of holding its full width until the field hits its floor and the row stacks.

## Context

`CUI-32`/`CUI-36` already let the label column shrink. What it does not do is shrink *in time*: a section with `forceLabelWidth` kept its full cap while the field walked all the way down to `10rem`, so a form ran out of room while a third of it was still label.

## Approach

A grid track satisfies its **max** before a flexible track flexes. `minmax(min-content, 224px)` therefore takes its 224px first, and `minmax(10rem, 1fr)` absorbs the entire squeeze. Clamping the cap to a share of the container makes the two shrink together:

Before:
```ts
const labelTrack = responsive
  ? `minmax(min-content, ${labelWidthCap})`   // ←
  : labelWidthCap;
```

After:
```ts
const labelTrack = responsive
  ? `minmax(min-content, ${
      labelWidth ? `min(${labelWidth}, ${LABEL_MAX_CQI}cqi)` : labelWidthCap   // ←
    })`
  : labelWidthCap;
```

`cqi` resolves against the `responsive` container the Form already establishes, so this needs no measurement and no new prop. Above ~2.5× the cap the fraction is the larger of the two and the column is sized exactly as before.

`40cqi` is a **starting point for review on the preview, not a derived constant** — it is "slightly under half, with the column gap and padding accounted for".

Measured on the `ResponsiveLabelSqueeze` story — container width → label track / field track (widest input):

| `forceLabelWidth` | Container | Before | After |
| --- | --- | --- | --- |
| 224 | 520 | 224 / 233 (206) | 208 / 249 (222) |
| 224 | 480 | 224 / 193 (167) | 192 / 225 (198) |
| 224 | 440 | 221 / 156 (132) | 176 / 201 (174) |
| 265 | 620 | 265 / 309 (282) | 248 / 309 (282) |
| 265 | 520 | 265 / 192 (167) | 208 / 249 (222) |
| 265 | 460 | 241 / 156 (132) | 184 / 213 (186) |
| 265 | 440 | 241 / 156 (132) | *stacked* |

Zero overflow at every width in both columns; after the change the field never reaches its floor.

**The stacking threshold was also wrong for any wide cap.** It was a module constant built from `LABEL_MIN_CH`, so a section capped at 265px needed 437px to fit but did not stack until ~367px — a 70px band where the field sat pinned at its floor with no recovery. It is now derived from the section's own label width. An auto-sized column keeps the `24ch` floor, so that case is unchanged.

## Screenshots

<!-- Storybook › Templates/Form › ResponsiveLabelSqueeze — drag the frame from 60rem down through 440px, at forceLabelWidth 224 and 265. Capture the 480px state in both, side by side: before, the label is still at full width and the input is visibly starved; after, both have given ground. -->

## Usage

`forceLabelWidth` now takes a CSS length as well as a pixel number, so a cap can follow the root font size instead of being computed once. Both forms are in the stories:

Before:
```tsx
<FormSection title={{ name: 'Identity', icon: 'Account' }} forceLabelWidth={224}>
```

After — either is valid, the string form is new:
```tsx
<FormSection title={{ name: 'Identity', icon: 'Account' }} forceLabelWidth="15rem">   // ←
```

## Review focus

- 🟡 `form/Form.component.tsx` › `FormSection` / `labelTrack` — the `min(cap, 40cqi)` clamp. It changes resting appearance on every `responsive` form with an explicit label cap, between roughly 1024 and 1200px. This is the number to argue about.
- 🟡 `form/Form.component.tsx` › `stackBelow` — the threshold moved from a module constant to a per-section value threaded through `SectionGrid` and `FieldSubgridRow` as `$stackBelow`. Same plumbing as the existing `$labelTrack`, no new context, but it is the change that alters *when* a section stacks.
- ⚪ `form/Form.component.tsx` › `forceLabelWidth` — widened to `number | string`. Additive; a bare number still means px.

## How to test

1. `npm run storybook`
2. Templates → Form → **ResponsiveLabelSqueeze**. Drag the dashed frame's right edge inward. The label column should start shrinking well before the input reaches its minimum, and the row should stack only once both are genuinely out of room.
3. Set the `forceLabelWidth` control to `265` and repeat — it should stack before anything overflows, which it previously did not.
4. **ResponsiveLabelSqueezeRemCap** — the same shape with a `15rem` cap; the column should track the root font size.
5. Every other Form story should be unchanged at full width.

## Follow-up

The `40cqi` share needs a designer's call on a live preview before this leaves draft.

## References

- `CUI-32` / `CUI-36` — made the label column shrink at all; this PR is about when.
