### PR TITLE
Form: keep the content clear of the scrollbar in both layouts

### DIFF
--- a/src/lib/components/form/Form.component.tsx
+++ b/src/lib/components/form/Form.component.tsx
@@ -152,6 +152,12 @@ const ScrollArea = styled(BasicPageLayout)`
   flex-grow: 1;
   align-self: stretch;
   overflow-y: auto;
+  /* Reserve the scrollbar's width whether or not it is showing. Without it a form
+     that grows past its box moves every field left by the scrollbar's width the
+     moment it becomes scrollable, and the bar sits directly against the fields
+     because the tab layout's 16px inset comes from an ancestor outside this
+     scroller. */
+  scrollbar-gutter: stable;
 `;
 
 // A FormSection lays its FormGroups out so labels align across the section from

--- a/src/lib/components/form/Form.component.tsx
+++ b/src/lib/components/form/Form.component.tsx
@@ -112,6 +112,11 @@ const StyledForm = styled.form<{
 // `width: 100%` needs `box-sizing: border-box`, or the content-box padding
 // overflows the parent by exactly that padding. The cap then has to include the
 // padding to keep the same 45rem of *content* the pinned width gave.
+//
+// Both branches carry the same `padding-right`: padding on an ancestor insets the
+// scrollbar along with the content, so only the scroller's own layout can put
+// space between the two. The header and footer share it so their actions line up
+// with the fields.
 const PAGE_CONTENT_MAX_WIDTH = '45rem';
 const BasicPageLayout = styled.div<{ $layoutKind: 'page' | 'tab' }>`
   box-sizing: border-box;
@@ -125,6 +130,7 @@ const BasicPageLayout = styled.div<{ $layoutKind: 'page' | 'tab' }>`
   `
       : `
   width: 100%;
+  padding-right: ${spacing.f16};
   padding-bottom: ${spacing.r24};`}
 `;
 
@@ -152,11 +158,9 @@ const ScrollArea = styled(BasicPageLayout)`
   flex-grow: 1;
   align-self: stretch;
   overflow-y: auto;
-  /* Reserve the scrollbar's width whether or not it is showing. Without it a form
-     that grows past its box moves every field left by the scrollbar's width the
-     moment it becomes scrollable, and the bar sits directly against the fields
-     because the tab layout's 16px inset comes from an ancestor outside this
-     scroller. */
+  /* Reserve the bar's width whether or not it is showing, so the fields do not
+     shift left the moment the form starts scrolling. This reserves only the space
+     the bar occupies; the gap between bar and content is the padding-right above. */
   scrollbar-gutter: stable;
 `;
 


### PR DESCRIPTION
Was: a `Form`'s scrollbar sat directly against its fields, with no space between them, and the content jumped sideways the moment the form started scrolling. Now: there is a gap, and nothing moves as scrolling starts or stops.

<img width="1144" height="421" alt="cui1196-scroll-gutter-comparison" src="https://github.com/user-attachments/assets/57f1a8c4-cf46-41ec-8929-7337d4aef2fc" />

`Templates/Form → Nesting And Non Field Content`, whose `Banner` spans the full section width and so reaches the content's right edge. Clearance from the bar goes from **0px** to **16px**; the bar is 11px, as the library's own scrollbar skin renders it in Chromium.

## Context

Reported by a designer against a `tab`-layout form. Split out of #1194, whose other half — a label-tone change that needs a design call — continues in #1197.

## Approach

Two declarations, two different effects; neither alone does the job.

| | What it does | What it does not do |
| --- | --- | --- |
| `padding-right: 16px` on the shared layout | puts real space between the content and the bar | nothing at all while the form is not scrolling |
| `scrollbar-gutter: stable` on the scroll area | reserves the bar's width unconditionally, so content no longer jumps inward by that width the instant the box starts scrolling | it reserves the space the bar *occupies* — on its own the content still ends exactly where the bar begins |

The padding has to be the form's own: padding on an ancestor insets the scrollbar along with the content, so it can never get *between* the two. That is why a surrounding panel's inset, however large, left the bar on the fields. It goes on `BasicPageLayout` — shared by the header, the scroll area and the footer — so a header or footer action keeps the same inset as the content between them.

## Review focus

- 🟡 `form/Form.component.tsx` › `BasicPageLayout` — every `tab`-layout form loses 16px of content width on the right, and its header actions move in by the same amount; visual only, no API change. A consumer that already pads its own right edge will now show both insets and should drop its own.
- 🟡 `form/Form.component.tsx` › `ScrollArea` — `scrollbar-gutter: stable` applies to both layouts, so a form that does *not* scroll is inset by the bar's width too. That is the point — no shift when it starts scrolling — but it is a permanent few px wherever scrollbars are classic.

## How to test

1. `npm run storybook`, then Templates → Form → **Nesting And Non Field Content** — a `tab` form tall enough to scroll. Its `Banner` spans the section's full width, so its right edge *is* the content edge: check it now stops short of the scrollbar instead of touching it. A text field cannot show this — an `Input` is 20.5rem by default and stops nowhere near the edge.
2. Drag the frame's bottom edge until the form no longer scrolls, then back. Nothing should move horizontally as it crosses that boundary. Where the scrollbar is a zero-width overlay, neither effect is visible.

## Follow-up

- An action *outside* the scroll area (the header in a `tab` form, the footer in a `page` one) is inset by the layout's padding but not by the bar's width, so it lands a few px wide of the scrolling content's edge. Pre-existing, and what the `page` layout has always done; aligning them exactly means measuring the bar at runtime, as `tablev2` already does.

## References

- #1194 — the PR this was split out of; its label-tone half continues in #1197.
