### PR TITLE
CUI-47 - Charts: grid lines on the default preset, unsmoothed time series

### DIFF
--- a/src/lib/components/charts/barchart/Barchart.tsx
+++ b/src/lib/components/charts/barchart/Barchart.tsx
@@ -52,7 +52,7 @@ type BarchartDisplayOptions = {
 type ResolvedBarchartDisplayOptions = Required<BarchartDisplayOptions>;
 
 const BARCHART_PRESETS: Record<'default' | 'modern', ResolvedBarchartDisplayOptions> = {
-  default: { noBackground: false, showHorizontalGridLines: false, noYAxisLine: false, noTickLine: false, noHeader: false },
+  default: { noBackground: false, showHorizontalGridLines: true, noYAxisLine: false, noTickLine: false, noHeader: false },
   modern:  { noBackground: true,  showHorizontalGridLines: true,  noYAxisLine: true,  noTickLine: true,  noHeader: true  },
 };
 
@@ -104,7 +104,7 @@ export type BarchartProps<T extends BarchartBars> = {
   /**
    * Named display preset that sets a group of visual defaults at once.
    *
-   * - `'default'` — opaque background, no grid lines, Y-axis line visible, tick marks visible.
+   * - `'default'` — opaque background, horizontal grid lines, Y-axis line visible, tick marks visible.
    * - `'modern'`  — transparent background, horizontal grid lines, no Y-axis line, no tick marks.
    *
    * Individual values can be overridden with `displayOptions`.
@@ -229,16 +229,31 @@ export const Barchart = <T extends BarchartBars>(props: BarchartProps<T>) => {
           margin={CHART_CONSTANTS.CHART_MARGIN}
           barCategoryGap={type.type === 'category' ? type.gap : undefined}
         >
-          <CartesianGrid
-            vertical={resolvedShowHorizontalGridLines ? false : true}
-            horizontal={true}
-            {...(!resolvedShowHorizontalGridLines ? { verticalPoints: [0], horizontalPoints: [0] } : {})}
-            stroke={theme.border}
-            strokeOpacity={resolvedShowHorizontalGridLines ? 0.4 : 1}
-            syncWithTicks={resolvedShowHorizontalGridLines}
-            fill={resolvedNoBackground ? 'transparent' : theme.backgroundLevel4}
-            strokeWidth={1}
-          />
+          {/* The plot background and the two edges that frame it. They go
+              together: a preset without a background has no frame either. */}
+          {!resolvedNoBackground && (
+            <CartesianGrid
+              vertical
+              horizontal
+              verticalPoints={[0]}
+              horizontalPoints={[0]}
+              stroke={theme.border}
+              strokeWidth={1}
+              fill={theme.backgroundLevel4}
+            />
+          )}
+          {/* Grid lines proper, one per Y tick, kept behind the bars. */}
+          {resolvedShowHorizontalGridLines && (
+            <CartesianGrid
+              vertical={false}
+              horizontal
+              syncWithTicks
+              stroke={theme.border}
+              strokeOpacity={0.4}
+              strokeWidth={1}
+              fill="transparent"
+            />
+          )}
           {rechartsBars.map((bar) => {
             const { fill, dataKey, stackId } = bar;
             return (

--- a/src/lib/components/charts/linetimeseries/LineTimeSerieChart.tsx
+++ b/src/lib/components/charts/linetimeseries/LineTimeSerieChart.tsx
@@ -215,7 +215,7 @@ export function LineTimeSerieChart({
             line.withGradient ? (
               <Area
                 key={`${title}-${line.key}`}
-                type="monotone"
+                type="linear"
                 dataKey={line.dataKey}
                 stroke={line.stroke}
                 strokeWidth={1.5}
@@ -227,7 +227,7 @@ export function LineTimeSerieChart({
             ) : (
               <Line
                 key={`${title}-${line.key}`}
-                type="monotone"
+                type="linear"
                 dataKey={line.dataKey}
                 stroke={line.stroke}
                 dot={false}

--- a/src/lib/components/charts/linetimeseries/LineTimeSerieChart.types.ts
+++ b/src/lib/components/charts/linetimeseries/LineTimeSerieChart.types.ts
@@ -66,7 +66,7 @@ export type LineChartProps = (
   /**
    * Named display preset that sets a group of visual defaults at once.
    *
-   * - `'default'` — opaque background, no grid lines, header visible, Y-axis line visible.
+   * - `'default'` — opaque background, horizontal grid lines, header visible, Y-axis line visible.
    * - `'modern'`  — transparent background, horizontal grid lines, no header, no Y-axis line.
    *
    * Individual values can be overridden with `displayOptions`.
@@ -91,8 +91,8 @@ export type LineChartProps = (
    * - `noTickLine`              — hides the tick marks on the Y-axis.
    *
    * @example
-   * // Add grid lines to the default preset
-   * <LineTimeSerieChart displayOptions={{ showHorizontalGridLines: true }} ... />
+   * // Remove grid lines from the default preset
+   * <LineTimeSerieChart displayOptions={{ showHorizontalGridLines: false }} ... />
    */
   displayOptions?: {
     noBackground?: boolean;
@@ -112,7 +112,7 @@ export type LineChartProps = (
 type DisplayOptions = Required<NonNullable<LineChartProps['displayOptions']>>;
 
 export const CHART_PRESETS: Record<'default' | 'modern', DisplayOptions> = {
-  default: { noBackground: false, showHorizontalGridLines: false, noHeader: false, noYAxisLine: false, noTickLine: false },
+  default: { noBackground: false, showHorizontalGridLines: true, noHeader: false, noYAxisLine: false, noTickLine: false },
   modern:  { noBackground: true,  showHorizontalGridLines: true,  noHeader: true,  noYAxisLine: true,  noTickLine: true  },
 };
 


### PR DESCRIPTION
Two readability changes on the chart components, both reviewed live on an ARTESCA platform dashboard.

**Horizontal grid lines on the `default` preset** — `Barchart` and `LineTimeSerieChart`. The preset drew none, and with the Y axis on the right nothing tied a value on the axis to the data on the left. They use the intensity the `modern` preset already used, aligned on the Y ticks and drawn behind the data.

On the bar chart, the same flag also drove the vertical grid, so enabling grid lines silently removed the line at x=0. The plot frame now travels with the background, and the grid lines are their own layer.

**Time series drop the curve smoothing**, `monotone` to `linear`. Smoothing invented shape between two measured samples: peaks were rounded and widened, a plateau followed by a drop gained an S-curve nobody measured, and a gap in the data was disguised as a plausible curve instead of showing as a gap.

Callers that want the previous look can still pass `displayOptions={{ showHorizontalGridLines: false }}`. Preset documentation updated accordingly.

Closes CUI-47

<img width="1919" height="1769" alt="Screenshot 2026-09-04 at 19-01-32 CUI-47 before and after" src="https://github.com/user-attachments/assets/61e47179-3a26-4f8f-a9d4-260c8428e6ce" />

