### PR TITLE
Fonts: a slow webfont no longer drops the UI into Times

### DIFF
--- a/.storybook/preview-head.html
+++ b/.storybook/preview-head.html
@@ -4,15 +4,10 @@
   integrity="sha384-fnmOCqbTlWIlj8LyTjo7mOUStjsKC4pOpQbqyi7RrhN7udi9RwhKkMHpvLbHG9Sr"
   crossorigin="anonymous"
 />
-<link
-  href="https://fonts.googleapis.com/css?family=Lato:400,700"
-  rel="stylesheet"
-  type="text/css"
-/>
 <style>
   html,
   body {
-    font-family: 'Lato';
+    font-family: 'Lato', system-ui, sans-serif;
     font-size: max(14px, 0.972vw);
   }
   .main {
@@ -93,7 +88,7 @@
   .storybook-mutiselect-container {
     width: 400px;
   }
-  .sbdocs.sbdocs-wrapper{
+  .sbdocs.sbdocs-wrapper {
     padding-bottom: 0;
   }
 </style>

--- a/src/lib/components/accordion/Accordion.component.tsx
+++ b/src/lib/components/accordion/Accordion.component.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useState } from 'react';
 
 import { spacing, Stack } from '../../spacing';
+import { fontFamily } from '../../style/theme';
 import { Box } from '../box/Box';
 import { Icon } from '../icon/Icon.component';
 
@@ -38,7 +39,7 @@ const AccordionHeader = styled.button<{
   background-color: transparent;
   color: ${(props) => props.theme.textPrimary};
   padding: 0;
-  font-family: 'Lato';
+  font-family: ${fontFamily};
   ${({ $isOpen, theme }) =>
     $isOpen &&
     `

--- a/src/lib/components/buttonv2/Buttonv2.component.tsx
+++ b/src/lib/components/buttonv2/Buttonv2.component.tsx
@@ -1,7 +1,7 @@
 import type { ButtonHTMLAttributes } from 'react';
 import styled, { css } from 'styled-components';
 import { spacing } from '../../spacing';
-import { fontSize, fontWeight } from '../../style/theme';
+import { fontFamily, fontSize, fontWeight } from '../../style/theme';
 import { getContrastText } from '../../utils';
 import { Loader } from '../loader/Loader.component';
 import { Tooltip, Props as TooltipProps } from '../tooltip/Tooltip.component';
@@ -82,7 +82,7 @@ export const ButtonStyled = styled.button.withConfig({
   text-decoration: none;
   border: none;
   text-decoration: none;
-  font-family: 'Lato';
+  font-family: ${fontFamily};
   font-weight: ${fontWeight.base};
   padding: ${spacing.r4} ${spacing.r8};
   font-size: ${fontSize.base};

--- a/src/lib/components/editor/editorTheme.ts
+++ b/src/lib/components/editor/editorTheme.ts
@@ -4,7 +4,7 @@ import { tags } from '@lezer/highlight';
 import { getLuminance } from 'polished';
 import type { Extension } from '@codemirror/state';
 import type { CoreUITheme } from '../../style/theme';
-import { lineColor5 } from '../../style/theme';
+import { fontFamilyMonospace, lineColor5 } from '../../style/theme';
 
 export function isDarkBackground(theme: CoreUITheme): boolean {
   try {
@@ -46,7 +46,7 @@ export function createEditorTheme(theme: CoreUITheme): Extension {
       '&': {
         backgroundColor: theme.backgroundLevel1,
         color: theme.textPrimary,
-        fontFamily: "'Courier New', monospace",
+        fontFamily: fontFamilyMonospace,
         fontSize: '12px',
         lineHeight: '1.6',
       },

--- a/src/lib/components/inlineinput/InlineInput.tsx
+++ b/src/lib/components/inlineinput/InlineInput.tsx
@@ -8,6 +8,7 @@ import {
 import styled from 'styled-components';
 import { UseMutationResult } from 'react-query';
 import { spacing, Stack } from '../../spacing';
+import { fontFamily } from '../../style/theme';
 import { Input, InputProps } from '../inputv2/inputv2';
 import { Loader } from '../loader/Loader.component';
 import { HelperText } from '../text/Text.component';
@@ -51,7 +52,7 @@ const NameTrigger = styled.span`
   border: 1px solid ${(props) => props.theme.border};
   background: transparent;
   color: ${(props) => props.theme.textPrimary};
-  font-family: 'Lato';
+  font-family: ${fontFamily};
   font-size: 1rem;
   white-space: nowrap;
   cursor: pointer;

--- a/src/lib/components/inputv2/inputv2.tsx
+++ b/src/lib/components/inputv2/inputv2.tsx
@@ -3,7 +3,7 @@ import styled, { css } from 'styled-components';
 import { spacing } from '../../spacing';
 import { DESCRIPTION_PREFIX, useFieldContext } from '../form/Form.component';
 import { Icon, IconName } from '../icon/Icon.component';
-import { CoreUITheme } from '../../style/theme';
+import { CoreUITheme, fontFamily } from '../../style/theme';
 
 export const convertSizeToRem = (size?: '1' | '2/3' | '1/2' | '1/3') => {
   if (size === '2/3') return '14rem';
@@ -16,7 +16,7 @@ const StyledInput = styled.input<{ $hasIcon: boolean }>`
   max-width: ${(props) =>
     props.$hasIcon ? `calc(100% - 1rem - ${spacing.f8})` : '100%'};
 
-  font-family: 'Lato';
+  font-family: ${fontFamily};
   ${(props) =>
     props.disabled &&
     `

--- a/src/lib/components/navbar/Navbar.component.tsx
+++ b/src/lib/components/navbar/Navbar.component.tsx
@@ -20,6 +20,7 @@ import {
 import { Logo } from '../../icons/branding';
 import { spacing } from '../../spacing';
 import {
+  fontFamily,
   fontSize,
   fontWeight,
   navbarHeight,
@@ -358,6 +359,7 @@ const TabsMenuTrigger = styled.button`
   border: none;
   cursor: pointer;
   white-space: nowrap;
+  font-family: ${fontFamily};
   font-size: ${fontSize.base};
   color: inherit;
   background-color: transparent;

--- a/src/lib/components/tablev2/useDroppedColumns.tsx
+++ b/src/lib/components/tablev2/useDroppedColumns.tsx
@@ -15,7 +15,7 @@ import {
   useRole,
 } from '@floating-ui/react';
 import { spacing } from '../../spacing';
-import { zIndex } from '../../style/theme';
+import { fontFamily, zIndex } from '../../style/theme';
 import { getThemePropSelector } from '../../utils';
 import { Icon } from '../icon/Icon.component';
 import { Text } from '../text/Text.component';
@@ -46,6 +46,7 @@ const TriggerButton = styled.button`
   border: none;
   background: transparent;
   cursor: pointer;
+  font-family: ${fontFamily};
   color: ${getThemePropSelector('textPrimary')};
   &:hover {
     background-color: ${getThemePropSelector('highlight')};

--- a/src/lib/components/textarea/TextArea.component.tsx
+++ b/src/lib/components/textarea/TextArea.component.tsx
@@ -10,6 +10,7 @@ import {
 } from 'react';
 import styled, { css } from 'styled-components';
 import { spacing } from '../../spacing';
+import { fontFamily } from '../../style/theme';
 
 type TextAreaVariant = 'code' | 'text';
 type Props = TextareaHTMLAttributes<HTMLTextAreaElement> & {
@@ -36,7 +37,7 @@ const TextAreaContainer = styled.textarea.withConfig({
   border-radius: 4px;
   resize: ${(props) => (props.$autoGrow ? 'none' : 'vertical')};
   font-family: ${(props) =>
-    props.$variant === 'code' ? 'Courier New' : 'Lato'};
+    props.$variant === 'code' ? "'Courier New', monospace" : fontFamily};
   font-size: ${spacing.f14};
 
   ${(props) =>

--- a/src/lib/components/textarea/TextArea.component.tsx
+++ b/src/lib/components/textarea/TextArea.component.tsx
@@ -10,7 +10,7 @@ import {
 } from 'react';
 import styled, { css } from 'styled-components';
 import { spacing } from '../../spacing';
-import { fontFamily } from '../../style/theme';
+import { fontFamily, fontFamilyMonospace } from '../../style/theme';
 
 type TextAreaVariant = 'code' | 'text';
 type Props = TextareaHTMLAttributes<HTMLTextAreaElement> & {
@@ -37,7 +37,7 @@ const TextAreaContainer = styled.textarea.withConfig({
   border-radius: 4px;
   resize: ${(props) => (props.$autoGrow ? 'none' : 'vertical')};
   font-family: ${(props) =>
-    props.$variant === 'code' ? "'Courier New', monospace" : fontFamily};
+    props.$variant === 'code' ? fontFamilyMonospace : fontFamily};
   font-size: ${spacing.f14};
 
   ${(props) =>

--- a/src/lib/index.css
+++ b/src/lib/index.css
@@ -1,6 +1,6 @@
 html,
 body {
-  font-family: 'Lato';
+  font-family: 'Lato', system-ui, sans-serif;
   font-size: max(14px, 0.972vw);
 }
 
@@ -8,6 +8,7 @@ body {
 @font-face {
   font-family: 'Lato';
   font-style: normal;
+  font-display: swap;
   font-weight: normal;
   src:
     url('./style/fonts/Lato-Regular.woff2') format('woff2'),
@@ -19,6 +20,7 @@ body {
 @font-face {
   font-family: 'Lato';
   font-style: normal;
+  font-display: swap;
   font-weight: bold;
   src:
     url('./style/fonts/Lato-Bold.woff2') format('woff2'),
@@ -30,6 +32,7 @@ body {
 @font-face {
   font-family: 'Fira Code';
   font-style: normal;
+  font-display: swap;
   font-weight: 400;
   src:
     url('./style/fonts/FiraCode-Regular.woff2') format('woff2'),

--- a/src/lib/style/theme.ts
+++ b/src/lib/style/theme.ts
@@ -217,9 +217,10 @@ export const chartColors = {
   lineColor8,
 };
 
-// The trailing generic is load-bearing: a bare `'Lato'` falls back to the
-// browser's default font, which is a serif.
+// The trailing generic is load-bearing on both: a family name with nothing
+// after it falls back to the browser's default font, which is a serif.
 export const fontFamily = "'Lato', system-ui, sans-serif";
+export const fontFamilyMonospace = "'Courier New', monospace";
 
 export const fontSize = {
   smaller: '0.71rem',

--- a/src/lib/style/theme.ts
+++ b/src/lib/style/theme.ts
@@ -217,6 +217,10 @@ export const chartColors = {
   lineColor8,
 };
 
+// The trailing generic is load-bearing: a bare `'Lato'` falls back to the
+// browser's default font, which is a serif.
+export const fontFamily = "'Lato', system-ui, sans-serif";
+
 export const fontSize = {
   smaller: '0.71rem',
   small: '0.85rem',


### PR DESCRIPTION
**TL;DR** — A slow or failed Lato load no longer drops the whole UI into a serif: text renders in a system sans and swaps to Lato as soon as it arrives.

<img width="800" height="270" alt="font-fallback-before-after" src="https://github.com/user-attachments/assets/85962cf9-ce04-4916-a915-97110c8e4050" />

*Storybook with the Lato requests blocked. Only the `font-family` and `font-display` declarations differ between the two.*

### Context / Why

Reported as typography that was sometimes right and sometimes wrong on the same build, with a reload fixing it only some of the time. Whether the webfont wins its race against the rest of the page decided which font you got, and losing that race was far more visible than it should have been.

### 🧩 Approach

Every `font-family` in the library named `'Lato'` with nothing after it. A single unavailable family does not fall back to a comparable face — it falls back to the browser's default, which is a serif. Rendering `Good morning, …` at weight 700 / 32px in Chromium 152 on macOS, with Lato absent:

| declaration | width | matches |
| --- | --- | --- |
| a bare unavailable family (before) | 248.03px | `serif` — and `Times New Roman` to the pixel |
| the same family + `system-ui, sans-serif` (after) | 246.50px | `system-ui` |
| `serif` (reference) | 248.03px | |
| `system-ui` (reference) | 246.50px | |
| `sans-serif` (reference) | 270.19px | |

The absolute widths only exist to identify each row; the finding is which reference each one lands on. Before, a lost font race resolved to Times. After, it resolves to the platform UI face.

The stack is `'Lato', system-ui, sans-serif`, defined once as a `fontFamily` token beside the existing `fontSize` and `fontWeight` exports. Only the trailing generic is load-bearing for the bug — `system-ui` is there so the interim render is the platform UI face rather than Helvetica, and an engine that doesn't know the keyword simply skips it and takes `sans-serif`.

Form controls carry the declaration themselves rather than inheriting it, because `input`, `button` and `textarea` do not inherit font from `body` — the UA stylesheet gives them their own. That turned out to cover two cases: the five declarations that named `'Lato'` directly, and two native buttons that named no family at all and so had never rendered in Lato. The navbar's tab-overflow trigger and the table's dropped-columns `+N` trigger both computed `Arial` before this change and `Lato, system-ui, sans-serif` after.

Separately, no `@font-face` set `font-display`, leaving it at `auto`: Chrome holds text **invisible** for ~3s and only then paints a fallback. `swap` paints immediately and substitutes Lato whenever it arrives. It is also the only value that always converges on Lato — `fallback` and `optional` stop substituting after their swap period, which would leave the font shown dependent on the load, and that nondeterminism is the reported complaint.

The ticket also asked for a monospace token. `fontFamilyMonospace` is `'Courier New', monospace` and has two call sites, since the editor theme already carried the same literal as the `code` variant of `TextArea`. Behaviour-preserving — the code textarea still computes to `Courier New, monospace`.

### 🔧 Usage

Consumers declaring the family themselves have the same gap, and can now take the stack from the library instead of repeating it:

```ts
// before — src/lib/components/accordion/Accordion.component.tsx
font-family: 'Lato';

// after
import { fontFamily } from '../../style/theme';

font-family: ${fontFamily};   // ←
```

Externally that import is `@scality/core-ui/dist/style/theme`.

### 🔍 Review focus

- 🟡 **Moderate** — `src/lib/index.css` › the three `@font-face` rules — `font-display: swap` changes first paint for *every* consumer: a brief flash of the fallback replaces a brief blank. That is the intended trade, but it is visible on every cold load, so it is the line to disagree with if anyone wants to.
- 🟡 **Moderate** — `src/lib/style/theme.ts` › `fontFamily` — `system-ui` is not metric-matched to Lato, so there is a small reflow when Lato swaps in. Bounded to the first paint of a cold load. A `size-adjust` fallback face would remove it; deliberately not done here.
- ⚪ **Minor** — `Navbar.component.tsx` › `TabsMenuTrigger` and `tablev2/useDroppedColumns.tsx` › `TriggerButton` — these two change what a user sees today rather than only under a failed font load, since both were in `Arial` on every render. Small, visible, and outside the strict reading of the ticket.

### 🧪 How to test

1. `npm run storybook`
2. Open a story with buttons and text inputs (Buttonv2, Input, TextArea, Accordion). Everything should be in Lato — including the Navbar "More" tab-overflow trigger, and the Table `+N` dropped-columns trigger below ~560px, both of which were in Arial before.
3. DevTools → Network → add a request-blocking pattern for `*Lato*`, then reload.
4. Expect everything in the platform UI font — **not** in Times. Before this change the same step rendered serif.
5. Remove the block and reload: text appears immediately, then becomes Lato — it should never be invisible while the font loads.

### Follow-up

- The same `html, body` rule also sets `font-size` on **both** selectors. A consumer that overrides only `html` therefore ends up with `html` and `body` at different sizes, so `rem` and inherited `em` scale on different curves. Real defect, deliberately out of scope: fixing it moves the rem scale for every consumer and needs its own verification sweep. No ticket for it yet.
- The library bundles a Fira Code `@font-face` that nothing declares, so the code surfaces render Courier New while a bundled monospace face goes unused. Either the face or the token should probably go; no ticket yet.

### 🔗 References

- [CUI-48](https://scality.atlassian.net/browse/CUI-48) — a slow or failed Lato load renders the whole UI in the browser default serif

<details><summary>What changed</summary>

Eleven files: the `fontFamily` and `fontFamilyMonospace` tokens in `src/lib/style/theme.ts`, the `html, body` stack plus `font-display: swap` in `src/lib/index.css`, the token applied at the five component declarations that named the family directly (Accordion, Buttonv2, InlineInput, Input, TextArea) and at the two native buttons that named none (Navbar, tablev2), the monospace token at its second call site (`editor/editorTheme.ts`), and Storybook's `preview-head.html`.

That last one is dev-only: it declared a bare `'Lato'` on `html, body` and pulled the family from Google Fonts, so the dev surface kept the defect the library was fixing and never exercised the bundled `@font-face` rules where `font-display` lives.

The three `@font-face` `font-family` descriptors keep a bare family name on purpose — they declare what the family is *called*, so a fallback list there would be meaningless.

`selectv2/SelectStyle.ts` already used `font-family: inherit` and is untouched. Buttons whose only content is an icon (IconHelper, TextBadge's remove control) are left alone — they render no text for a family to apply to.

</details>


[CUI-48]: https://scality.atlassian.net/browse/CUI-48?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
