### PR TITLE
Checkbox: keep the box on the label's first line when the label wraps

### DIFF
--- a/src/lib/components/checkbox/Checkbox.component.test.tsx
+++ b/src/lib/components/checkbox/Checkbox.component.test.tsx
@@ -1,0 +1,41 @@
+import { render as rtlRender, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import React, { ReactElement } from 'react';
+import { CoreUiThemeProvider } from '../coreuithemeprovider/CoreUiThemeProvider';
+import { coreUIAvailableThemes } from '../../style/theme';
+import { Checkbox } from './Checkbox.component';
+
+const render = (ui: ReactElement) =>
+  rtlRender(
+    <CoreUiThemeProvider theme={coreUIAvailableThemes.darkRebrand}>
+      {ui}
+    </CoreUiThemeProvider>,
+  );
+
+// No test for the box being named after its label rather than after the help
+// affordance: jsdom's name computation stops short of the nested button and
+// reports the clean name whether the `aria-labelledby` is wired or not.
+describe('Checkbox', () => {
+  it('toggles when the label is clicked', async () => {
+    const onChange = jest.fn();
+    render(<Checkbox label="Enable versioning" onChange={onChange} />);
+
+    await userEvent.click(screen.getByText('Enable versioning'));
+
+    expect(onChange).toHaveBeenCalledTimes(1);
+  });
+
+  it('keeps the help affordance inside the label it annotates', () => {
+    render(
+      <Checkbox
+        label="Delete objects after replication"
+        labelHelpTooltip="Objects are removed from the source only once the destination confirms the write."
+      />,
+    );
+
+    const help = screen.getByRole('button', { name: 'More information' });
+    expect(
+      screen.getByText('Delete objects after replication').closest('label'),
+    ).toContainElement(help);
+  });
+});

--- a/src/lib/components/checkbox/Checkbox.component.tsx
+++ b/src/lib/components/checkbox/Checkbox.component.tsx
@@ -1,8 +1,15 @@
-import { ChangeEvent, InputHTMLAttributes, forwardRef } from 'react';
-import styled from 'styled-components';
-import { spacing, Stack } from '../../spacing';
+import {
+  ChangeEvent,
+  InputHTMLAttributes,
+  ReactNode,
+  forwardRef,
+  useId,
+} from 'react';
+import styled, { css } from 'styled-components';
+import { spacing } from '../../spacing';
 
-import { Text } from '../text/Text.component';
+import { helpIconReserve, LabelHelpIcon } from '../iconhelper/IconHelper';
+import { COMPACT_LINE_HEIGHT, Text } from '../text/Text.component';
 import { FocusVisibleStyle } from '../buttonv2/Buttonv2.component';
 
 const getCheckmarkSvgUrl = (color: string) => {
@@ -16,7 +23,58 @@ const getIndeterminateSvgUrl = (color: string) => {
 };
 
 const CheckboxInput = styled.input`
-	transform: scale(1.5);`;
+  transform: scale(1.5);
+`;
+
+/**
+ * Typography is pinned here so the label's line box and `BoxSlot`'s height both
+ * resolve against `Text`'s own 1rem, whatever the ambient font size.
+ */
+const CheckboxRow = styled.span`
+  display: flex;
+  gap: ${spacing.r8};
+  font-size: 1rem;
+  line-height: ${COMPACT_LINE_HEIGHT};
+  /* A wrapped label hangs under its own first line; centring would put the box
+     in the gutter between two lines. */
+  align-items: flex-start;
+`;
+
+/**
+ * Holds the box on the label's first line: a slot one line box tall centring its
+ * own content, so neither side has to know how tall the other is. Sized only when
+ * there is a label, so a bare `Checkbox` keeps the geometry it had.
+ */
+const BoxSlot = styled.span<{ $hasLabel: boolean }>`
+  display: flex;
+  align-items: center;
+  flex: none;
+  ${({ $hasLabel }) =>
+    $hasLabel &&
+    css`
+      height: ${COMPACT_LINE_HEIGHT}em;
+    `}
+`;
+
+// A block so the label's lines and its help icon share one inline formatting
+// context; a `span`, because this is inside a `<label>`. `min-width: 0` is
+// load-bearing -- `break-word` below does not lower the min-content width, so
+// without it this flex item overflows instead of wrapping.
+const LabelBlock = styled.span`
+  display: block;
+  min-width: 0;
+`;
+
+/**
+ * `overflow-wrap` because a label is not always prose: an event name such as
+ * `s3:ObjectCreated:CompleteMultipartUpload` offers nowhere to break. `break-word`
+ * and not `anywhere`, which would also drop min-content to one character and
+ * collapse a label column sized to its content.
+ */
+const LabelText = styled(Text)<{ $reserveHelpIcon: boolean }>`
+  overflow-wrap: break-word;
+  ${({ $reserveHelpIcon }) => $reserveHelpIcon && helpIconReserve}
+`;
 
 export type Props = {
   /**
@@ -25,6 +83,11 @@ export type Props = {
    * When inside a FormGroup, set the label on FormGroup's `label` prop instead.
    */
   label?: string;
+  /**
+   * Help text for a `?` icon at the end of the label, mirroring `FormGroup`'s prop
+   * of the same name. Ignored without a `label`.
+   */
+  labelHelpTooltip?: ReactNode;
   value?: string;
   checked?: boolean;
   disabled?: boolean;
@@ -32,24 +95,51 @@ export type Props = {
 } & InputHTMLAttributes<HTMLInputElement>;
 
 const Checkbox = forwardRef<HTMLInputElement, Props>(
-  ({ disabled, checked, label, value, onChange, ...rest }, ref) => {
+  (
+    { disabled, checked, label, labelHelpTooltip, value, onChange, ...rest },
+    ref,
+  ) => {
+    const hasLabel = !!label;
+    const hasHelpIcon = hasLabel && !!labelHelpTooltip;
+    // The help affordance is a `<button>` inside the `<label>`, and a descendant
+    // widget folds its own name into the control's: the box was announced as
+    // "Short label More information". Naming it after the label text alone fixes
+    // it; skipped when the caller names the box itself.
+    const labelTextId = useId();
+    const callerNamesIt =
+      rest['aria-label'] !== undefined || rest['aria-labelledby'] !== undefined;
     return (
-      <StyledCheckbox
-        $disabled={disabled}
-        className="sc-checkbox"
-      >
-        <Stack>
-          <CheckboxInput
-            type="checkbox"
-            checked={checked}
-            disabled={disabled}
-            value={value}
-            onChange={onChange}
-            ref={ref}
-            {...rest}
-          />
-          {label && <Text>{label}</Text>}
-        </Stack>
+      <StyledCheckbox $disabled={disabled} className="sc-checkbox">
+        <CheckboxRow>
+          <BoxSlot $hasLabel={hasLabel}>
+            <CheckboxInput
+              type="checkbox"
+              checked={checked}
+              disabled={disabled}
+              value={value}
+              onChange={onChange}
+              ref={ref}
+              aria-labelledby={
+                hasHelpIcon && !callerNamesIt ? labelTextId : undefined
+              }
+              {...rest}
+            />
+          </BoxSlot>
+          {hasLabel && (
+            <LabelBlock>
+              <LabelText
+                id={labelTextId}
+                compact
+                $reserveHelpIcon={hasHelpIcon}
+              >
+                {label}
+              </LabelText>
+              {hasHelpIcon && (
+                <LabelHelpIcon tooltipMessage={labelHelpTooltip} />
+              )}
+            </LabelBlock>
+          )}
+        </CheckboxRow>
       </StyledCheckbox>
     );
   },
@@ -93,7 +183,8 @@ const StyledCheckbox = styled.label<{
     border: 0;
     background-color: transparent;
     background-size: contain;
-    box-shadow: inset 0 0 0 ${spacing.r1} ${(props) => props.theme.textSecondary};
+    box-shadow: inset 0 0 0 ${spacing.r1}
+      ${(props) => props.theme.textSecondary};
   }
 
   /* Checked */
@@ -112,7 +203,8 @@ const StyledCheckbox = styled.label<{
   /* Indeterminate */
 
   [type='checkbox']:indeterminate::before {
-    box-shadow: inset 0 0 0 ${spacing.r1} ${(props) => props.theme.selectedActive};
+    box-shadow: inset 0 0 0 ${spacing.r1}
+      ${(props) => props.theme.selectedActive};
     background-color: ${(props) => props.theme.highlight};
     background-image: ${(props) => getIndeterminateSvgUrl(props.theme.textPrimary)};
   }
@@ -144,4 +236,4 @@ const StyledCheckbox = styled.label<{
     cursor: not-allowed;
     background-color: ${(props) => props.theme.textSecondary};
   }
-`
+`;

--- a/src/lib/components/form/Form.component.tsx
+++ b/src/lib/components/form/Form.component.tsx
@@ -11,7 +11,11 @@ import {
 import styled, { css } from 'styled-components';
 import { spacing, Stack, Wrap } from '../../spacing';
 import { Icon, IconName } from '../icon/Icon.component';
-import { HELP_ICON_SIZE, IconHelp } from '../iconhelper/IconHelper';
+import {
+  helpIconReserve,
+  IconHelp,
+  LabelHelpIcon,
+} from '../iconhelper/IconHelper';
 import { ScrollbarWrapper } from '../scrollbarwrapper/ScrollbarWrapper.component';
 import { HelperText, Text } from '../text/Text.component';
 
@@ -288,29 +292,10 @@ const GridLabelCell = styled.div`
   min-width: 0;
 `;
 
-const HELP_ICON_RESERVE = `calc(${HELP_ICON_SIZE} + ${spacing.r8})`;
-
-/**
- * Reserves the room the help icon sits in. The break opportunity is in front of the
- * icon, so nothing on the icon's own box can suppress it. End padding on the label's
- * inline box lands on its last line instead -- where the icon goes -- and counts
- * toward min-content, so a column sized to the text fits the icon too.
- */
+// The label, holding the room its help icon will sit in. See `helpIconReserve`
+// for why the room has to be reserved on the label rather than around the icon.
 const LabelText = styled(Text)<{ $reserveHelpIcon: boolean }>`
-  ${({ $reserveHelpIcon }) =>
-    $reserveHelpIcon &&
-    css`
-      padding-right: ${HELP_ICON_RESERVE};
-    `}
-`;
-
-/**
- * Pulled back onto the room `LabelText` reserved, by exactly its own width, so
- * placing it costs the line nothing and no break is needed to fit it.
- */
-const HelpIconSlot = styled.span`
-  display: inline-block;
-  margin-left: -${HELP_ICON_SIZE};
+  ${({ $reserveHelpIcon }) => $reserveHelpIcon && helpIconReserve}
 `;
 
 // Carries the section's label-column config down to each FormGroup so a row can
@@ -389,14 +374,7 @@ const FormGroup = ({
         {requireMode !== 'all' && required && ' *'}
         {requireMode === 'all' && !required && ' (optional)'}
       </LabelText>
-      {labelHelpTooltip && (
-        <HelpIconSlot>
-          <IconHelp
-            tooltipMessage={labelHelpTooltip}
-            overlayStyle={maxWidthTooltip}
-          />
-        </HelpIconSlot>
-      )}
+      {labelHelpTooltip && <LabelHelpIcon tooltipMessage={labelHelpTooltip} />}
     </label>
   );
 

--- a/src/lib/components/form/Form.component.tsx
+++ b/src/lib/components/form/Form.component.tsx
@@ -10,9 +10,8 @@ import {
 } from 'react';
 import styled, { css } from 'styled-components';
 import { spacing, Stack, Wrap } from '../../spacing';
-import { Box } from '../box/Box';
 import { Icon, IconName } from '../icon/Icon.component';
-import { IconHelp } from '../iconhelper/IconHelper';
+import { HELP_ICON_SIZE, IconHelp } from '../iconhelper/IconHelper';
 import { ScrollbarWrapper } from '../scrollbarwrapper/ScrollbarWrapper.component';
 import { HelperText, Text } from '../text/Text.component';
 
@@ -285,16 +284,33 @@ const FieldSubgridRow = styled.div<{
   }}
 `;
 
-const GridLabelCell = styled.div<{ $hasHelpTooltip: boolean }>`
+const GridLabelCell = styled.div`
   min-width: 0;
-  ${({ $hasHelpTooltip }) =>
-    $hasHelpTooltip &&
+`;
+
+const HELP_ICON_RESERVE = `calc(${HELP_ICON_SIZE} + ${spacing.r8})`;
+
+/**
+ * Reserves the room the help icon sits in. The break opportunity is in front of the
+ * icon, so nothing on the icon's own box can suppress it. End padding on the label's
+ * inline box lands on its last line instead -- where the icon goes -- and counts
+ * toward min-content, so a column sized to the text fits the icon too.
+ */
+const LabelText = styled(Text)<{ $reserveHelpIcon: boolean }>`
+  ${({ $reserveHelpIcon }) =>
+    $reserveHelpIcon &&
     css`
-      /* The non-responsive column reserves 2rem beyond the label for the help
-         icon affordance; reserve the same here so the label column is identical
-         in both layouts. */
-      padding-right: ${spacing.r32};
+      padding-right: ${HELP_ICON_RESERVE};
     `}
+`;
+
+/**
+ * Pulled back onto the room `LabelText` reserved, by exactly its own width, so
+ * placing it costs the line nothing and no break is needed to fit it.
+ */
+const HelpIconSlot = styled.span`
+  display: inline-block;
+  margin-left: -${HELP_ICON_SIZE};
 `;
 
 // Carries the section's label-column config down to each FormGroup so a row can
@@ -365,22 +381,21 @@ const FormGroup = ({
           position alone. Disabled keeps the primary tone: the wrapping label is
           already at 0.5 opacity, and compounding the two costs more contrast than
           the pairing gains. */}
-      <Text color={disabled ? undefined : 'textSecondary'}>
+      <LabelText
+        color={disabled ? undefined : 'textSecondary'}
+        $reserveHelpIcon={!!labelHelpTooltip}
+      >
         {label}
         {requireMode !== 'all' && required && ' *'}
         {requireMode === 'all' && !required && ' (optional)'}
-      </Text>
+      </LabelText>
       {labelHelpTooltip && (
-        <Box
-          display="inline-block"
-          marginLeft={spacing.r8}
-          style={{ whiteSpace: 'nowrap' }}
-        >
+        <HelpIconSlot>
           <IconHelp
             tooltipMessage={labelHelpTooltip}
             overlayStyle={maxWidthTooltip}
           />
-        </Box>
+        </HelpIconSlot>
       )}
     </label>
   );
@@ -430,9 +445,7 @@ const FormGroup = ({
         $fixedLabel={sectionLabel.fixedLabel}
         $stackBelow={sectionLabel.stackBelow}
       >
-        <GridLabelCell $hasHelpTooltip={!!labelHelpTooltip}>
-          {labelContent}
-        </GridLabelCell>
+        <GridLabelCell>{labelContent}</GridLabelCell>
         {fieldContent}
       </FieldSubgridRow>
     </FieldContext.Provider>

--- a/src/lib/components/form/Form.test.tsx
+++ b/src/lib/components/form/Form.test.tsx
@@ -57,10 +57,11 @@ describe('Form', () => {
   });
 
   /**
-   * The marker is appended to the label inside the same Text, so it is the piece
-   * that silently falls out of the accessible name -- or loses the space before it
-   * -- if that composition is restructured. Tone itself is deliberately not
-   * asserted: reading a colour declaration back out proves nothing.
+   * The marker is appended to the label inside the same `LabelText`, so it is
+   * the piece that silently falls out of the accessible name -- or loses the
+   * space before it -- if that composition is restructured. Tone itself is
+   * deliberately not asserted: reading a colour declaration back out proves
+   * nothing.
    */
   it.each([
     ['partial', 'User name', true, 'User name *'],
@@ -87,6 +88,28 @@ describe('Form', () => {
       expect(screen.getByRole('textbox')).toHaveAccessibleName(expected);
     },
   );
+
+  // jsdom has no layout, so the icon's position is out of reach here. What this pins
+  // is that moving the icon out of its old wrapper kept it inside its label.
+  it('keeps the help affordance inside the label it annotates', () => {
+    render(
+      <Form layout={{ kind: 'page', title: 'Test Form' }}>
+        <FormSection>
+          <FormGroup
+            id="tls-field"
+            label="Enable LDAP Over TLS"
+            labelHelpTooltip="Encrypt the connection to the directory server."
+            content={<input type="text" id="tls-field" />}
+          />
+        </FormSection>
+      </Form>,
+    );
+
+    const help = screen.getByRole('button', { name: 'More information' });
+    expect(
+      screen.getByText('Enable LDAP Over TLS').closest('label'),
+    ).toContainElement(help);
+  });
 
   it('keeps the labelled field visible and usable with responsive shrink', async () => {
     render(

--- a/src/lib/components/iconhelper/IconHelper.tsx
+++ b/src/lib/components/iconhelper/IconHelper.tsx
@@ -1,5 +1,6 @@
 import { CSSProperties, ReactNode } from 'react';
-import styled from 'styled-components';
+import styled, { css } from 'styled-components';
+import { spacing } from '../../spacing';
 import { Icon } from '../icon/Icon.component';
 import { fontSize } from '../../style/theme';
 import { Position, Tooltip } from '../tooltip/Tooltip.component';
@@ -18,7 +19,31 @@ type IconHelpProps = {
   title?: string;
 };
 
+/**
+ * The icon's footprint. Exported so a caller reserving room for the icon reads this
+ * number rather than a copy that can drift.
+ */
 export const HELP_ICON_SIZE = fontSize.base;
+
+/**
+ * Room for a help icon at the end of a label's last line. Pair it with
+ * `LabelHelpIcon`, which sits back in that room -- use both or neither.
+ *
+ * The icon is an atomic inline with a soft-wrap opportunity in front of it that
+ * nothing inside it can suppress, so it landed alone on the next line. Padding the
+ * label's own inline box puts the room on its last line, where the icon goes, and
+ * counts it toward min-content, so a column sized to its text fits the icon too.
+ */
+export const helpIconReserve = css`
+  padding-right: calc(${HELP_ICON_SIZE} + ${spacing.r8});
+`;
+
+const HelpIconSlot = styled.span`
+  display: inline-block;
+  margin-left: -${HELP_ICON_SIZE};
+`;
+
+const maxWidthTooltip = { maxWidth: '20rem' };
 
 const HelpButton = styled.button`
   display: inline-flex;
@@ -61,4 +86,18 @@ export const IconHelp = ({
       <Icon name="Info" color="buttonSecondary" />
     </HelpButton>
   </Tooltip>
+);
+
+/**
+ * A help icon annotating a label, pulled back onto the room `helpIconReserve` left
+ * for it by exactly its own width, so it costs the last line nothing to place.
+ */
+export const LabelHelpIcon = ({
+  tooltipMessage,
+}: {
+  tooltipMessage: ReactNode;
+}) => (
+  <HelpIconSlot>
+    <IconHelp tooltipMessage={tooltipMessage} overlayStyle={maxWidthTooltip} />
+  </HelpIconSlot>
 );

--- a/src/lib/components/iconhelper/IconHelper.tsx
+++ b/src/lib/components/iconhelper/IconHelper.tsx
@@ -18,18 +18,20 @@ type IconHelpProps = {
   title?: string;
 };
 
+export const HELP_ICON_SIZE = fontSize.base;
+
 const HelpButton = styled.button`
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  width: ${fontSize.base};
-  height: ${fontSize.base};
+  width: ${HELP_ICON_SIZE};
+  height: ${HELP_ICON_SIZE};
   background: none;
   border: none;
   padding: 0;
   margin: 0;
   color: inherit;
-  font-size: ${fontSize.base};
+  font-size: ${HELP_ICON_SIZE};
   line-height: 0;
   vertical-align: -0.125em;
   cursor: default;

--- a/src/lib/components/text/Text.component.tsx
+++ b/src/lib/components/text/Text.component.tsx
@@ -115,6 +115,12 @@ export const SmallerEmphaseTextStyle = styled(SmallerTextStyle) <{
   font-weight: 700;
   color: ${(props) => props.theme[`${props.statusColor}`]};
 `;
+/**
+ * The `compact` line height, exported so a caller aligning against a compact line
+ * box reads this number rather than a copy that can drift.
+ */
+export const COMPACT_LINE_HEIGHT = 1.2;
+
 const ChartTitleTextStyle = styled(BasicTextStyle)`
   letter-spacing: ${spacing.r2};
 `;
@@ -224,7 +230,7 @@ export const Text = styled.span.withConfig({
   ${(props) =>
     props.variant === 'ChartTitle' && `letter-spacing: ${spacing.r2};`}
 
-  ${(props) => props.compact && `line-height: 1.2;`}
+  ${(props) => props.compact && `line-height: ${COMPACT_LINE_HEIGHT};`}
 `;
 export const HelperText = ({ children, color, ...rest }: Props) => {
   return (

--- a/stories/Checkbox/checkbox.stories.tsx
+++ b/stories/Checkbox/checkbox.stories.tsx
@@ -26,6 +26,11 @@ const meta: Meta<Props> = {
         'Function to be called when the checkbox is clicked, optional',
     },
     label: { control: 'text', description: 'Label of the checkbox, optional' },
+    labelHelpTooltip: {
+      control: 'text',
+      description:
+        'Help text for a `?` icon at the end of the label, optional. Ignored without a `label`.',
+    },
     checked: {
       control: 'boolean',
       description: 'Control if the checkbox is checked, optional',
@@ -209,4 +214,50 @@ export const IndeterminateUseCase = {
       </Box>
     );
   },
+};
+
+/**
+ * What a label does once it stops fitting on one line: it wraps under its box, it
+ * keeps its help icon at the end of its last line, and with nowhere to break it
+ * breaks inside the word. Drag `frameWidth` down to about 200px.
+ */
+export const WrappedLabel: StoryObj<{ frameWidth: number }> = {
+  argTypes: {
+    frameWidth: {
+      control: { type: 'range', min: 140, max: 600, step: 10 },
+      description: 'Width of the frame the checkboxes have to fit in.',
+    },
+  },
+  args: { frameWidth: 260 },
+  render: ({ frameWidth }) => (
+    <div
+      style={{
+        width: frameWidth,
+        border: '1px dashed #888',
+        padding: '0.5rem',
+        display: 'flex',
+        flexDirection: 'column',
+        gap: '0.75rem',
+      }}
+    >
+      <Checkbox
+        label="I understand the consequences of activating TLS Verification"
+        onChange={() => {}}
+      />
+      <Checkbox
+        label="Delete objects after successful replication when checked"
+        labelHelpTooltip="Objects are removed from the source only once the destination confirms the write."
+        onChange={() => {}}
+      />
+      <Checkbox
+        label="s3:ObjectCreated:CompleteMultipartUpload"
+        onChange={() => {}}
+      />
+      <Checkbox
+        label="Short label"
+        labelHelpTooltip="A one-line label keeps its icon on the same line, as before."
+        onChange={() => {}}
+      />
+    </div>
+  ),
 };

--- a/stories/form.stories.tsx
+++ b/stories/form.stories.tsx
@@ -450,7 +450,7 @@ export const ResponsiveSizedInputs = {
             direction="horizontal"
             label="Default (size 1)"
             id="w-default"
-            labelHelpTooltip="The help icon reserves ~2rem in the label column"
+            labelHelpTooltip="The help icon reserves its own width plus a gap at the end of the label"
             content={<Input id="w-default" placeholder="20.5rem" />}
           />
           <FormGroup


### PR DESCRIPTION
**TL;DR** — A wrapping `Checkbox` label no longer breaks the row apart: the box stays on the label's first line, and the label can carry a help icon.

<img width="796" height="429" alt="cui1199-wrapped-label-comparison" src="https://github.com/user-attachments/assets/0ecda21a-8274-4d3d-9f5c-a7273ba8d721" />

*`Components/Inputs/Checkbox → Wrapped Label` at a 240px frame. The before is the four declarations from Context reverted in place, so only they differ.*

### Context / Why

`Checkbox` was only ever exercised with short labels. All four defects are invisible on one line and appear together the moment a label wraps — which is what happens as soon as the component sits in a narrow column.

| Cause | What a user sees |
| --- | --- |
| `Stack`'s `align-items: center` | on a two-line label the box floats to the vertical middle, pointing at the gap between the lines rather than at either |
| `Text`'s default 1.5rem line height | two lines read as two paragraphs |
| no `overflow-wrap` | a label with no space in it — an event name, say — does not wrap, it overflows its container |
| `label?: string`, rendered bare | no way to attach a help icon short of abandoning the prop |

### 🧩 Approach

**Holding the box on the first line without either side knowing the other's size.** `align-items: flex-start` alone hangs the box off the *top* of the first line, because the box is shorter than a line of text. So the box gets a slot exactly one line box tall which centres its own content:

```tsx
<CheckboxRow>                    // align-items: flex-start
  <BoxSlot $hasLabel>            // ← one line box tall, centres the box
    <CheckboxInput type="checkbox" … />
  </BoxSlot>
  <LabelBlock>…</LabelBlock>
</CheckboxRow>
```

`BoxSlot` is sized **only when there is a label**, so a bare `Checkbox` — what every table's row-selection column renders — keeps exactly the geometry it had. Two constants were named rather than restated: `Text` exports `COMPACT_LINE_HEIGHT` so the slot's height and the label's line height cannot drift, and the help icon's reserve pair moved out of `Form` into `IconHelper` next to `HELP_ICON_SIZE`, as `helpIconReserve` plus a `LabelHelpIcon` both label sites now render.

**`label` stays a `string`.** Widening it to `ReactNode` is the wider contract, not the safer one: it admits block elements that break the row, admits interactive elements inside what is a `<label>`, and makes the accessible name unpredictable. `FormGroup` answered the same question the same way, so the new prop is named to match.

**One defect the browser caught and jsdom cannot.** The help affordance is a `<button aria-label="More information">` inside the `<label>`, and per accname a descendant widget contributes its own name to the name the label gives the control — Chrome announced the box as `"Short label More information"`. It is fixed by naming the box after the label text alone via `aria-labelledby`, applied only to a checkbox that carries a help icon and skipped when the caller names the box itself. There is deliberately **no unit test**: `dom-accessibility-api` stops short of the nested button and reports the clean name whether the wiring is there or not, so a test would pass with the fix removed. Check it in the story instead.

### 🔧 Usage

```tsx
// before — a help icon on a Checkbox label had no route through the prop
<Checkbox label="Delete objects after successful replication when checked" />

// after
<Checkbox
  label="Delete objects after successful replication when checked"
  labelHelpTooltip="Objects are removed from the source only once the destination confirms the write."
/>
```

### 🔍 Review focus

- 🔴 **Critical** — `checkbox/Checkbox.component.tsx` › `Checkbox` — **every existing labelled `Checkbox` gets shorter**, with no opt-out: the label goes from `Text`'s default 1.5rem line box to a 1.2rem one, so the row loses 0.3rem, and the box moves from the row's vertical centre to the label's first line. On one line the box does not move against its label — the row around it does, everywhere the component is used.
- 🟡 **Moderate** — `iconhelper/IconHelper.tsx` › `helpIconReserve` / `LabelHelpIcon`, and their removal from `form/Form.component.tsx` — a move plus a fold: the slot, the icon and the 20rem tooltip cap are now one component that both label sites call, rather than the same four lines written out twice. `Form`'s own tests and stories are untouched.
- 🟡 **Moderate** — `checkbox/Checkbox.component.tsx` › `BoxSlot` — the `$hasLabel` guard is the only thing keeping table row-selection checkboxes at their current size. If it goes, every such box grows to a text line box.

### 🧪 How to test

1. `npm run storybook`, open **Components/Inputs/Checkbox → Wrapped Label**.
2. Drag `frameWidth` from 600 down to 160. At every width: each box sits on its label's **first** line, each help icon at the end of its label's **last** line, and the dashed frame never scrolls sideways.
3. `s3:ObjectCreated:CompleteMultipartUpload` has no space to break at — confirm it breaks *inside* the word rather than escaping the frame.
4. Open the browser's accessibility inspector on the two checkboxes with a help icon: their names should be the label text alone, with `More information` listed as its own separate node.
5. Open **Checkbox → Indeterminate Use Case** and confirm the table's row-selection checkboxes are unchanged — the no-label path must not move.

### Follow-up

- **Stacked on #1198**, which introduces the `HELP_ICON_SIZE` export and the reserve technique this branch builds on. That commit shows in this PR's range and disappears once #1198 merges; **merge #1198 first.** The Form-side story and test comment this branch inherited have been brought back in line with #1198's current head, so the rebase no longer reinstates anything #1198 has since cut.
- The same accessible-name pollution exists today in `FormGroup`, on every field whose label carries a help icon. It cannot take the fix used here — `FormGroup` renders the `<label>` but does not own the control, which the consumer passes in as `content`. Needs its own decision and its own PR.
- `HELP_ICON_SIZE`, `helpIconReserve` and `LabelHelpIcon` stay library-internal. Same open question as #1198: whether a consumer reserving room for the icon should be able to read the size.

### 🔗 References

- [#1198](https://github.com/scality/core-ui/pull/1198) — keeps a `FormGroup` label's help icon on the label's last line; introduces `HELP_ICON_SIZE` and the reserve technique this PR generalises.
