### PR TITLE
CopyButton: make iconOnly actually collapse an outline button

### DIFF
--- a/src/lib/components/buttonv2/CopyButton.component.test.tsx
+++ b/src/lib/components/buttonv2/CopyButton.component.test.tsx
@@ -227,6 +227,62 @@ describe("CopyButton", () => {
 		});
 	});
 
+	// The one place the repo's "no CSS assertions" rule has to bend: the floor is a
+	// value this component computes, not a stylesheet rule read back, and jsdom has
+	// no layout to observe the collapse it blocks. Kept to a single test.
+	it("computes the outline width floor: default on, dropped by iconOnly, overridable", () => {
+		const { unmount } = render(
+			<CopyButton variant="outline" textToCopy="x" label="key" />,
+			{ wrapper: Wrapper },
+		);
+		expect(screen.getByRole("button", { name: "Copy key" })).toHaveStyle({
+			minWidth: "8.5rem",
+		});
+		unmount();
+
+		const collapsed = render(
+			<CopyButton variant="outline" textToCopy="x" label="key" iconOnly />,
+			{ wrapper: Wrapper },
+		);
+		expect(
+			screen.getByRole("button", { name: "Copy key" }).style.minWidth,
+		).toBe("");
+		collapsed.unmount();
+
+		render(
+			<CopyButton
+				variant="outline"
+				textToCopy="x"
+				label="key"
+				style={{ minWidth: "2rem" }}
+			/>,
+			{ wrapper: Wrapper },
+		);
+		expect(screen.getByRole("button", { name: "Copy key" })).toHaveStyle({
+			minWidth: "2rem",
+		});
+	});
+
+	it("keeps the label as the accessible name once collapsed to its icon", async () => {
+		const writeTextMock = navigator.clipboard.writeText as jest.Mock;
+		writeTextMock.mockResolvedValueOnce(undefined);
+
+		render(
+			<CopyButton variant="outline" textToCopy="x" label="key" iconOnly />,
+			{ wrapper: Wrapper },
+		);
+
+		await act(() =>
+			userEvent.click(screen.getByRole("button", { name: "Copy key" })),
+		);
+
+		await waitFor(() => {
+			expect(
+				screen.getByRole("button", { name: "Copied key!" }),
+			).toBeInTheDocument();
+		});
+	});
+
 	it("outline variant with label: tooltip is Copy {label} then Copied {label}! on success", async () => {
 		const writeTextMock = navigator.clipboard.writeText as jest.Mock;
 		writeTextMock.mockResolvedValueOnce(undefined);

--- a/src/lib/components/buttonv2/CopyButton.component.test.tsx
+++ b/src/lib/components/buttonv2/CopyButton.component.test.tsx
@@ -227,42 +227,6 @@ describe("CopyButton", () => {
 		});
 	});
 
-	// The one place the repo's "no CSS assertions" rule has to bend: the floor is a
-	// value this component computes, not a stylesheet rule read back, and jsdom has
-	// no layout to observe the collapse it blocks. Kept to a single test.
-	it("computes the outline width floor: default on, dropped by iconOnly, overridable", () => {
-		const { unmount } = render(
-			<CopyButton variant="outline" textToCopy="x" label="key" />,
-			{ wrapper: Wrapper },
-		);
-		expect(screen.getByRole("button", { name: "Copy key" })).toHaveStyle({
-			minWidth: "8.5rem",
-		});
-		unmount();
-
-		const collapsed = render(
-			<CopyButton variant="outline" textToCopy="x" label="key" iconOnly />,
-			{ wrapper: Wrapper },
-		);
-		expect(
-			screen.getByRole("button", { name: "Copy key" }).style.minWidth,
-		).toBe("");
-		collapsed.unmount();
-
-		render(
-			<CopyButton
-				variant="outline"
-				textToCopy="x"
-				label="key"
-				style={{ minWidth: "2rem" }}
-			/>,
-			{ wrapper: Wrapper },
-		);
-		expect(screen.getByRole("button", { name: "Copy key" })).toHaveStyle({
-			minWidth: "2rem",
-		});
-	});
-
 	it("keeps the label as the accessible name once collapsed to its icon", async () => {
 		const writeTextMock = navigator.clipboard.writeText as jest.Mock;
 		writeTextMock.mockResolvedValueOnce(undefined);

--- a/src/lib/components/buttonv2/CopyButton.component.tsx
+++ b/src/lib/components/buttonv2/CopyButton.component.tsx
@@ -6,25 +6,19 @@ import { Button, type Props } from './Buttonv2.component';
 // The outline variant swaps its label on success ("Copy X" -> "Copied X!"), so the
 // button reserves room for the longer string and keeps its width when clicked.
 //
-// The reservation is a character-count heuristic, carried over unchanged from when
-// this was an inline style: `7rem` is the fixed part -- icon, padding, border and
-// the word "Copied!" -- and `length / 2` adds 0.5rem per label character as a
-// stand-in for average character width. That average is the weak point. Measured at
-// the 14px root the floor grows 7px per character against ~6px of real text, so it
-// over-reserves for a narrow label and is too small for an all-uppercase one, where
-// the content outgrows the floor and the button resizes on click anyway.
+// Character-count heuristic, inherited unchanged: `7rem` for the fixed part (icon,
+// padding, border, "Copied!") plus 0.5rem per label character as an average width.
+// The average under-reserves for an all-uppercase label, which still resizes.
 const outlineWidthFloor = (label?: string) =>
   `${(label ? label.length / 2 : 0) + 7}rem`;
 
 /**
  * A `Button` carrying the outline variant's width floor.
  *
- * The floor is a stylesheet rule rather than an inline `style` because `iconOnly`
- * hides the label through a `@container` query and an inline style outranks every
- * stylesheet rule — so an inline floor held a collapsed button at its full labelled
- * width with nothing in it. The breakpoint is read from `iconOnly` itself rather
- * than passed in beside it, so the floor and the label cannot answer to different
- * widths.
+ * A stylesheet rule, not an inline `style`: `iconOnly` hides the label via a
+ * `@container` query, which an inline style outranks -- so an inline floor held a
+ * collapsed button at its full labelled width. The breakpoint is read from
+ * `iconOnly` itself so the floor and the label cannot disagree.
  */
 const FlooredButton = styled(Button)<{ $floor?: string }>`
   min-width: ${({ $floor }) => $floor ?? 'auto'};

--- a/src/lib/components/buttonv2/CopyButton.component.tsx
+++ b/src/lib/components/buttonv2/CopyButton.component.tsx
@@ -3,9 +3,23 @@ import styled from 'styled-components';
 import { Icon } from '../icon/Icon.component';
 import { Button, type Props } from './Buttonv2.component';
 
-// The outline variant swaps its label on success ("Copy X" -> "Copied X!"), which
-// is a character wider, so the button reserves room for the longer string and keeps
-// its width when clicked.
+// The outline variant swaps its label on success ("Copy X" -> "Copied X!"), three
+// characters wider, so the button reserves room for the longer string and keeps its
+// width when clicked.
+//
+// The reservation is a character-count heuristic, carried over unchanged from when
+// this was an inline style. `7rem` is the fixed part -- the icon, the padding, the
+// border and the word "Copied!" -- and `length / 2` adds 0.5rem per label character
+// as a stand-in for average character width.
+//
+// That average is the weak point, and it is worth knowing which way it fails.
+// Measured at the 14px root, the floor grows 7px per character while the rendered
+// text grows about 6px for an ordinary mixed-case label, 3.4px for one made of
+// narrow glyphs and 14.5px for one made of wide ones. So it holds for the labels
+// this component actually gets, over-reserves for narrow ones (an empty tail of up
+// to ~150px at 40 characters), and is simply too small for an all-uppercase label:
+// there the content outgrows the floor, the floor stops applying, and the button
+// resizes by ~16px on click anyway -- the very thing it exists to prevent.
 const outlineWidthFloor = (label?: string) =>
   `${(label ? label.length / 2 : 0) + 7}rem`;
 

--- a/src/lib/components/buttonv2/CopyButton.component.tsx
+++ b/src/lib/components/buttonv2/CopyButton.component.tsx
@@ -78,12 +78,19 @@ export const CopyButton = ({
       {...props}
       variant={variant === 'outline' ? 'outline' : undefined}
       style={{
-        ...props.style,
         ...(isSuccess && { cursor: 'not-allowed', opacity: 0.5 }),
+        // The floor reserves room for the label swap ("Copy X" -> "Copied X!") so
+        // the button keeps its width when clicked. `iconOnly` asks for the opposite
+        // — a button narrower than its label — and the floor wins, because it is an
+        // inline style the container query cannot reach. So an `iconOnly` copy
+        // button gets no floor and may widen by the one character the swap adds.
         minWidth:
-          variant === 'outline'
+          variant === 'outline' && !props.iconOnly
             ? `${(label ? label.length / 2 : 0) + 7}rem`
             : undefined,
+        // Last, so a consumer can override the floor (or anything else) from
+        // `style`. It used to be first, which made every value here unreachable.
+        ...props.style,
       }}
       label={
         variant === 'outline'

--- a/src/lib/components/buttonv2/CopyButton.component.tsx
+++ b/src/lib/components/buttonv2/CopyButton.component.tsx
@@ -1,6 +1,34 @@
 import { useEffect, useState } from 'react';
+import styled from 'styled-components';
 import { Icon } from '../icon/Icon.component';
 import { Button, type Props } from './Buttonv2.component';
+
+// The outline variant swaps its label on success ("Copy X" -> "Copied X!"), which
+// is a character wider, so the button reserves room for the longer string and keeps
+// its width when clicked.
+const outlineWidthFloor = (label?: string) =>
+  `${(label ? label.length / 2 : 0) + 7}rem`;
+
+/**
+ * A `Button` carrying the outline variant's width floor.
+ *
+ * The floor is a stylesheet rule rather than an inline `style` on purpose.
+ * `iconOnly` hides the label through a `@container` query, and an inline style
+ * outranks every stylesheet rule — so an inline floor held the button at its full
+ * labelled width with nothing in it, and the only way out was to switch the floor
+ * off in JS for every form of `iconOnly`, numeric ones included.
+ *
+ * The breakpoint is read from `iconOnly` itself rather than passed in beside it, so
+ * the floor and the label cannot end up answering to different widths: below it the
+ * label is hidden and the floor is gone, above it both are there and the button
+ * still does not resize on click.
+ */
+const FlooredButton = styled(Button)<{ $floor?: string }>`
+  min-width: ${({ $floor }) => $floor ?? 'auto'};
+  ${({ iconOnly }) =>
+    typeof iconOnly === 'number' &&
+    `@container responsive (max-width: ${iconOnly}px) { min-width: auto; }`}
+`;
 
 export const COPY_STATE_IDLE = 'idle';
 export const COPY_STATE_SUCCESS = 'success';
@@ -73,23 +101,21 @@ export const CopyButton = ({
 } & Omit<Props, 'tooltip' | 'label'>) => {
   const { copy, copyStatus } = useClipboard();
   const isSuccess = copyStatus === COPY_STATE_SUCCESS;
+  const { iconOnly } = props;
   return (
-    <Button
+    <FlooredButton
       {...props}
       variant={variant === 'outline' ? 'outline' : undefined}
+      // A button collapsed at every width has no label to reserve room for.
+      $floor={
+        variant === 'outline' && iconOnly !== true
+          ? outlineWidthFloor(label)
+          : undefined
+      }
       style={{
         ...(isSuccess && { cursor: 'not-allowed', opacity: 0.5 }),
-        // The floor reserves room for the label swap ("Copy X" -> "Copied X!") so
-        // the button keeps its width when clicked. `iconOnly` asks for the opposite
-        // — a button narrower than its label — and the floor wins, because it is an
-        // inline style the container query cannot reach. So an `iconOnly` copy
-        // button gets no floor and may widen by the one character the swap adds.
-        minWidth:
-          variant === 'outline' && !props.iconOnly
-            ? `${(label ? label.length / 2 : 0) + 7}rem`
-            : undefined,
-        // Last, so a consumer can override the floor (or anything else) from
-        // `style`. It used to be first, which made every value here unreachable.
+        // Last, so a consumer can override anything here from `style`. It used to
+        // be first, which made every value here unreachable.
         ...props.style,
       }}
       label={

--- a/src/lib/components/buttonv2/CopyButton.component.tsx
+++ b/src/lib/components/buttonv2/CopyButton.component.tsx
@@ -3,39 +3,28 @@ import styled from 'styled-components';
 import { Icon } from '../icon/Icon.component';
 import { Button, type Props } from './Buttonv2.component';
 
-// The outline variant swaps its label on success ("Copy X" -> "Copied X!"), three
-// characters wider, so the button reserves room for the longer string and keeps its
-// width when clicked.
+// The outline variant swaps its label on success ("Copy X" -> "Copied X!"), so the
+// button reserves room for the longer string and keeps its width when clicked.
 //
 // The reservation is a character-count heuristic, carried over unchanged from when
-// this was an inline style. `7rem` is the fixed part -- the icon, the padding, the
-// border and the word "Copied!" -- and `length / 2` adds 0.5rem per label character
-// as a stand-in for average character width.
-//
-// That average is the weak point, and it is worth knowing which way it fails.
-// Measured at the 14px root, the floor grows 7px per character while the rendered
-// text grows about 6px for an ordinary mixed-case label, 3.4px for one made of
-// narrow glyphs and 14.5px for one made of wide ones. So it holds for the labels
-// this component actually gets, over-reserves for narrow ones (an empty tail of up
-// to ~150px at 40 characters), and is simply too small for an all-uppercase label:
-// there the content outgrows the floor, the floor stops applying, and the button
-// resizes by ~16px on click anyway -- the very thing it exists to prevent.
+// this was an inline style: `7rem` is the fixed part -- icon, padding, border and
+// the word "Copied!" -- and `length / 2` adds 0.5rem per label character as a
+// stand-in for average character width. That average is the weak point. Measured at
+// the 14px root the floor grows 7px per character against ~6px of real text, so it
+// over-reserves for a narrow label and is too small for an all-uppercase one, where
+// the content outgrows the floor and the button resizes on click anyway.
 const outlineWidthFloor = (label?: string) =>
   `${(label ? label.length / 2 : 0) + 7}rem`;
 
 /**
  * A `Button` carrying the outline variant's width floor.
  *
- * The floor is a stylesheet rule rather than an inline `style` on purpose.
- * `iconOnly` hides the label through a `@container` query, and an inline style
- * outranks every stylesheet rule — so an inline floor held the button at its full
- * labelled width with nothing in it, and the only way out was to switch the floor
- * off in JS for every form of `iconOnly`, numeric ones included.
- *
- * The breakpoint is read from `iconOnly` itself rather than passed in beside it, so
- * the floor and the label cannot end up answering to different widths: below it the
- * label is hidden and the floor is gone, above it both are there and the button
- * still does not resize on click.
+ * The floor is a stylesheet rule rather than an inline `style` because `iconOnly`
+ * hides the label through a `@container` query and an inline style outranks every
+ * stylesheet rule — so an inline floor held a collapsed button at its full labelled
+ * width with nothing in it. The breakpoint is read from `iconOnly` itself rather
+ * than passed in beside it, so the floor and the label cannot answer to different
+ * widths.
  */
 const FlooredButton = styled(Button)<{ $floor?: string }>`
   min-width: ${({ $floor }) => $floor ?? 'auto'};

--- a/src/lib/components/buttonv2/CopyButton.component.tsx
+++ b/src/lib/components/buttonv2/CopyButton.component.tsx
@@ -116,10 +116,10 @@ export const CopyButton = ({
           : undefined
       }
       style={{
-        ...(isSuccess && { cursor: 'not-allowed', opacity: 0.5 }),
-        // Last, so a consumer can override anything here from `style`. It used to
-        // be first, which made every value here unreachable.
         ...props.style,
+        // Last, so the success state cannot be styled away while clicks are still
+        // being swallowed.
+        ...(isSuccess && { cursor: 'not-allowed', opacity: 0.5 }),
       }}
       label={
         variant === 'outline'

--- a/stories/copybutton.stories.tsx
+++ b/stories/copybutton.stories.tsx
@@ -1,6 +1,6 @@
 import { Meta, StoryObj } from '@storybook/react-webpack5';
 import React from 'react';
-import { CopyButton } from '../src/lib/next';
+import { Box, CopyButton, Stack, Text } from '../src/lib/next';
 import { Wrapper } from './common';
 
 type Story = StoryObj<typeof CopyButton>;
@@ -55,4 +55,53 @@ export const OutlinedCopyButtonWithBigLabel: Story = {
     label: 'Certificate',
     textToCopy: 'Certificate',
   },
+};
+
+// `iconOnly` on an outline copy button: the width floor that keeps the button from
+// resizing on click used to be applied unconditionally, so the button stayed ~8.5rem
+// wide with nothing in it. Both forms are shown — `true` collapses always, a number
+// collapses below that container width, which needs the `container` Box to resolve.
+export const OutlinedCopyButtonIconOnly: StoryObj = {
+  render: () => (
+    <Wrapper className="storybook-button" style={{ height: 'auto' }}>
+      <Stack direction="vertical" gap="r16">
+        <Stack direction="vertical" gap="r4">
+          <Text>iconOnly — collapsed at every width</Text>
+          <Box>
+            <CopyButton
+              variant="outline"
+              label="Certificate"
+              textToCopy="Certificate"
+              iconOnly
+            />
+          </Box>
+        </Stack>
+        <Stack direction="vertical" gap="r4">
+          <Text>
+            iconOnly={'{240}'} — drag the frame below 240px to collapse it
+          </Text>
+          <div
+            style={{
+              resize: 'horizontal',
+              overflow: 'auto',
+              width: '20rem',
+              minWidth: '8rem',
+              maxWidth: '100%',
+              border: '1px dashed #666',
+              padding: '0.5rem',
+            }}
+          >
+            <Box container>
+              <CopyButton
+                variant="outline"
+                label="Certificate"
+                textToCopy="Certificate"
+                iconOnly={240}
+              />
+            </Box>
+          </div>
+        </Stack>
+      </Stack>
+    </Wrapper>
+  ),
 };

--- a/stories/copybutton.stories.tsx
+++ b/stories/copybutton.stories.tsx
@@ -59,15 +59,11 @@ export const OutlinedCopyButtonWithBigLabel: Story = {
   },
 };
 
-// `iconOnly` on an outline copy button. The floor that stops the button resizing
-// when its label swaps on success used to be applied unconditionally, so a collapsed
-// button kept its full labelled width with nothing in it.
-//
-// Both forms are shown. `true` collapses at every width, so there is no label to
-// reserve room for and no floor. A number collapses below that container width —
-// which needs the `container` Box to resolve — and keeps the floor above it, so
-// drag the second frame back over 240px and the button should stay put when
-// clicked rather than growing by the character "Copied" adds.
+// `iconOnly` on an outline copy button, in both forms. `true` collapses at every
+// width, so there is no label to reserve room for and no floor. A number collapses
+// below that container width — which needs the `container` Box to resolve — and
+// keeps the floor above it, so drag the second frame back over 240px and the button
+// should stay put when clicked.
 export const OutlinedCopyButtonIconOnly: StoryObj = {
   render: () => (
     <Stack direction="vertical" gap="r16">

--- a/stories/copybutton.stories.tsx
+++ b/stories/copybutton.stories.tsx
@@ -65,45 +65,43 @@ export const OutlinedCopyButtonWithBigLabel: Story = {
 // collapses below that container width, which needs the `container` Box to resolve.
 export const OutlinedCopyButtonIconOnly: StoryObj = {
   render: () => (
-    <Wrapper className="storybook-button" style={{ height: 'auto' }}>
-      <Stack direction="vertical" gap="r16">
-        <Stack direction="vertical" gap="r4">
-          <Text>iconOnly — collapsed at every width</Text>
-          <Box>
+    <Stack direction="vertical" gap="r16">
+      <Stack direction="vertical" gap="r4">
+        <Text>iconOnly — collapsed at every width</Text>
+        <Box>
+          <CopyButton
+            variant="outline"
+            label="Certificate"
+            textToCopy="Certificate"
+            iconOnly
+          />
+        </Box>
+      </Stack>
+      <Stack direction="vertical" gap="r4">
+        <Text>
+          iconOnly={'{240}'} — drag the frame below 240px to collapse it
+        </Text>
+        <div
+          style={{
+            resize: 'horizontal',
+            overflow: 'auto',
+            width: '20rem',
+            minWidth: '8rem',
+            maxWidth: '100%',
+            border: '1px dashed #666',
+            padding: '0.5rem',
+          }}
+        >
+          <Box container>
             <CopyButton
               variant="outline"
               label="Certificate"
               textToCopy="Certificate"
-              iconOnly
+              iconOnly={240}
             />
           </Box>
-        </Stack>
-        <Stack direction="vertical" gap="r4">
-          <Text>
-            iconOnly={'{240}'} — drag the frame below 240px to collapse it
-          </Text>
-          <div
-            style={{
-              resize: 'horizontal',
-              overflow: 'auto',
-              width: '20rem',
-              minWidth: '8rem',
-              maxWidth: '100%',
-              border: '1px dashed #666',
-              padding: '0.5rem',
-            }}
-          >
-            <Box container>
-              <CopyButton
-                variant="outline"
-                label="Certificate"
-                textToCopy="Certificate"
-                iconOnly={240}
-              />
-            </Box>
-          </div>
-        </Stack>
+        </div>
       </Stack>
-    </Wrapper>
+    </Stack>
   ),
 };

--- a/stories/copybutton.stories.tsx
+++ b/stories/copybutton.stories.tsx
@@ -1,6 +1,8 @@
 import { Meta, StoryObj } from '@storybook/react-webpack5';
 import React from 'react';
-import { Box, CopyButton, Stack, Text } from '../src/lib/next';
+import { Box, CopyButton } from '../src/lib/next';
+import { Text } from '../src/lib/components/text/Text.component';
+import { Stack } from '../src/lib/spacing';
 import { Wrapper } from './common';
 
 type Story = StoryObj<typeof CopyButton>;

--- a/stories/copybutton.stories.tsx
+++ b/stories/copybutton.stories.tsx
@@ -59,10 +59,15 @@ export const OutlinedCopyButtonWithBigLabel: Story = {
   },
 };
 
-// `iconOnly` on an outline copy button: the width floor that keeps the button from
-// resizing on click used to be applied unconditionally, so the button stayed ~8.5rem
-// wide with nothing in it. Both forms are shown — `true` collapses always, a number
-// collapses below that container width, which needs the `container` Box to resolve.
+// `iconOnly` on an outline copy button. The floor that stops the button resizing
+// when its label swaps on success used to be applied unconditionally, so a collapsed
+// button kept its full labelled width with nothing in it.
+//
+// Both forms are shown. `true` collapses at every width, so there is no label to
+// reserve room for and no floor. A number collapses below that container width —
+// which needs the `container` Box to resolve — and keeps the floor above it, so
+// drag the second frame back over 240px and the button should stay put when
+// clicked rather than growing by the character "Copied" adds.
 export const OutlinedCopyButtonIconOnly: StoryObj = {
   render: () => (
     <Stack direction="vertical" gap="r16">


### PR DESCRIPTION
**TL;DR** — `iconOnly` had no visible effect on an outline `CopyButton`: the label was hidden but the button kept its full width, leaving a lone icon in a wide empty box. It now collapses to the icon, and `iconOnly={240}` stays full width until its container drops below 240px.

## Context

`iconOnly` is the affordance a narrow container reaches for, and on an outline `CopyButton` it did nothing visible: the button stayed a wide outline box with one glyph in it. Found while making a password-field composite responsive — it was the one control in the row that could not narrow.

## Approach

The floor exists for a reason: an outline copy button's label swaps from `Copy X` to `Copied X!` on click, so without a reserved width the button resizes under the cursor. It was applied as an **inline style**, and that is the crux — an inline style outranks every stylesheet rule, so the `@container` query behind `iconOnly` could never reach it: `Button` dutifully hid the label while the box kept its full labelled width. Switching the floor off in JS would fix the boolean form and leave the numeric one half broken, so the floor moved into the stylesheet under the same query, reading its breakpoint off `iconOnly` itself rather than off a second copy of the number:

```ts
const FlooredButton = styled(Button)<{ $floor?: string }>`
  min-width: ${({ $floor }) => $floor ?? 'auto'};
  ${({ iconOnly }) =>                                                      // ←
    typeof iconOnly === 'number' &&
    `@container responsive (max-width: ${iconOnly}px) { min-width: auto; }`}
`;
```

| `iconOnly` | Floor | Result |
| --- | --- | --- |
| unset | always | never resizes on click |
| `true` | none emitted | no label to reserve room for |
| `240` | above 240px only | holds its width while labelled, collapses below |
| `0` | always | matches `Button`, which treats 0 as a breakpoint nothing is narrower than |

`0` is the row worth a second look: it is falsy, so a JS guard would read it as "always collapse" while `Button` reads it as "never collapse". Measured in a browser, since jsdom evaluates no `@container`: computed `min-width` is `175px` above the breakpoint and `0px` below it, and neither button carries an inline `min-width`.

## Screenshots

**CopyButton → Outlined Copy Button Icon Only** with the frame at its default 20rem — `iconOnly` is icon-width, `iconOnly={240}` is still labelled:

<img width="397" height="203" alt="cui1195-icononly-frame-20rem" src="https://github.com/user-attachments/assets/e2df576f-9a6d-4100-97f6-c672d63368f8" />

The same story with the frame dragged to 216px — the numeric form has collapsed too:

<img width="397" height="203" alt="cui1195-icononly-frame-216px" src="https://github.com/user-attachments/assets/133eb643-274b-49b9-a897-84c225b48b0a" />

## Usage

Sourced from the story in this diff. Before, `iconOnly` was accepted on an outline button but had no visible effect:

```tsx
<CopyButton variant="outline" label="Certificate" textToCopy="Certificate" />
```

After — either form collapses the button; the numeric form needs a `container` ancestor to resolve against, and keeps its no-resize floor above the breakpoint:

```tsx
<Box container>
  <CopyButton variant="outline" label="Certificate" textToCopy="Certificate" iconOnly={240} />
</Box>
```

## Review focus

- 🟡 `buttonv2/CopyButton.component.tsx` › `FlooredButton` — the floor moves from an inline style to a class, so a consumer's `style={{ minWidth }}` now wins over it where before it was silently ignored; intended, and the one thing here worth disagreeing with. The success-state `cursor`/`opacity` deliberately keeps its precedence over `style`, so it cannot be unstyled while clicks are still being swallowed.
- ⚪ `buttonv2/CopyButton.component.tsx` › `outlineWidthFloor` — the arithmetic is unchanged, only where it is applied; every outline `CopyButton` with no `iconOnly` renders the same floor as before.
- ⚪ `buttonv2/CopyButton.component.test.tsx` — the width-floor test is removed rather than adapted: jsdom cannot evaluate the query and `jest-styled-components` is not a dependency, so the assertion would have claimed more than it checked. The accessible-name test stays and the story is the gate.

## How to test

1. `npm run storybook`, then Components → CopyButton → **Outlined Copy Button Icon Only**.
2. The first button should be icon-width, not a wide outline box; hovering it shows `Copy Certificate`.
3. The second is full width at the frame's default size. Click it — the label becomes `Copied Certificate!` and the button must **not** change width. This is the one check no automated test covers: an isolated browser cannot be granted `clipboard-write`, so the success state never engages there.
4. Drag that frame below 240px: the button collapses to its icon, and returns to full width above 240px again. Click it while collapsed — the accessible name becomes `Copied Certificate!` and the icon turns into a check.
5. The other `Outlined Copy Button*` stories should be unchanged — same width, no resize on click.
