### PR TITLE
Form: dim the FormGroup label so a row reads as key and value

### DIFF
--- a/src/lib/components/form/Form.component.tsx
+++ b/src/lib/components/form/Form.component.tsx
@@ -361,7 +361,11 @@ const FormGroup = ({
       id={`${LABEL_PREFIX}${id}`}
       style={{ opacity: disabled ? 0.5 : 1 }}
     >
-      <Text>
+      {/* The key of a key/value pair, dimmed so the pair reads by tone and not by
+          position alone. Disabled keeps the primary tone: the wrapping label is
+          already at 0.5 opacity, and compounding the two costs more contrast than
+          the pairing gains. */}
+      <Text color={disabled ? undefined : 'textSecondary'}>
         {label}
         {requireMode !== 'all' && required && ' *'}
         {requireMode === 'all' && !required && ' (optional)'}

--- a/src/lib/components/form/Form.test.tsx
+++ b/src/lib/components/form/Form.test.tsx
@@ -56,6 +56,38 @@ describe('Form', () => {
     expect(onSubmit).toHaveBeenCalled();
   });
 
+  /**
+   * The marker is appended to the label inside the same Text, so it is the piece
+   * that silently falls out of the accessible name -- or loses the space before it
+   * -- if that composition is restructured. Tone itself is deliberately not
+   * asserted: reading a colour declaration back out proves nothing.
+   */
+  it.each([
+    ['partial', 'User name', true, 'User name *'],
+    ['all', 'Description', false, 'Description (optional)'],
+  ])(
+    'keeps the %s-mode marker in the field accessible name',
+    (requireMode, label, required, expected) => {
+      render(
+        <Form
+          layout={{ kind: 'tab' }}
+          requireMode={requireMode as 'all' | 'partial'}
+        >
+          <FormSection>
+            <FormGroup
+              id="marker-field"
+              label={label}
+              required={required}
+              content={<input type="text" id="marker-field" />}
+            />
+          </FormSection>
+        </Form>,
+      );
+
+      expect(screen.getByRole('textbox')).toHaveAccessibleName(expected);
+    },
+  );
+
   it('keeps the labelled field visible and usable with responsive shrink', async () => {
     render(
       <Form layout={{ kind: 'tab' }} responsive>


### PR DESCRIPTION
**TL;DR** — A form row's label and its value no longer read as two equally weighted columns: the label is dimmer than the value it labels, so the pair reads by tone rather than by position.

<img width="1860" height="629" alt="cui1197-label-tone-comparison" src="https://github.com/user-attachments/assets/dd210178-d987-421a-a000-b169a65dfe06" />

*`Templates/Form → PageForm` on `darkRebrand`, two fields filled by hand because the story ships them empty and the pairing is the whole point. The before is this diff's single declaration reverted in place, so nothing else differs.*

### Context / Why

The dimming is the designer's own request. Split out of #1194 so the scroll-gutter repair there could merge without waiting on this design decision — that half has since landed as #1196.

### 🧩 Approach

**The require markers dim with the label rather than against it** — the label, the required `*` and the `(optional)` suffix all sit in one `<Text>`, and the two markers are opposites: `(optional)` says an obligation is absent, `*` says one exists. Dimming both is the right *default* on consistency grounds, since a `page` form already renders its "\* are required fields" legend in `textSecondary` italic, and a brighter marker on the field than on the legend explaining it would trade an invisible inconsistency for a visible one. **This is the hunk to push back on if the marker should stand out.**

**A disabled label keeps the primary tone**, since it is already dimmed by the `0.5` opacity on its wrapping `<label>` and compounding the two costs more contrast than the pairing gains. Contrast ratios against `backgroundLevel4`, computed from the theme's own hex values with the disabled label composited at 0.5 over that background:

| | disabled label, as shipped | if it dimmed too | enabled label (dimmed) |
| --- | --- | --- | --- |
| `darkRebrand` | 4.46:1 | 3.08:1 | 8.31:1 |
| `artescaLight` | 3.58:1 | 2.33:1 | 7.43:1 |

So the dimming itself is not a contrast question — an enabled label clears AA with room to spare. The guard exists because the *disabled* label already falls short of AA's 4.5:1 today, in both themes, and compounding would deepen it. WCAG 1.4.3 exempts inactive controls, so neither figure is a violation either way.

The help icon sits in a sibling `Box` outside the `<Text>`, so it keeps its own colour and is untouched by this change.

### 🔍 Review focus

- 🟡 **Moderate** — `form/Form.component.tsx` › `FormGroup` label — restyles every form label in every consuming application, with no opt-out. The dimmed key is the designer's own request; what is open is whether the required `*` should dim with it, and that is the one thing here worth disagreeing with.
- ⚪ **Minor** — `form/Form.component.tsx` › the disabled ternary — the only other conditional. It exists solely to stop two dimming mechanisms compounding, per the table above.
- ⚪ **Minor** — `form/Form.test.tsx` — pins the accessible names `User name *` and `Description (optional)`. The marker is appended inside the label's `Text`, so it is the piece that would silently fall out of that name, or lose the space before it, if the composition were restructured. Tone is deliberately not asserted.

### 🧪 How to test

1. `npm run storybook`, then Templates → Form → **PageForm**, and type something into a couple of fields. There is no story for this change: it is one declaration on every `FormGroup` label, so the existing forms carry it.
2. The rows should read as key-then-value rather than two equal columns. Judge whether `Email`'s `*` is legible enough at the label's tone — that is the open question.
3. Flip `requireMode` to `all` in the args panel, or open **AllRequiredPageForm**: `(optional)` should sit at the same tone as the label it qualifies.
4. The first row is disabled — it should read as dimmed once, by opacity, and not washed out relative to the enabled labels. Switch to `artescaLight`, where the rejected compounded version was worst.

### Follow-up

- **Needs designer sign-off before merge**, on the marker question only. Dev review does not need to wait — it is one line.
- The disabled label's AA shortfall is pre-existing and out of scope. Worth its own ticket if 3.58:1 is judged unacceptable.
- Only the `page` layout renders the "\* are required fields" legend, so a `tab`-layout form with `requireMode="partial"` shows the marker with nothing explaining it. Pre-existing and untouched, but it is the other half of the marker question.

### 🔗 References

- #1194 — the PR this was split out of; its scroll-gutter half merged as #1196.
