### PR TITLE
SearchInput: let the box shrink with its container instead of overflowing it

### DIFF
--- a/src/lib/components/searchinput/SearchInput.component.tsx
+++ b/src/lib/components/searchinput/SearchInput.component.tsx
@@ -1,7 +1,7 @@
 import { ChangeEvent, forwardRef, useEffect, useRef, useState } from 'react';
 import styled, { css } from 'styled-components';
 import { Icon, IconName } from '../icon/Icon.component';
-import { Input, InputSize } from '../inputv2/inputv2';
+import { convertSizeToRem, Input, InputSize } from '../inputv2/inputv2';
 import { Button } from '../buttonv2/Buttonv2.component';
 import { spacing } from '../../spacing';
 import { CoreUITheme } from '../../style/theme';
@@ -23,9 +23,20 @@ const SearchInputContainer = styled.div.withConfig({
   componentId: 'sc-searchinput',
 })<{
   $disabled?: boolean;
+  $width: string;
 }>`
   position: relative;
+  /* Hugs its content, no wider than the parent -- max-content alone pinned the box
+     and it overflowed. Two declarations, not min(max-content, 100%): an intrinsic
+     keyword inside a math function is invalid, so the whole width is dropped and the
+     box goes full-bleed.
+     Floor is the 1/2 size, never more than the width asked for. min-width beats
+     max-width, so past it the box overflows rather than shrink further: a field
+     rationed to a few px looks fine but is unusable, and the overflow is what tells
+     the layout around it to adapt. */
   width: max-content;
+  max-width: 100%;
+  min-width: min(${convertSizeToRem('1/2')}, ${(props) => props.$width});
 
   input[value] {
     max-width: calc(100% - 1rem - ${spacing.f8} - 1rem);
@@ -106,7 +117,11 @@ const SearchInput = forwardRef(
     };
 
     return (
-      <SearchInputContainer $disabled={disabled} {...rest}>
+      <SearchInputContainer
+        $disabled={disabled}
+        $width={convertSizeToRem(size)}
+        {...rest}
+      >
         <Input
           autoComplete={autoComplete}
           min={'1'}
@@ -120,6 +135,9 @@ const SearchInput = forwardRef(
           onChange={handleChange}
           onReset={reset}
           size={size}
+          /* The container above can now be narrower than `size`; without this the
+             input keeps that width and overflows it. The two move together. */
+          fluid
           leftIcon={searchIcon}
           leftIconColor={searchIconColor}
           className="search-box"

--- a/src/lib/components/tablev2/Search.tsx
+++ b/src/lib/components/tablev2/Search.tsx
@@ -2,6 +2,7 @@ import styled from 'styled-components';
 import { useEffect } from 'react';
 import { useTableContext } from './Tablev2.component';
 import { SearchInput } from '../searchinput/SearchInput.component';
+import { convertSizeToRem } from '../inputv2/inputv2';
 import { Props } from '../searchinput/SearchInput.component';
 import { BasicText } from '../text/Text.component';
 import { TableLocalType } from './TableUtils';
@@ -19,9 +20,22 @@ export type SearchProps = {
   totalCount?: number;
 } & Omit<Props, 'onChange'>;
 
+// Wide enough for "Total:" over a count and its entity name without reflowing as the
+// count changes width.
+const COUNT_MIN_WIDTH = '4.3rem';
+
 const SearchContainer = styled.div`
   display: flex;
   align-items: center;
+  /* The count plus its gap plus the search box's own floor. Without a floor here this
+     wrapper's automatic minimum is its min-content, which includes the box's full
+     max-content -- so it never shrinks and the box can never use its max-width: 100%.
+     With 0 instead it shrinks past its content and the box slides under whatever sits
+     to its right; stopping at the content floor makes the row overflow instead, which
+     is the visible signal that the toolbar has to adapt. */
+  min-width: calc(
+    ${COUNT_MIN_WIDTH} + ${spacing.r8} + ${convertSizeToRem('1/2')}
+  );
 `;
 
 const ResultContainer = styled(BasicText)`
@@ -41,7 +55,7 @@ const TableItemCountContainer = styled(BasicText)`
   display: flex;
   flex-direction: column;
   margin-right: ${spacing.r8};
-  min-width: 4.3rem;
+  min-width: ${COUNT_MIN_WIDTH};
 `;
 export const TableItemCount = ({
   entity,

--- a/stories/SearchInput/searchinput.stories.tsx
+++ b/stories/SearchInput/searchinput.stories.tsx
@@ -171,3 +171,42 @@ export const WithCustomIconColor = {
     );
   },
 };
+
+/**
+ * The box shrinks with its container instead of overflowing it, down to the `1/2`
+ * size. Drag `frameWidth`: the default box gives ground from 287px to its 10rem
+ * floor, then overflows rather than shrink into uselessness. The `1/3` box is
+ * already at its own size -- the floor is never wider than the `size` asked for.
+ */
+export const Narrow = {
+  argTypes: {
+    frameWidth: { control: { type: 'range', min: 60, max: 500, step: 10 } },
+  },
+  args: { frameWidth: 250 },
+  render: ({ frameWidth }: { frameWidth: number }) => {
+    const [value, setValue] = useState('');
+    return (
+      <Wrapper>
+        <Title>Default size, in a {frameWidth}px frame</Title>
+        <div style={{ width: frameWidth, outline: '1px dashed #888' }}>
+          <SearchInput
+            value={value}
+            placeholder="Search server..."
+            onChange={(e) => setValue(e.target.value)}
+            onReset={() => setValue('')}
+          />
+        </div>
+        <Title>size="1/3", same frame</Title>
+        <div style={{ width: frameWidth, outline: '1px dashed #888' }}>
+          <SearchInput
+            value=""
+            size="1/3"
+            placeholder="Search server..."
+            onChange={action('on input change')}
+            onReset={action('on input reset')}
+          />
+        </div>
+      </Wrapper>
+    );
+  },
+};


### PR DESCRIPTION
Was: a search box never got any narrower, whatever room it was given — so in a cramped toolbar it pushed the button beside it out of the panel, and nothing the surrounding layout did could rein it in. Now: it shrinks along with its container, down to a floor where it stops and overflows on purpose.

<img width="685" height="357" alt="cui41-narrow-comparison" src="https://github.com/user-attachments/assets/83d1b68c-a720-4c49-9857-710b4357fe62" />

`SearchInput → Narrow` at a 250px frame — the box on its own.

## Context

CUI-41, reported against a toolbar that could not be narrowed: the search box held its width and pushed the action button beside it out of the panel.

## Approach

**The box.** `SearchInputContainer` pinned `width: max-content`, and `SearchInput` never forwarded `fluid` to the `Input` inside it — so even a container that *could* have shrunk it had no effect. Both halves move together now: the container hugs its content but stops at the parent, and the input is always fluid. The floor is `10rem` — the `1/2` size, and the same number `Form` uses as its field floor (`FIELD_MIN_REM`) — and never wider than the `size` actually asked for, so a `1/3` box keeps its own 84px.

**The floor is a signal, not a fix.** Past it the box overflows rather than shrink further. A search field rationed down to a few px still *looks* fine while being unusable, which is the kind of degradation a screenshot review cannot catch; an overflow is what tells the surrounding layout it has to adapt — collapse an action button to `iconOnly`, drop a counter — and only the consumer can decide which.

**`Table.Search` gained nothing from the above on its own.** Its `SearchContainer` declared no `min-width`, so as a flex item its automatic minimum was its own min-content — which includes the box's full max-content. The wrapper could therefore never shrink, and the box's `max-width: 100%` had nothing narrower to resolve against: the toolbar overflowed below 482px with or without the box change. A box can override its own automatic minimum; it cannot override a wrapper's. `SearchContainer` now floors at the count plus its gap plus the box's own floor.

| Container | Search box | Text field | Button pushed out |
| --- | --- | --- | --- |
| 900 → 520 | 287 | 247 | 0 |
| 480 | 270 | 230 | 0 |
| 400 | 190 | 151 | 0 |
| 360 | 150 | 113 | 0 |
| 349 | 140 (floor) | 103 | overflow starts |

A toolbar of count + search + a labelled action button held to 482px before; it now holds to **349px**, or **262px** once the button goes `iconOnly`. `min-width: 0` on that wrapper would also unblock the shrink and was rejected: the wrapper then shrinks past its own content and the box slides *under* whatever sits to its right, where stopping at the content floor overflows instead — the failure mode consumers already recognise.

## Screenshots

The `Table.Search` toolbar in a 400px container, which is what the wrapper floor buys:

<img width="952" height="216" alt="cui41-toolbar-comparison" src="https://github.com/user-attachments/assets/1f4177a7-cc11-45d8-b4ff-9011d8134913" />

## Usage

No API change and nothing to adopt — every existing call site gets the new behaviour. A consumer that worked around the pinned width by passing a smaller `size` can drop that workaround.

## Review focus

- 🟡 `searchinput/SearchInput.component.tsx` › `SearchInputContainer` — `width: max-content` + `max-width: 100%` as **two declarations**. The obvious `min(max-content, 100%)` is invalid CSS: an intrinsic keyword cannot appear inside a math function, so the whole declaration is dropped and the box goes full-bleed at every width, dragging the absolutely-positioned clear button to the parent's right edge. Silent — no console warning.
- 🟡 `tablev2/Search.tsx` › `SearchContainer` — the `calc()` floor, and the counter's `4.3rem` lifted into `COUNT_MIN_WIDTH` so the two cannot drift apart. Note this file now imports `convertSizeToRem` from `inputv2` — the same module `SearchInput` already imports, so no cycle, but it is a new edge from `tablev2` to the input sizing table.
- ⚪ `SearchInput.component.tsx` › `Input` — `fluid` is unconditional. Gating it would let a consumer shrink the container while the input inside stayed rigid and overflowed it, which is worse than either end state.

## How to test

1. **SearchInput → Narrow**, drag `frameWidth` from 500 down to 60. Each box hugs its own `size` while there is room, then tracks the frame; the default box stops at 140px and starts overflowing, the `1/3` box holds 84px throughout.
2. Type into the default box at a narrow frame — the reset button stays inside the right edge (measured 1px in at both 600px and 250px).
3. **SearchInput → Default** — those boxes sit in 250px wrappers and used to overflow them. They should now fit exactly.
4. Any `Table.Search` in a flex toolbar beside an action button: narrow the container and confirm the search box gives ground before anything leaves the row.

## Follow-up

- The `SearchContainer` floor is a static `calc()` that assumes the count is rendered. `TableSearch` renders it unconditionally today, so nothing is broken — but if a consumer ever gains the ability to drop the count, dropping it would buy no headroom: the breakpoint stays at 349px instead of moving to 281px, and the 68px transfers to the search box rather than back to the row. Whoever adds that ability has to move the floor with it.
- Recorded with the open design questions on this toolbar (drop the count / an icon-only search that expands on click / accept the floor). Not scheduled, and only worth acting on if a real UI is seen hitting it.

## References

- **CUI-41** — carries the original report and the measurements above.
