### PR TITLE
Form: reserve the scroll gutter and dim the FormGroup label

### DIFF
--- a/src/lib/components/form/Form.component.tsx
+++ b/src/lib/components/form/Form.component.tsx
@@ -139,6 +139,12 @@ const ScrollArea = styled(BasicPageLayout)`
   flex-grow: 1;
   align-self: stretch;
   overflow-y: auto;
+  /* Reserve the scrollbar's width whether or not it is showing. Without it a form
+     that grows past its box moves every field left by the scrollbar's width the
+     moment it becomes scrollable, and the bar sits directly against the fields
+     because the tab layout's 16px inset comes from an ancestor outside this
+     scroller. */
+  scrollbar-gutter: stable;
 `;
 
 // A FormSection lays its FormGroups out so labels align across the section from
@@ -334,7 +340,9 @@ const FormGroup = ({
       id={`${LABEL_PREFIX}${id}`}
       style={{ opacity: disabled ? 0.5 : 1 }}
     >
-      <Text>
+      {/* The key of a key/value pair: dimmer than the value beside it, so the two
+          are told apart by tone rather than by position alone. */}
+      <Text color="textSecondary">
         {label}
         {requireMode !== 'all' && required && ' *'}
         {requireMode === 'all' && !required && ' (optional)'}

--- a/stories/form.stories.tsx
+++ b/stories/form.stories.tsx
@@ -958,3 +958,69 @@ export const ResponsivePageFormInFlexRow = {
   ),
   args: { requireMode: 'partial', responsive: true },
 };
+
+// The two things this pair of changes affects, in one view. The frame is short on
+// purpose so the form scrolls:
+//   - the scrollbar now has a reserved gutter, so it no longer sits against the
+//     field edges and the fields do not jump left when the form becomes scrollable
+//     (drag the bottom edge past the last field and back to see the difference);
+//   - the FormGroup label is `textSecondary`, so the key reads as dimmer than the
+//     value beside it. Compare the disabled row, which dims further at 50% opacity.
+export const ScrollGutterAndLabelTone = {
+  render: ({ requireMode }) => (
+    <div
+      style={{
+        resize: 'vertical',
+        overflow: 'auto',
+        height: '18rem',
+        width: '38rem',
+        maxWidth: '100%',
+        border: '1px dashed #666',
+      }}
+    >
+      <Form layout={{ kind: 'tab' }} requireMode={requireMode} responsive>
+        <FormSection title={{ name: 'Identity', icon: 'Account' }}>
+          <FormGroup
+            direction="horizontal"
+            label="User name"
+            id="gt-name"
+            content={<Input id="gt-name" />}
+            required
+          />
+          <FormGroup
+            direction="horizontal"
+            label="Description"
+            id="gt-desc"
+            content={<Input id="gt-desc" />}
+          />
+          <FormGroup
+            direction="horizontal"
+            label="Created on"
+            id="gt-created"
+            content={<Input id="gt-created" />}
+            disabled
+          />
+          <FormGroup
+            direction="horizontal"
+            label="Owner"
+            id="gt-owner"
+            content={<Input id="gt-owner" />}
+          />
+          <FormGroup
+            direction="horizontal"
+            label="Contact email"
+            id="gt-email"
+            content={<Input id="gt-email" />}
+          />
+          <FormGroup
+            direction="horizontal"
+            label="Notes"
+            id="gt-notes"
+            content={<Input id="gt-notes" />}
+          />
+        </FormSection>
+      </Form>
+    </div>
+  ),
+  args: { requireMode: 'partial' },
+};


### PR DESCRIPTION
## TL;DR

Two resting-appearance changes to `Form`: the scroll area reserves a gutter for its scrollbar, and a `FormGroup`'s label renders dimmer than the value beside it.

## Context

Both come from a design review of forms at narrow widths: the scrollbar sat directly against the fields, and a key/value row read as two columns of equally weighted text with the pairing left to be inferred from position.

## Approach

Bundled into one PR because they are one designer look at the same component, not because they share a mechanism.

**Gutter.** A `page` form insets its content 16px on the right; a `tab` form's inset comes from an ancestor *outside* the scroller, so the bar lands against the fields. Independently, either layout shifted every field left by the scrollbar's width at the moment the form grew past its box.

```
const ScrollArea = styled(BasicPageLayout)`
  flex-grow: 1;
  align-self: stretch;
  overflow-y: auto;
  scrollbar-gutter: stable;   // ←
`;
```

Chosen over adding `padding-right` to the `tab` branch: padding is the smaller diff and would match `page` exactly, but it re-introduces the reflow the moment a form crosses into scrolling. Note this reserves the **scrollbar's** width, not 16px — if a visible gap is wanted as well it is the gutter *plus* padding, which is a decision for the preview.

**Label tone.** One line, `<Text>` → `<Text color="textSecondary">`. The value keeps `textPrimary`, so the contrast comes from dimming the key rather than emphasising the value.

## Screenshots

<!-- Storybook › Templates/Form › ScrollGutterAndLabelTone. Two captures: (1) the frame short enough to scroll, showing the gutter between the bar and the field edges; (2) the same rows before/after the label tone change, including the disabled row so the compounded dimming is visible. -->

## Review focus

- 🟡 `form/Form.component.tsx` › `FormGroup` label — `textSecondary` restyles every form label in every consuming application. One line, entirely a design call.
- 🟡 `form/Form.component.tsx` › `ScrollArea` — `scrollbar-gutter: stable` applies to both layouts, so every scrolling form gains a few px of right gutter.
- ⚪ `stories/form.stories.tsx` › `ScrollGutterAndLabelTone` — a deliberately short frame so both changes are visible in one view.

## How to test

1. `npm run storybook`
2. Templates → Form → **ScrollGutterAndLabelTone**.
3. Drag the frame's bottom edge until the form scrolls and back again. The fields should not shift horizontally as the scrollbar appears, and the bar should not touch them.
4. Check the label tone against the values, and specifically the disabled row — a disabled label is dimmed a second time by its `0.5` opacity, and may want to keep the primary tone rather than compound the two.
5. Confirm the custom scrollbar treatment (`ScrollbarWrapper` / `.scroll-fade`) still composes with the gutter.

## Follow-up

Needs designer sign-off on a live preview before it leaves draft — both halves change resting appearance fleet-wide.

## References

- Both items come from the same design review; the gutter is "adjust scrollbar layout" and the tone is the key/value standardisation item.
