### PR TITLE
AttachmentTable: collapse the row's Remove button before the row leaves the panel

### DIFF
--- a/src/lib/organisms/attachments/AttachmentTable.tsx
+++ b/src/lib/organisms/attachments/AttachmentTable.tsx
@@ -115,6 +115,25 @@ const SearchBoxContainer = styled.div`
   padding: ${spacing.r16};
 `;
 
+/**
+ * `flex-grow: 1` reads as "the search box fills the toolbar". It does not, and it
+ * is worth knowing before someone relies on it: `SearchBoxContainer` is a block, so
+ * on the normal path there is no flex line to grow along and the declaration is
+ * inert. It applies only on the error path, where the input sits in a `Stack` next
+ * to a `Loader`. Left in place rather than moved, because the error path is the one
+ * place it does something and that appearance has not been measured.
+ *
+ * So the box is a fixed **287px** at every width, and this component cannot change
+ * that: `SearchInput` pins `width: max-content` on its own container and does not
+ * forward `fluid` to the `Input` inside it, which carries its own `20.5rem`.
+ * Overriding it from out here means reaching through two components' internals.
+ *
+ * It is the *second* floor this table hits. `SearchBoxContainer` has no minimum of
+ * its own -- it tracks its parent 1:1 -- but its 14px left padding plus the box's
+ * 287px anchors 301px of content, so the row bleeds again below a 301px container.
+ * That is 57px below the button's 357.63px crossover, which is why the button is
+ * the one this change addresses.
+ */
 const StyledSearchInput = styled(SearchInput)<{ $searchInputIsFocused }>`
   flex-grow: 1;
 
@@ -126,9 +145,35 @@ const StyledSearchInput = styled(SearchInput)<{ $searchInputIsFocused }>`
   }
 `;
 
-const AttachmentTableContainer = styled.div`
-  height: 100%;
-`;
+/**
+ * The container width, in px, at or below which the row's `Remove` button drops its
+ * label. Read by `iconOnly` as `@container responsive (max-width: Npx)`, against the
+ * container declared on this component's own wrapper.
+ *
+ * Measured, not chosen. The button is icon + "Remove" + padding and will not go
+ * below **88.89px** at any width -- its `min-width` is `0`, so that is intrinsic
+ * content width and no CSS floor relaxes it. Its column is `flex: 0.5` on a `0`
+ * basis, so as the table narrows the column's share falls until it can no longer
+ * pay for the button; from there the button's right edge simply stops moving while
+ * the panel keeps shrinking around it. It bleeds rather than scrolls or clips:
+ * these panels are `overflow: visible`, so `scrollWidth` never rises and there is
+ * no scrollbar and no clipped edge to notice -- the row is just outside the box.
+ *
+ * The crossover is a **357.63px** container, and past it the overhang grows one px
+ * per px: +0.63 at 357, +16.63 at 341. So the threshold has to sit *above* 357.63,
+ * not below -- 340 was tried first and left that whole band overflowing with the
+ * label still on. 360 clears it with ~2.4px to spare.
+ *
+ * Collapsed, the button is **32.5px**, so this buys back 56.39px of row.
+ *
+ * Below this the next floor is the search box: 287px, unconditional, anchored at
+ * the toolbar's 14px left padding, so the toolbar pins 301px of content and the row
+ * bleeds again below a **301px** container. The element that pokes out first there
+ * is actually this button again -- collapsed, its right edge lands 0.23px past the
+ * search box's -- but the search box is what sets the floor, and it is not fixable
+ * from here; see the note on `StyledSearchInput`.
+ */
+const REMOVE_COLLAPSE_PX = 360;
 
 const CenterredSecondaryText = styled(SecondaryText)`
   display: block;
@@ -488,265 +533,277 @@ export const AttachmentTable = <
   const [searchInputIsFocused, setSearchInputIsFocused] = useState(false);
 
   return (
-    <Table
-      columns={[
-        {
-          Header: 'Name',
-          accessor: 'name',
-          cellStyle: {
-            flex: 1.5,
-            marginRight: '1.5rem',
-          },
-          //@ts-expect-error
-          Cell: ({
-            value,
-            row: { original: entity },
-          }: {
-            value: string;
-            row: { original: AttachableEntity<ENTITY_TYPE, ENTITY> };
-          }) => {
-            const { data: asyncName, status } = useQuery({
-              ...(getNameQuery
-                ? getNameQuery(entity)
-                : { queryKey: ['fakeQuery'], queryFn: () => value }),
-              enabled: !value,
-            });
+    /* `iconOnly={REMOVE_COLLAPSE_PX}` is a `@container responsive` query, so it
+       needs an ancestor declaring that container -- and it has to be this table,
+       not whatever the consumer happens to provide, or the button would collapse
+       on someone else's width. The wrapper exists for that and nothing else; it
+       is `width`/`height: 100%` so `Table`, which is already both, keeps the box
+       it had. */
+    <Box container height="100%" width="100%">
+      <Table
+        columns={[
+          {
+            Header: 'Name',
+            accessor: 'name',
+            cellStyle: {
+              flex: 1.5,
+              marginRight: '1.5rem',
+            },
+            //@ts-expect-error
+            Cell: ({
+              value,
+              row: { original: entity },
+            }: {
+              value: string;
+              row: { original: AttachableEntity<ENTITY_TYPE, ENTITY> };
+            }) => {
+              const { data: asyncName, status } = useQuery({
+                ...(getNameQuery
+                  ? getNameQuery(entity)
+                  : { queryKey: ['fakeQuery'], queryFn: () => value }),
+                enabled: !value,
+              });
 
-            if (value) {
-              return <ConstrainedText text={value} lineClamp={2} />;
-            }
-            if (status === 'error') {
-              return (
-                <>An error occured while loading {entityName.singular} name</>
-              );
-            }
-            if (status === 'loading' || status === 'idle') {
-              return <>Loading...</>;
-            }
-            if (status === 'success') {
-              if (!asyncName) {
-                return <EmptyCell />;
+              if (value) {
+                return <ConstrainedText text={value} lineClamp={2} />;
               }
-              return <ConstrainedText text={asyncName} lineClamp={2} />;
-            }
+              if (status === 'error') {
+                return (
+                  <>An error occured while loading {entityName.singular} name</>
+                );
+              }
+              if (status === 'loading' || status === 'idle') {
+                return <>Loading...</>;
+              }
+              if (status === 'success') {
+                if (!asyncName) {
+                  return <EmptyCell />;
+                }
+                return <ConstrainedText text={asyncName} lineClamp={2} />;
+              }
 
-            return <EmptyCell />;
+              return <EmptyCell />;
+            },
           },
-        },
-        {
-          Header: 'Attachment',
-          accessor: 'isPending',
-          cellStyle: {
-            flex: 0.5,
+          {
+            Header: 'Attachment',
+            accessor: 'isPending',
+            cellStyle: {
+              flex: 0.5,
+            },
+            Cell: ({ value }: { value?: boolean }) => {
+              return value ? <>Pending</> : <>Attached</>;
+            },
           },
-          Cell: ({ value }: { value?: boolean }) => {
-            return value ? <>Pending</> : <>Attached</>;
-          },
-        },
-        {
-          Header: <Box flex={0.5} />,
-          accessor: 'action',
-          cellStyle: {
-            textAlign: 'right',
-            flex: 0.5,
-            marginLeft: 'auto',
-            marginRight: '0.5rem',
-          },
-          Cell: ({
-            row: { original: entity },
-          }: {
-            row: { original: AttachableEntity<ENTITY_TYPE> };
-          }) => (
-            <Button
-              size="inline"
-              onClick={() => {
-                dispatch({
-                  action: AttachmentAction.REMOVE,
-                  entity: {
-                    name: entity.name,
-                    id: entity.id,
-                    type: entity.type,
-                  },
-                });
-              }}
-              icon={<Icon name="Close" />}
-              label="Remove"
-              variant="danger"
-              disabled={!!entity.disableDetach}
-            />
-          ),
-        },
-      ]}
-      data={desiredAttachedEntities.map((entity) => ({
-        ...entity,
-        isPending: entity.isPending || false,
-        action: null,
-      }))}
-      defaultSortingKey="name"
-    >
-      <SearchBoxContainer
-        {...{
-          ref: (element) => {
-            if (element?.firstElementChild) {
-              setSearchWidth(
-                element.firstElementChild.getBoundingClientRect().width -
-                  2 +
-                  'px',
-              );
-            }
-          },
-        }}
-      >
-        {filteredEntities.status === 'error' ? (
-          <Tooltip
-            overlay={
-              <>We failed to load the entities, hence search is disabled</>
-            }
-          >
-            <Stack>
-              <StyledSearchInput
-                autoComplete="off"
-                placeholder={searchEntityPlaceholder}
-                {...getInputProps({
-                  ref: (element) => {
-                    if (element) searchInputRef.current = element;
-                  },
-                })}
-                onFocus={() => {
-                  openMenu();
-                  setSearchInputIsFocused(true);
+          {
+            Header: <Box flex={0.5} />,
+            accessor: 'action',
+            cellStyle: {
+              textAlign: 'right',
+              flex: 0.5,
+              marginLeft: 'auto',
+              marginRight: '0.5rem',
+            },
+            Cell: ({
+              row: { original: entity },
+            }: {
+              row: { original: AttachableEntity<ENTITY_TYPE> };
+            }) => (
+              <Button
+                size="inline"
+                iconOnly={REMOVE_COLLAPSE_PX}
+                onClick={() => {
+                  dispatch({
+                    action: AttachmentAction.REMOVE,
+                    entity: {
+                      name: entity.name,
+                      id: entity.id,
+                      type: entity.type,
+                    },
+                  });
                 }}
-                onBlur={() => {
-                  setSearchInputIsFocused(false);
-                }}
-                disabled={filteredEntities.status === 'error'}
+                icon={<Icon name="Close" />}
+                label="Remove"
+                variant="danger"
+                disabled={!!entity.disableDetach}
               />
-              <Loader />
-            </Stack>
-          </Tooltip>
-        ) : (
-          <StyledSearchInput
-            autoComplete="off"
-            placeholder={searchEntityPlaceholder}
-            {...getInputProps({
-              ref: (element) => {
-                if (element) searchInputRef.current = element;
-              },
-            })}
-            onFocus={() => {
-              openMenu();
-              setSearchInputIsFocused(true);
-            }}
-            onBlur={() => {
-              setSearchInputIsFocused(false);
-            }}
-            $searchInputIsFocused={searchInputIsFocused}
-          />
-        )}
-        <MenuContainer
-          {...getMenuProps()}
-          $width={searchWidth}
-          $isOpen={isOpen}
-          $searchInputIsFocused={searchInputIsFocused}
-        >
-          {isOpen &&
-            filteredEntities.status === 'success' &&
-            filteredEntities.data?.entities.map((item, index) => (
-              <li key={`${item.id}${index}`} {...getItemProps({ item, index })}>
-                <Text>{item.name}</Text>
-              </li>
-            ))}
-          {isOpen && filteredEntities.status === 'loading' && (
-            <li>
-              <Text>Searching...</Text>
-            </li>
-          )}
-          {isOpen && filteredEntities.status === 'error' && (
-            <li>
-              <Text color="statusCritical">
-                An error occured while searching
-              </Text>
-            </li>
-          )}
-          {isOpen &&
-            filteredEntities.status === 'success' &&
-            (filteredEntities.data?.number || 0) >
-              filteredEntities.data?.entities.length && (
-              <li>
-                <Text
-                  isGentleEmphazed={true}
-                  color="textSecondary"
-                  style={{ textAlign: 'right' }}
-                >
-                  There{' '}
-                  {(filteredEntities.data?.number || 0) -
-                    filteredEntities.data?.entities.length ===
-                  1
-                    ? 'is'
-                    : 'are'}{' '}
-                  {(filteredEntities.data?.number || 0) -
-                    filteredEntities.data?.entities.length}{' '}
-                  more{' '}
-                  {(filteredEntities.data?.number || 0) -
-                    filteredEntities.data?.entities.length ===
-                  1
-                    ? entityName.singular
-                    : entityName.plural}{' '}
-                  matching your search. Suggestion: try more specific search
-                  expression.
-                </Text>
-              </li>
-            )}
-          {isOpen &&
-            filteredEntities.status === 'success' &&
-            filteredEntities.data?.entities.length === 0 && (
-              <li>
-                <Text isGentleEmphazed={true} color="textSecondary">
-                  No {entityName.plural} found matching your search.
-                </Text>
-              </li>
-            )}
-        </MenuContainer>
-      </SearchBoxContainer>
-      <Table.SingleSelectableContent
-        rowHeight={rowHeight}
-        separationLineVariant="backgroundLevel2"
+            ),
+          },
+        ]}
+        data={desiredAttachedEntities.map((entity) => ({
+          ...entity,
+          isPending: entity.isPending || false,
+          action: null,
+        }))}
+        defaultSortingKey="name"
       >
-        {(rows) => (
-          <>
-            {initiallyAttachedEntitiesStatus === 'idle' ||
-            initiallyAttachedEntitiesStatus === 'loading' ? (
-              <Wrap style={{ height: `${tableRowHeight[rowHeight]}rem` }}>
-                <p></p>
-                <Stack>
-                  <Loader />
-                  <Text>Loading {entityName.plural}...</Text>
-                </Stack>
-                <p></p>
-              </Wrap>
-            ) : initiallyAttachedEntitiesStatus === 'error' ? (
-              <Stack
-                style={{
-                  justifyContent: 'center',
-                  height: `${tableRowHeight[rowHeight]}rem`,
-                }}
-              >
-                <Icon name="Exclamation-circle" color="statusWarning" />
-                <Text color="textSecondary">
-                  Failed to load attached {entityName.plural}.
-                </Text>
+        <SearchBoxContainer
+          {...{
+            ref: (element) => {
+              if (element?.firstElementChild) {
+                setSearchWidth(
+                  element.firstElementChild.getBoundingClientRect().width -
+                    2 +
+                    'px',
+                );
+              }
+            },
+          }}
+        >
+          {filteredEntities.status === 'error' ? (
+            <Tooltip
+              overlay={
+                <>We failed to load the entities, hence search is disabled</>
+              }
+            >
+              <Stack>
+                <StyledSearchInput
+                  autoComplete="off"
+                  placeholder={searchEntityPlaceholder}
+                  {...getInputProps({
+                    ref: (element) => {
+                      if (element) searchInputRef.current = element;
+                    },
+                  })}
+                  onFocus={() => {
+                    openMenu();
+                    setSearchInputIsFocused(true);
+                  }}
+                  onBlur={() => {
+                    setSearchInputIsFocused(false);
+                  }}
+                  disabled={filteredEntities.status === 'error'}
+                />
+                <Loader />
               </Stack>
-            ) : (
-              desiredAttachedEntities.length === 0 && (
-                <CenterredSecondaryText>
-                  No {entityName.plural} attached
-                </CenterredSecondaryText>
-              )
+            </Tooltip>
+          ) : (
+            <StyledSearchInput
+              autoComplete="off"
+              placeholder={searchEntityPlaceholder}
+              {...getInputProps({
+                ref: (element) => {
+                  if (element) searchInputRef.current = element;
+                },
+              })}
+              onFocus={() => {
+                openMenu();
+                setSearchInputIsFocused(true);
+              }}
+              onBlur={() => {
+                setSearchInputIsFocused(false);
+              }}
+              $searchInputIsFocused={searchInputIsFocused}
+            />
+          )}
+          <MenuContainer
+            {...getMenuProps()}
+            $width={searchWidth}
+            $isOpen={isOpen}
+            $searchInputIsFocused={searchInputIsFocused}
+          >
+            {isOpen &&
+              filteredEntities.status === 'success' &&
+              filteredEntities.data?.entities.map((item, index) => (
+                <li
+                  key={`${item.id}${index}`}
+                  {...getItemProps({ item, index })}
+                >
+                  <Text>{item.name}</Text>
+                </li>
+              ))}
+            {isOpen && filteredEntities.status === 'loading' && (
+              <li>
+                <Text>Searching...</Text>
+              </li>
             )}
-            {desiredAttachedEntities.length > 0 && rows}
-          </>
-        )}
-      </Table.SingleSelectableContent>
-    </Table>
+            {isOpen && filteredEntities.status === 'error' && (
+              <li>
+                <Text color="statusCritical">
+                  An error occured while searching
+                </Text>
+              </li>
+            )}
+            {isOpen &&
+              filteredEntities.status === 'success' &&
+              (filteredEntities.data?.number || 0) >
+                filteredEntities.data?.entities.length && (
+                <li>
+                  <Text
+                    isGentleEmphazed={true}
+                    color="textSecondary"
+                    style={{ textAlign: 'right' }}
+                  >
+                    There{' '}
+                    {(filteredEntities.data?.number || 0) -
+                      filteredEntities.data?.entities.length ===
+                    1
+                      ? 'is'
+                      : 'are'}{' '}
+                    {(filteredEntities.data?.number || 0) -
+                      filteredEntities.data?.entities.length}{' '}
+                    more{' '}
+                    {(filteredEntities.data?.number || 0) -
+                      filteredEntities.data?.entities.length ===
+                    1
+                      ? entityName.singular
+                      : entityName.plural}{' '}
+                    matching your search. Suggestion: try more specific search
+                    expression.
+                  </Text>
+                </li>
+              )}
+            {isOpen &&
+              filteredEntities.status === 'success' &&
+              filteredEntities.data?.entities.length === 0 && (
+                <li>
+                  <Text isGentleEmphazed={true} color="textSecondary">
+                    No {entityName.plural} found matching your search.
+                  </Text>
+                </li>
+              )}
+          </MenuContainer>
+        </SearchBoxContainer>
+        <Table.SingleSelectableContent
+          rowHeight={rowHeight}
+          separationLineVariant="backgroundLevel2"
+        >
+          {(rows) => (
+            <>
+              {initiallyAttachedEntitiesStatus === 'idle' ||
+              initiallyAttachedEntitiesStatus === 'loading' ? (
+                <Wrap style={{ height: `${tableRowHeight[rowHeight]}rem` }}>
+                  <p></p>
+                  <Stack>
+                    <Loader />
+                    <Text>Loading {entityName.plural}...</Text>
+                  </Stack>
+                  <p></p>
+                </Wrap>
+              ) : initiallyAttachedEntitiesStatus === 'error' ? (
+                <Stack
+                  style={{
+                    justifyContent: 'center',
+                    height: `${tableRowHeight[rowHeight]}rem`,
+                  }}
+                >
+                  <Icon name="Exclamation-circle" color="statusWarning" />
+                  <Text color="textSecondary">
+                    Failed to load attached {entityName.plural}.
+                  </Text>
+                </Stack>
+              ) : (
+                desiredAttachedEntities.length === 0 && (
+                  <CenterredSecondaryText>
+                    No {entityName.plural} attached
+                  </CenterredSecondaryText>
+                )
+              )}
+              {desiredAttachedEntities.length > 0 && rows}
+            </>
+          )}
+        </Table.SingleSelectableContent>
+      </Table>
+    </Box>
   );
 };

--- a/src/lib/organisms/attachments/AttachmentTable.tsx
+++ b/src/lib/organisms/attachments/AttachmentTable.tsx
@@ -116,16 +116,13 @@ const SearchBoxContainer = styled.div`
 `;
 
 /**
- * `flex-grow: 1` reads as "the search box fills the toolbar". It does not:
- * `SearchBoxContainer` is a block, so on the normal path there is no flex line to
- * grow along and the declaration is inert. It applies only on the error path, where
- * the input sits in a `Stack` beside a `Loader`, so it is left in place.
+ * `flex-grow: 1` is inert on the normal path -- `SearchBoxContainer` is a block, so
+ * there is no flex line to grow along. It is kept for the error path, where the
+ * input sits in a `Stack` beside a `Loader`.
  *
- * The box is therefore a fixed 287px at every width, and this component cannot
- * change that: `SearchInput` pins `width: max-content` on its own container and does
- * not forward `fluid` to the `Input` inside it. That plus the toolbar's 14px left
- * padding is this table's *second* floor, at a 301px container -- 57px below the
- * button's crossover, which is why the button is what this change addresses.
+ * So the box is a fixed 287px, and this component cannot change that: `SearchInput`
+ * pins `width: max-content` and does not forward `fluid`. That is this table's next
+ * floor, at a 301px container.
  */
 const StyledSearchInput = styled(SearchInput)<{ $searchInputIsFocused }>`
   flex-grow: 1;
@@ -142,17 +139,10 @@ const StyledSearchInput = styled(SearchInput)<{ $searchInputIsFocused }>`
  * The container width, in px, at or below which the row's `Remove` button drops its
  * label. Read by `iconOnly` as `@container responsive (max-width: Npx)`.
  *
- * Measured, not chosen. The button will not go below its intrinsic 88.89px, and its
- * column is `flex: 0.5` on a `0` basis, so once the column's share stops paying for
- * the button its right edge stays put while the panel shrinks around it. It bleeds
- * rather than clips -- these panels are `overflow: visible`, so `scrollWidth` never
- * rises and there is no scrollbar or clipped edge to notice.
- *
- * The crossover is a **357.63px** container, so the threshold has to sit *above*
- * that, not below: 340 was tried first and left the whole 357-to-341 band
- * overflowing with the label still on. 360 clears it with ~2.4px to spare, and buys
- * back 56.39px of row. The next floor below is the search box's, at 301px -- see
- * the note on `StyledSearchInput`.
+ * The button will not go below its intrinsic 88.89px, and its column is `flex: 0.5`
+ * on a `0` basis, so it overflows rather than shrinks -- invisibly, since these
+ * panels are `overflow: visible`. Measured: overflow starts just under 357px, so 360
+ * to keep some spare.
  */
 const REMOVE_COLLAPSE_PX = 360;
 
@@ -514,12 +504,9 @@ export const AttachmentTable = <
   const [searchInputIsFocused, setSearchInputIsFocused] = useState(false);
 
   return (
-    /* `iconOnly={REMOVE_COLLAPSE_PX}` is a `@container responsive` query, so it
-       needs an ancestor declaring that container -- and it has to be this table,
-       not whatever the consumer happens to provide, or the button would collapse
-       on someone else's width. The wrapper exists for that and nothing else; it
-       is `width`/`height: 100%` so `Table`, which is already both, keeps the box
-       it had. */
+    /* `iconOnly` is a `@container responsive` query and needs an ancestor declaring
+       that container -- this table's own box, not whatever the consumer provides.
+       `100%` both ways, so `Table` keeps the box it had. */
     <Box container height="100%" width="100%">
       <Table
         columns={[

--- a/src/lib/organisms/attachments/AttachmentTable.tsx
+++ b/src/lib/organisms/attachments/AttachmentTable.tsx
@@ -116,23 +116,16 @@ const SearchBoxContainer = styled.div`
 `;
 
 /**
- * `flex-grow: 1` reads as "the search box fills the toolbar". It does not, and it
- * is worth knowing before someone relies on it: `SearchBoxContainer` is a block, so
- * on the normal path there is no flex line to grow along and the declaration is
- * inert. It applies only on the error path, where the input sits in a `Stack` next
- * to a `Loader`. Left in place rather than moved, because the error path is the one
- * place it does something and that appearance has not been measured.
+ * `flex-grow: 1` reads as "the search box fills the toolbar". It does not:
+ * `SearchBoxContainer` is a block, so on the normal path there is no flex line to
+ * grow along and the declaration is inert. It applies only on the error path, where
+ * the input sits in a `Stack` beside a `Loader`, so it is left in place.
  *
- * So the box is a fixed **287px** at every width, and this component cannot change
- * that: `SearchInput` pins `width: max-content` on its own container and does not
- * forward `fluid` to the `Input` inside it, which carries its own `20.5rem`.
- * Overriding it from out here means reaching through two components' internals.
- *
- * It is the *second* floor this table hits. `SearchBoxContainer` has no minimum of
- * its own -- it tracks its parent 1:1 -- but its 14px left padding plus the box's
- * 287px anchors 301px of content, so the row bleeds again below a 301px container.
- * That is 57px below the button's 357.63px crossover, which is why the button is
- * the one this change addresses.
+ * The box is therefore a fixed 287px at every width, and this component cannot
+ * change that: `SearchInput` pins `width: max-content` on its own container and does
+ * not forward `fluid` to the `Input` inside it. That plus the toolbar's 14px left
+ * padding is this table's *second* floor, at a 301px container -- 57px below the
+ * button's crossover, which is why the button is what this change addresses.
  */
 const StyledSearchInput = styled(SearchInput)<{ $searchInputIsFocused }>`
   flex-grow: 1;
@@ -147,31 +140,19 @@ const StyledSearchInput = styled(SearchInput)<{ $searchInputIsFocused }>`
 
 /**
  * The container width, in px, at or below which the row's `Remove` button drops its
- * label. Read by `iconOnly` as `@container responsive (max-width: Npx)`, against the
- * container declared on this component's own wrapper.
+ * label. Read by `iconOnly` as `@container responsive (max-width: Npx)`.
  *
- * Measured, not chosen. The button is icon + "Remove" + padding and will not go
- * below **88.89px** at any width -- its `min-width` is `0`, so that is intrinsic
- * content width and no CSS floor relaxes it. Its column is `flex: 0.5` on a `0`
- * basis, so as the table narrows the column's share falls until it can no longer
- * pay for the button; from there the button's right edge simply stops moving while
- * the panel keeps shrinking around it. It bleeds rather than scrolls or clips:
- * these panels are `overflow: visible`, so `scrollWidth` never rises and there is
- * no scrollbar and no clipped edge to notice -- the row is just outside the box.
+ * Measured, not chosen. The button will not go below its intrinsic 88.89px, and its
+ * column is `flex: 0.5` on a `0` basis, so once the column's share stops paying for
+ * the button its right edge stays put while the panel shrinks around it. It bleeds
+ * rather than clips -- these panels are `overflow: visible`, so `scrollWidth` never
+ * rises and there is no scrollbar or clipped edge to notice.
  *
- * The crossover is a **357.63px** container, and past it the overhang grows one px
- * per px: +0.63 at 357, +16.63 at 341. So the threshold has to sit *above* 357.63,
- * not below -- 340 was tried first and left that whole band overflowing with the
- * label still on. 360 clears it with ~2.4px to spare.
- *
- * Collapsed, the button is **32.5px**, so this buys back 56.39px of row.
- *
- * Below this the next floor is the search box: 287px, unconditional, anchored at
- * the toolbar's 14px left padding, so the toolbar pins 301px of content and the row
- * bleeds again below a **301px** container. The element that pokes out first there
- * is actually this button again -- collapsed, its right edge lands 0.23px past the
- * search box's -- but the search box is what sets the floor, and it is not fixable
- * from here; see the note on `StyledSearchInput`.
+ * The crossover is a **357.63px** container, so the threshold has to sit *above*
+ * that, not below: 340 was tried first and left the whole 357-to-341 band
+ * overflowing with the label still on. 360 clears it with ~2.4px to spare, and buys
+ * back 56.39px of row. The next floor below is the search box's, at 301px -- see
+ * the note on `StyledSearchInput`.
  */
 const REMOVE_COLLAPSE_PX = 360;
 

--- a/stories/attachment.stories.tsx
+++ b/stories/attachment.stories.tsx
@@ -139,11 +139,9 @@ export const ConfirmationModal = {
  * The table in a panel-sized column, which is the shape it ships in.
  *
  * Drag `frameWidth` down. At **360px** the row's `Remove` button drops its label for
- * a tooltip. Without that the button is what stops the row shrinking, and from
- * 357.63px the row bleeds out of the panel -- these panels are `overflow: visible`,
- * so there is no scrollbar or clipped edge to give it away. Keep going and the
- * search box is the next floor at **301px**, which is `SearchInput`'s fixed width
- * and not fixable from this component.
+ * a tooltip; without it the row bleeds out of the panel with nothing to show it,
+ * since these panels are `overflow: visible`. The next floor is the search box at
+ * **301px**, which is `SearchInput`'s fixed width and not fixable from here.
  */
 export const NarrowPanel = {
   argTypes: {

--- a/stories/attachment.stories.tsx
+++ b/stories/attachment.stories.tsx
@@ -136,18 +136,14 @@ export const ConfirmationModal = {
 };
 
 /**
- * The table in a panel-sized column, which is the shape it actually ships in.
+ * The table in a panel-sized column, which is the shape it ships in.
  *
- * Drag `frameWidth` down. At **360px** the row's `Remove` button drops its label and
- * keeps only its icon, the label moving to a tooltip. Without that it is the button
- * that stops the row shrinking -- it will not go below 88.89px -- and from 357.63px
- * the row bleeds out of the panel: these panels are `overflow: visible`, so there is
- * no scrollbar and no clipped edge to give it away, the row is simply outside the
- * box. The overhang then grows a px per px, reaching 16.63px at 341.
- *
- * Keep going and the search box is the next floor, at **301px** -- its own 287px
- * plus the toolbar's 14px left padding. That one is `SearchInput`'s fixed width and
- * is not fixable from this component.
+ * Drag `frameWidth` down. At **360px** the row's `Remove` button drops its label for
+ * a tooltip. Without that the button is what stops the row shrinking, and from
+ * 357.63px the row bleeds out of the panel -- these panels are `overflow: visible`,
+ * so there is no scrollbar or clipped edge to give it away. Keep going and the
+ * search box is the next floor at **301px**, which is `SearchInput`'s fixed width
+ * and not fixable from this component.
  */
 export const NarrowPanel = {
   argTypes: {

--- a/stories/attachment.stories.tsx
+++ b/stories/attachment.stories.tsx
@@ -134,3 +134,67 @@ export const ConfirmationModal = {
     );
   },
 };
+
+/**
+ * The table in a panel-sized column, which is the shape it actually ships in.
+ *
+ * Drag `frameWidth` down. At **360px** the row's `Remove` button drops its label and
+ * keeps only its icon, the label moving to a tooltip. Without that it is the button
+ * that stops the row shrinking -- it will not go below 88.89px -- and from 357.63px
+ * the row bleeds out of the panel: these panels are `overflow: visible`, so there is
+ * no scrollbar and no clipped edge to give it away, the row is simply outside the
+ * box. The overhang then grows a px per px, reaching 16.63px at 341.
+ *
+ * Keep going and the search box is the next floor, at **301px** -- its own 287px
+ * plus the toolbar's 14px left padding. That one is `SearchInput`'s fixed width and
+ * is not fixable from this component.
+ */
+export const NarrowPanel = {
+  argTypes: {
+    frameWidth: {
+      control: { type: 'range', min: 200, max: 900, step: 10 },
+    },
+  },
+  args: { frameWidth: 383 },
+  render: ({ frameWidth }: { frameWidth: number }) => {
+    const theme = useTheme();
+    return (
+      <Box
+        data-testid="panel-frame"
+        style={{
+          width: frameWidth,
+          height: '100%',
+          backgroundColor: theme.backgroundLevel4,
+          outline: '1px dashed #888',
+        }}
+        p={'1rem'}
+      >
+        <AttachmentProvider>
+          <AttachmentTable
+            entityName={{ plural: 'users', singular: 'user' }}
+            filteredEntities={{
+              status: 'success',
+              data: {
+                number: 1,
+                entities: [
+                  { name: 'jean.dupont@example.com', id: 'a', type: 'USER' },
+                  { name: 'storage-operators-emea', id: 'b', type: 'USER' },
+                ],
+              },
+            }}
+            initialAttachmentOperations={[]}
+            onEntitySearchChange={action('onEntitySearchChange')}
+            searchEntityPlaceholder="Search user by name"
+            initiallyAttachedEntities={[
+              { name: 'jean.dupont@example.com', id: 'a', type: 'USER' },
+              { name: 'storage-operators-emea', id: 'b', type: 'USER' },
+              { name: 'svc-backup', id: 'c', type: 'USER' },
+            ]}
+            initiallyAttachedEntitiesStatus={'success'}
+            onAttachmentsOperationsChanged={() => {}}
+          />
+        </AttachmentProvider>
+      </Box>
+    );
+  },
+};


### PR DESCRIPTION
**TL;DR** — Once the attach table got narrow, its rows quietly hung outside the panel they live in — no scrollbar, nothing clipped, just content sitting outside the box. The row's `Remove` button now drops its label and keeps its icon before that can happen.

> **Read this with whitespace hidden: [Files changed → `?w=1`](https://github.com/scality/core-ui/pull/1200/files?w=1)** (or the ⚙ next to *Files changed* → **Hide whitespace changes**). GitHub reports 344/246 lines; ignoring whitespace it is **102 insertions, 4 deletions**, and `AttachmentTable.tsx` alone drops from 530 changed lines to 46. The rest is the JSX return re-indenting by two spaces under a new wrapper.

## Context

The button will not shrink: icon + the word "Remove" + padding, holding its intrinsic **89.89px** at every width. Its column is `flex: 0.5` on a `0` basis, so as the table narrows the column's share falls until it can no longer pay for the button — from there the button's right edge stops moving while the panel keeps shrinking around it. These panels are `overflow: visible`, so `scrollWidth` never rises, no scrollbar appears and nothing is cut off; the row is simply *outside* the box, which is why only a bounding-rect comparison finds it.

## Approach

`iconOnly={360}` collapses the button to its icon before that can happen, moving the label into a tooltip. That is a `@container responsive` query, so the table declares that container itself:

```tsx
<Box container height="100%" width="100%">   // ← declares the `responsive` container
  <Table columns={[ … ]}>
```

It has to be the table's own container rather than whatever the consumer happens to provide, or the button would collapse on someone else's width.

**The threshold comes out of the sweep, not out of arithmetic.** The crossover is a **357.63px** container, past which the overhang grows a pixel per pixel; the threshold is 360. Deriving it instead by subtracting the test frame's padding gave 340 and left the whole 341–357 band still overflowing with the label on — the exact defect this removes — because the frame is content-box.

Verified in an isolated Chrome from 900px down to 302px: nothing overhangs at any sampled width, the label goes off at 360 and is on at 361, 900 and 560 are identical to before, the collapsed control keeps role `button` and the accessible name `Remove`, and the new wrapper did not change the table's box. Collapsed the button is 33.5px, so this buys back 56.39px of row.

**Below a 301px container the row bleeds again**, and that one is not fixable here: the search box is an unconditional 287px which, with the toolbar's 14px left padding, pins 301px of content. That is `SearchInput`'s own `width: max-content` plus the `20.5rem` on the `Input` inside it, so it belongs to CUI-41.

## Screenshots

`Components/AttachmentTable → Narrow Panel` at a 341px container — one width inside the band the first threshold would have missed. The dashed line is the container edge.

<img width="806" height="338" alt="cui1200-narrow-panel-comparison" src="https://github.com/user-attachments/assets/cd053f49-aeb0-44fd-97be-d7ca13bdb32f" />

## Review focus

- 🟡 `organisms/attachments/AttachmentTable.tsx › AttachmentTable` — **the root element changes.** A `<Box container>` now wraps `<Table>`, so consumers get one extra div and everything inside the table resolves `@container responsive` against the table's width instead of an outer container. Nothing inside uses such a query except this button, and no consumer content renders inside it, so the shadowing is contained — but it is the change with the widest reach.
- 🟡 `organisms/attachments/AttachmentTable.tsx › REMOVE_COLLAPSE_PX` — **behaviour changes for every existing consumer with no opt-out.** Below a 360px table the `Remove` button is icon-only. That is the point of the PR, and the label survives as a tooltip and as the accessible name, but nobody asked for it by setting a prop.
- ⚪ `organisms/attachments/AttachmentTable.tsx › StyledSearchInput` — `flex-grow: 1` is documented as inert on the normal path and **left in place**, because it does apply on the error path and that appearance has not been measured. Also removes `AttachmentTableContainer`, defined and never rendered since its only use was deleted in 2024.

## How to test

1. `npm run storybook`, open **Components/AttachmentTable → Narrow Panel**.
2. Drag `frameWidth` from 900 down to about 302. The rows stay inside the dashed frame the whole way — watch the right-hand edge, not for a scrollbar, because there will never be one.
3. Cross 360: the `Remove` label disappears and the icon stays. Hover it and confirm the tooltip reads "Remove".
4. Keep going below 301 and the row starts to hang out again — that is the search box's own width, out of scope here.
5. Sanity-check a normal width (560 or 900): the button still shows its label and looks exactly as it did.

## Follow-up

- **CUI-41** is what moves the next floor, and one thing here breaks with it: `MenuContainer`'s width comes from a ref callback measuring `firstElementChild.getBoundingClientRect().width - 2`, and ref callbacks do not re-fire on resize, so the dropdown would keep whatever width it had at mount. It is invisible today *because* the search box never resizes. Worth fixing in the same change, or the dropdown detaches from the field it belongs to.
- The third column's header and body cell disagree on width once the table is narrow (49.2 vs 40.27 at 320). The body cell was being forced open by the button; collapsing it shrank the gap and flipped its direction but did not close it. That is header/body box-model work, not this.
- No test was added: this component has no test file, jsdom cannot evaluate a container query, and a smoke test would guard nothing here — the story carries the evidence.

## References

- **CUI-41** — `SearchInput` cannot shrink; it is the next floor this table hits, at a 301px container.
