### PR TITLE
Form: keep a label's help icon on the label's last line

### DIFF
--- a/src/lib/components/form/Form.component.tsx
+++ b/src/lib/components/form/Form.component.tsx
@@ -10,9 +10,8 @@ import {
 } from 'react';
 import styled, { css } from 'styled-components';
 import { spacing, Stack, Wrap } from '../../spacing';
-import { Box } from '../box/Box';
 import { Icon, IconName } from '../icon/Icon.component';
-import { IconHelp } from '../iconhelper/IconHelper';
+import { HELP_ICON_SIZE, IconHelp } from '../iconhelper/IconHelper';
 import { ScrollbarWrapper } from '../scrollbarwrapper/ScrollbarWrapper.component';
 import { HelperText, Text } from '../text/Text.component';
 
@@ -285,16 +284,33 @@ const FieldSubgridRow = styled.div<{
   }}
 `;
 
-const GridLabelCell = styled.div<{ $hasHelpTooltip: boolean }>`
+const GridLabelCell = styled.div`
   min-width: 0;
-  ${({ $hasHelpTooltip }) =>
-    $hasHelpTooltip &&
+`;
+
+const HELP_ICON_RESERVE = `calc(${HELP_ICON_SIZE} + ${spacing.r8})`;
+
+/**
+ * Reserves the room the help icon sits in. The break opportunity is in front of the
+ * icon, so nothing on the icon's own box can suppress it. End padding on the label's
+ * inline box lands on its last line instead -- where the icon goes -- and counts
+ * toward min-content, so a column sized to the text fits the icon too.
+ */
+const LabelText = styled(Text)<{ $reserveHelpIcon: boolean }>`
+  ${({ $reserveHelpIcon }) =>
+    $reserveHelpIcon &&
     css`
-      /* The non-responsive column reserves 2rem beyond the label for the help
-         icon affordance; reserve the same here so the label column is identical
-         in both layouts. */
-      padding-right: ${spacing.r32};
+      padding-right: ${HELP_ICON_RESERVE};
     `}
+`;
+
+/**
+ * Pulled back onto the room `LabelText` reserved, by exactly its own width, so
+ * placing it costs the line nothing and no break is needed to fit it.
+ */
+const HelpIconSlot = styled.span`
+  display: inline-block;
+  margin-left: -${HELP_ICON_SIZE};
 `;
 
 // Carries the section's label-column config down to each FormGroup so a row can
@@ -365,22 +381,21 @@ const FormGroup = ({
           position alone. Disabled keeps the primary tone: the wrapping label is
           already at 0.5 opacity, and compounding the two costs more contrast than
           the pairing gains. */}
-      <Text color={disabled ? undefined : 'textSecondary'}>
+      <LabelText
+        color={disabled ? undefined : 'textSecondary'}
+        $reserveHelpIcon={!!labelHelpTooltip}
+      >
         {label}
         {requireMode !== 'all' && required && ' *'}
         {requireMode === 'all' && !required && ' (optional)'}
-      </Text>
+      </LabelText>
       {labelHelpTooltip && (
-        <Box
-          display="inline-block"
-          marginLeft={spacing.r8}
-          style={{ whiteSpace: 'nowrap' }}
-        >
+        <HelpIconSlot>
           <IconHelp
             tooltipMessage={labelHelpTooltip}
             overlayStyle={maxWidthTooltip}
           />
-        </Box>
+        </HelpIconSlot>
       )}
     </label>
   );
@@ -430,9 +445,7 @@ const FormGroup = ({
         $fixedLabel={sectionLabel.fixedLabel}
         $stackBelow={sectionLabel.stackBelow}
       >
-        <GridLabelCell $hasHelpTooltip={!!labelHelpTooltip}>
-          {labelContent}
-        </GridLabelCell>
+        <GridLabelCell>{labelContent}</GridLabelCell>
         {fieldContent}
       </FieldSubgridRow>
     </FieldContext.Provider>

--- a/src/lib/components/form/Form.test.tsx
+++ b/src/lib/components/form/Form.test.tsx
@@ -57,10 +57,11 @@ describe('Form', () => {
   });
 
   /**
-   * The marker is appended to the label inside the same Text, so it is the piece
-   * that silently falls out of the accessible name -- or loses the space before it
-   * -- if that composition is restructured. Tone itself is deliberately not
-   * asserted: reading a colour declaration back out proves nothing.
+   * The marker is appended to the label inside the same `LabelText`, so it is
+   * the piece that silently falls out of the accessible name -- or loses the
+   * space before it -- if that composition is restructured. Tone itself is
+   * deliberately not asserted: reading a colour declaration back out proves
+   * nothing.
    */
   it.each([
     ['partial', 'User name', true, 'User name *'],
@@ -87,6 +88,28 @@ describe('Form', () => {
       expect(screen.getByRole('textbox')).toHaveAccessibleName(expected);
     },
   );
+
+  // jsdom has no layout, so the icon's position is out of reach here. What this pins
+  // is that moving the icon out of its old wrapper kept it inside its label.
+  it('keeps the help affordance inside the label it annotates', () => {
+    render(
+      <Form layout={{ kind: 'page', title: 'Test Form' }}>
+        <FormSection>
+          <FormGroup
+            id="tls-field"
+            label="Enable LDAP Over TLS"
+            labelHelpTooltip="Encrypt the connection to the directory server."
+            content={<input type="text" id="tls-field" />}
+          />
+        </FormSection>
+      </Form>,
+    );
+
+    const help = screen.getByRole('button', { name: 'More information' });
+    expect(
+      screen.getByText('Enable LDAP Over TLS').closest('label'),
+    ).toContainElement(help);
+  });
 
   it('keeps the labelled field visible and usable with responsive shrink', async () => {
     render(

--- a/src/lib/components/iconhelper/IconHelper.tsx
+++ b/src/lib/components/iconhelper/IconHelper.tsx
@@ -18,18 +18,20 @@ type IconHelpProps = {
   title?: string;
 };
 
+export const HELP_ICON_SIZE = fontSize.base;
+
 const HelpButton = styled.button`
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  width: ${fontSize.base};
-  height: ${fontSize.base};
+  width: ${HELP_ICON_SIZE};
+  height: ${HELP_ICON_SIZE};
   background: none;
   border: none;
   padding: 0;
   margin: 0;
   color: inherit;
-  font-size: ${fontSize.base};
+  font-size: ${HELP_ICON_SIZE};
   line-height: 0;
   vertical-align: -0.125em;
   cursor: default;

--- a/stories/form.stories.tsx
+++ b/stories/form.stories.tsx
@@ -450,7 +450,7 @@ export const ResponsiveSizedInputs = {
             direction="horizontal"
             label="Default (size 1)"
             id="w-default"
-            labelHelpTooltip="The help icon reserves ~2rem in the label column"
+            labelHelpTooltip="The help icon reserves its own width plus a gap at the end of the label"
             content={<Input id="w-default" placeholder="20.5rem" />}
           />
           <FormGroup


### PR DESCRIPTION
**TL;DR** — A form label's help `?` no longer breaks onto a line of its own in a narrow label column: it stays on the label's last line, beside the final word.

<img width="1406" height="570" alt="cui1198-help-icon-comparison" src="https://github.com/user-attachments/assets/b866788a-c2aa-405a-8e04-b01b48f3dd74" />

*`Templates/Form → Form Group Help Icon Orphan` at its default frame width — the third row is the one that was broken even wide open.*

### Context / Why

As a label column narrows, the label text stays put and only the help icon moves: `Enable LDAP Over TLS *` keeps its line and the `?` drops onto a line of its own, left-aligned under it. Every form whose label column can be squeezed hits this, so it is not one form's problem.

### 🧩 Approach

The icon is an **atomic inline**, so the soft-wrap opportunity that fires is the one *in front of* it — the `white-space: nowrap` that looked like a guard sat on a box containing only the icon, which suppresses breaks *inside* it and never the break before it. The room is therefore reserved inline, where the break happens:

```ts
padding-right: calc(${HELP_ICON_SIZE} + ${spacing.r8});  // on the label's own inline box
margin-left: -${HELP_ICON_SIZE};                         // on the icon's slot: advance 0
```

End padding on an inline box lands at the end of its **last** line — exactly where the icon goes — and counts toward min-content, so a column sized to its text is now sized to the icon too; the icon is then pulled back onto that room by its own width, so placing it costs the line nothing.

**The reserve this replaces was causing the worst case rather than partly guarding against it.** `GridLabelCell`'s `padding-right: 2rem` sat *outside* the line box, so a content-sized column came out as label + 2rem, the text filled the content box exactly, and the icon had precisely zero room at every width — the third row below.

A `nowrap` group around the last word and the icon was rejected: it is narrower in the common case but takes no soft-wrap opportunity at all, so at a 150px column that unbreakable label overflows by ~105px instead of wrapping.

Story `FormGroupHelpIconOrphan`, `forceLabelWidth={150}`, sweeping the frame 640px → 280px. *Orphaned* = the icon's top is below the label's last line.

| Label | Before | After |
| --- | --- | --- |
| `Description` | orphans once the column reaches 120px | **never orphans** |
| `Enable LDAP Over TLS *` | wraps to two lines, icon follows the last one | unchanged |
| `AuthenticationConfigurationEndpoint` (one unbreakable word) | **orphaned at every width** | **never orphans** |

Below the width where the section stacks, a column narrower than one unbreakable word *plus* the icon still wraps the icon — there is genuinely no room, and wrapping beats overflowing.

### 🔍 Review focus

- 🟡 **Moderate** — `form/Form.component.tsx` › `LabelText` / `HelpIconSlot` / `GridLabelCell` — every label with a help tooltip changes shape, and the label column comes out **7px narrower** on a content-sized row: the reservation is now the icon's real width plus its gap (`1rem + spacing.r8` = 21px at a 14px root) instead of a flat `2rem` = 28px. Worth confirming the negative margin reads as deliberate and that the removed `GridLabelCell` reserve is not load-bearing elsewhere.
- ⚪ **Minor** — `iconhelper/IconHelper.tsx` › `HELP_ICON_SIZE` — new internal export, so the reservation and the icon it reserves for cannot drift apart. Not added to the public entry point; see Follow-up.

### 🧪 How to test

1. `npm run storybook`, open **Templates/Form → Form Group Help Icon Orphan**.
2. Drag the dashed frame from full width down to ~300px. The help icon should stay on its label's last line the whole way, in all three rows.
3. Check the third row (`AuthenticationConfigurationEndpoint`) at the *default* width too — that one was orphaned even with the frame wide open.
4. Sanity-check a form with ordinary labels — **Responsive Form**, **Responsive Sized Inputs**, **Page Form** — for an icon overflowing its label cell or text escaping it.

### Follow-up

- `HELP_ICON_SIZE` is internal. A consumer reserving room for the icon in its own layout has to restate the number by hand, which is the same silent-drift hazard this PR removes inside the library. Exporting it is a public-API decision rather than part of a bug fix.
- **Merge this before #1199.** That branch builds on `HELP_ICON_SIZE` and generalises the reserve pair into `IconHelper` so `Checkbox` can share it.

### 🔗 References

- [#1199](https://github.com/scality/core-ui/pull/1199) — applies the same technique to `Checkbox` and moves the reserve pair into `IconHelper`; stacked on this one.
