### PR TITLE
Form: stop stacking a wide-label section while both columns still fit

### DIFF
--- a/src/lib/components/form/Form.component.tsx
+++ b/src/lib/components/form/Form.component.tsx
@@ -75,9 +75,8 @@ const LABEL_MIN_CH = 24;
 // together; above ~2.5x the cap the fraction is the larger of the two and the
 // column is sized exactly as before.
 const LABEL_MAX_CQI = 40;
-// The width below which a section stacks: its own label column plus the field
-// floor plus the column gap. Derived per section rather than fixed, or a section
-// with a label cap wider than LABEL_MIN_CH overflows in the band between the two.
+// The width below which a section stacks: the label floor plus the field floor
+// plus the column gap.
 const stackBelow = (labelFloor: string) =>
   `calc(${labelFloor} + ${FIELD_MIN_REM}rem + ${spacing.r32})`;
 
@@ -480,9 +479,13 @@ const FormSection = ({
         labelWidth ? `min(${labelWidth}, ${LABEL_MAX_CQI}cqi)` : labelWidthCap
       })`
     : labelWidthCap;
-  // The auto column has no length to derive from, so it keeps the readability
-  // floor it has always used.
-  const sectionStackBelow = stackBelow(labelWidth ?? `${LABEL_MIN_CH}ch`);
+  // Stack on the readability floor, not the cap: the clamped label never occupies its
+  // cap at narrow widths, so a cap-derived threshold stacks the row while both columns
+  // still fit. A cap under the floor is its own floor — the label cannot use room it
+  // was never given.
+  const sectionStackBelow = stackBelow(
+    labelWidth ? `min(${labelWidth}, ${LABEL_MIN_CH}ch)` : `${LABEL_MIN_CH}ch`,
+  );
 
   return (
     <FormSectionContext.Provider

--- a/src/lib/components/form/Form.component.tsx
+++ b/src/lib/components/form/Form.component.tsx
@@ -75,8 +75,9 @@ const LABEL_MIN_CH = 24;
 // together; above ~2.5x the cap the fraction is the larger of the two and the
 // column is sized exactly as before.
 const LABEL_MAX_CQI = 40;
-// The width below which a section stacks: the label floor plus the field floor
-// plus the column gap.
+// The width below which a section stacks. The floor is a parameter rather than a
+// fixed value: a section whose label cap exceeds LABEL_MIN_CH would otherwise
+// overflow in the band between the two.
 const stackBelow = (labelFloor: string) =>
   `calc(${labelFloor} + ${FIELD_MIN_REM}rem + ${spacing.r32})`;
 


### PR DESCRIPTION
**TL;DR** — A form with wide labels no longer flips to a stacked layout while both columns still fit: it holds two columns down to the width where the label would genuinely be too narrow to read.

<img width="874" height="491" alt="cui-stacking-threshold-comparison" src="https://github.com/user-attachments/assets/cd8a7147-dec6-446e-80f4-4b43e0596ecd" />

*`Templates/Form → ResponsiveLabelSqueeze`, 265px cap, frame at 402px — a width inside the band where the two differ.*

### Context / Why

A side effect of #1193, which taught the label column to shrink. The two halves of that fix disagree, and only across a narrow band of widths. Not filed in Jira.

### 🧩 Approach

#1193 clamped the label column so it gives ground alongside the field, and made each section's stacking point depend on that section's label cap rather than a fixed 24-character constant. But a clamped label no longer *occupies* its cap at narrow widths, so a stacking point derived from the cap overstates what the row needs, and the row stacks while both columns are still comfortable.

The readability floor is what should decide, so the section takes the narrower of the two:

Before:
```tsx
const sectionStackBelow = stackBelow(labelWidth ?? `${LABEL_MIN_CH}ch`);   // ←
```

After:
```tsx
const sectionStackBelow = stackBelow(
  labelWidth ? `min(${labelWidth}, ${LABEL_MIN_CH}ch)` : `${LABEL_MIN_CH}ch`,   // ←
);
```

A cap narrower than the floor is its own floor — a label cannot use room it was never given. Wider, and the floor governs.

`stackBelow` is `calc(labelFloor + FIELD_MIN_REM rem + spacing.r32)`, so with `FIELD_MIN_REM = 10` and `spacing.r32 = 2rem` the field side contributes a flat 168px at a 14px root. For a 265px cap that gives:

| | label floor | section stacks below |
| --- | --- | --- |
| before | `265px` | **433px** — both columns still comfortable, and it stacked anyway |
| after | `min(265px, 24ch)` → 194.9px | **363px** — `24ch` is the narrower of the two, so the floor is what it stops on |

A **70px band** of widths that used to stack and no longer do. Both figures follow by arithmetic from the constants named above, so a reviewer can recheck them without running anything; `24ch` lands at 194.9px because Lato's digit advance is 0.58em, or 8.12px at a 14px root. A section with no `forceLabelWidth` is unaffected: it keeps the `24ch` floor it always used.

### 🔍 Review focus

- 🔴 **Critical** — `form/Form.component.tsx` › `FormSection` — **behaviour changes for every consumer passing `forceLabelWidth`, with no opt-out**: a section that stacks today stays two-column across a 70px band. That is the point of the PR, and no API changes so existing code compiles untouched — but nobody asked for it by setting a prop.
- 🟡 **Moderate** — `form/Form.component.tsx` › `sectionStackBelow` — `min()` inside `calc()` inside a container-query condition. An unsupported function there is dropped **silently**, which would leave a section that never stacks at all. Verified rather than trusted: the browser keeps the rule as `@container responsive (max-width: calc(12rem + min(265px, 24ch)))`, and overriding the condition back to `calc(12rem + 265px)` moves the measured transition to 433px.

### 🧪 How to test

1. `npm run storybook`, open **Templates/Form → ResponsiveLabelSqueeze** and set `forceLabelWidth` to 265.
2. Drag the frame's right edge from 500px down. Labels and fields should stay side by side until about 363px, then stack. On `development/1.0` the same form stacks at 433px.
3. Anywhere in between — 400px is a good spot — confirm the two-column layout still looks right rather than merely fitting: nothing clipped, no field under its own label.
4. Sanity-check a section with no `forceLabelWidth` — it keeps the 24-character floor it has always used, unchanged.

### Follow-up

- A limitation this PR does not fix: the label track's minimum is `min-content`, so a label whose longest word is wider than the clamp is pushed back past it while its siblings sit at the clamp, and label columns stop agreeing inside the band. Pre-existing, arrived with #1193's clamp, and needs a call on whether such labels should break mid-word. Holding rows two-column across more widths makes it visible at more sizes than before — the one argument for fixing both together. Not ticketed.

### 🔗 References

- #1193 — taught the label column to shrink; this corrects the stacking point it left behind.
