### PR TITLE
Attachment table: keep the search suggestions aligned with the field

### DIFF
--- a/src/lib/organisms/attachments/AttachmentTable.tsx
+++ b/src/lib/organisms/attachments/AttachmentTable.tsx
@@ -74,8 +74,13 @@ export type AttachmentTableProps<
 
 const rowHeight = 'h48';
 
+/**
+ * Anchored to `SearchBoxContainer`'s padding box with `left`/`right` rather than given a
+ * width, so the menu follows the field through a resize that causes no re-render -- a
+ * container query, or a side panel opening. Both insets also let the used width resolve
+ * from the over-constrained equation, so the borders need no compensating.
+ */
 const MenuContainer = styled.ul<{
-  $width: string;
   $isOpen: boolean;
   $searchInputIsFocused: boolean;
 }>`
@@ -84,7 +89,8 @@ const MenuContainer = styled.ul<{
   padding: 0;
   list-style: none;
   position: absolute;
-  width: ${(props) => props.$width};
+  left: ${spacing.r16};
+  right: ${spacing.r16};
   z-index: 1;
   margin: 0;
   ${(props) =>
@@ -119,10 +125,6 @@ const SearchBoxContainer = styled.div`
  * `flex-grow: 1` is inert on the normal path -- `SearchBoxContainer` is a block, so
  * there is no flex line to grow along. It is kept for the error path, where the
  * input sits in a `Stack` beside a `Loader`.
- *
- * So the box is a fixed 287px, and this component cannot change that: `SearchInput`
- * pins `width: max-content` and does not forward `fluid`. That is this table's next
- * floor, at a 301px container.
  */
 const StyledSearchInput = styled(SearchInput)<{ $searchInputIsFocused }>`
   flex-grow: 1;
@@ -500,7 +502,6 @@ export const AttachmentTable = <
   }, [reset]);
 
   // UI styling states
-  const [searchWidth, setSearchWidth] = useState('0px');
   const [searchInputIsFocused, setSearchInputIsFocused] = useState(false);
 
   return (
@@ -605,19 +606,7 @@ export const AttachmentTable = <
         }))}
         defaultSortingKey="name"
       >
-        <SearchBoxContainer
-          {...{
-            ref: (element) => {
-              if (element?.firstElementChild) {
-                setSearchWidth(
-                  element.firstElementChild.getBoundingClientRect().width -
-                    2 +
-                    'px',
-                );
-              }
-            },
-          }}
-        >
+        <SearchBoxContainer>
           {filteredEntities.status === 'error' ? (
             <Tooltip
               overlay={
@@ -666,7 +655,6 @@ export const AttachmentTable = <
           )}
           <MenuContainer
             {...getMenuProps()}
-            $width={searchWidth}
             $isOpen={isOpen}
             $searchInputIsFocused={searchInputIsFocused}
           >

--- a/src/lib/organisms/attachments/AttachmentTable.tsx
+++ b/src/lib/organisms/attachments/AttachmentTable.tsx
@@ -23,7 +23,7 @@ import {
   Text,
   Tooltip,
 } from '../../index';
-import styled from 'styled-components';
+import styled, { css } from 'styled-components';
 import { spacing, Stack, Wrap } from '../../spacing';
 import {
   AttachableEntity,
@@ -75,22 +75,22 @@ export type AttachmentTableProps<
 const rowHeight = 'h48';
 
 /**
- * Anchored to `SearchBoxContainer`'s padding box with `left`/`right` rather than given a
- * width, so the menu follows the field through a resize that causes no re-render -- a
- * container query, or a side panel opening. Both insets also let the used width resolve
- * from the over-constrained equation, so the borders need no compensating.
+ * Anchored to `SearchAnchor`, which is exactly as wide as the field, with `left`/`right`
+ * rather than given a width -- so the menu follows the field through a resize that causes
+ * no re-render: a container query, or a side panel opening. The old `-2px` border
+ * compensation is gone with it -- an auto width between two insets already lands on the
+ * border box.
  */
 const MenuContainer = styled.ul<{
   $isOpen: boolean;
-  $searchInputIsFocused: boolean;
 }>`
   background-color: ${(props) => props.theme.backgroundLevel1};
   background-clip: content-box;
   padding: 0;
   list-style: none;
   position: absolute;
-  left: ${spacing.r16};
-  right: ${spacing.r16};
+  left: 0;
+  right: 0;
   z-index: 1;
   margin: 0;
   ${(props) =>
@@ -102,9 +102,7 @@ const MenuContainer = styled.ul<{
       border-bottom-left-radius: 4px;
       border: 1px solid ${props.theme.selectedActive};
   `
-      : props.$searchInputIsFocused
-        ? `border-bottom: 1px solid ${props.theme.selectedActive};`
-        : ''}
+      : ''}
   border-top: 0;
   li {
     padding: ${spacing.r8};
@@ -117,24 +115,48 @@ const MenuContainer = styled.ul<{
 `;
 
 const SearchBoxContainer = styled.div`
-  position: relative;
   padding: ${spacing.r16};
+`;
+
+/**
+ * The menu's containing block, sized to the field rather than to the padding box around
+ * it: the field hugs its own content, so a menu spanning the whole box would be wider
+ * than the field it belongs to.
+ */
+const SearchAnchor = styled.div`
+  position: relative;
+  width: fit-content;
+  max-width: 100%;
 `;
 
 /**
  * `flex-grow: 1` is inert on the normal path -- `SearchBoxContainer` is a block, so
  * there is no flex line to grow along. It is kept for the error path, where the
  * input sits in a `Stack` beside a `Loader`.
+ *
+ * The seam with the open menu is keyed on the menu's own open state rather than on
+ * `:focus-within`. Both edges of the seam then move on one state change: an outside
+ * click blurs the input on `mousedown`, while the menu closes on the `mouseup` that
+ * follows, so a focus-driven seam reappeared under a menu that was still open.
+ *
+ * `&&` is load-bearing. `Input` paints its own border from `:hover` and
+ * `:focus-within`, both of which carry a pseudo-class and so outrank a plain
+ * `& > div`; the class has to be doubled to win. The old `& > div:focus-within`
+ * outranked them for free, which is why dropping the pseudo-class needed this.
  */
-const StyledSearchInput = styled(SearchInput)<{ $searchInputIsFocused }>`
+const StyledSearchInput = styled(SearchInput)<{ $isOpen: boolean }>`
   flex-grow: 1;
 
-  & > div:focus-within {
-    border-color: ${(props) => props.theme.selectedActive};
-    border-bottom-left-radius: 0;
-    border-bottom-right-radius: 0;
-    border-bottom: 0;
-  }
+  ${(props) =>
+    props.$isOpen &&
+    css`
+      && > div {
+        border-color: ${props.theme.selectedActive};
+        border-bottom-left-radius: 0;
+        border-bottom-right-radius: 0;
+        border-bottom: 0;
+      }
+    `}
 `;
 
 /**
@@ -501,9 +523,6 @@ export const AttachmentTable = <
     resetRef.current = reset;
   }, [reset]);
 
-  // UI styling states
-  const [searchInputIsFocused, setSearchInputIsFocused] = useState(false);
-
   return (
     /* `iconOnly` is a `@container responsive` query and needs an ancestor declaring
        that container -- this table's own box, not whatever the consumer provides.
@@ -607,118 +626,105 @@ export const AttachmentTable = <
         defaultSortingKey="name"
       >
         <SearchBoxContainer>
-          {filteredEntities.status === 'error' ? (
-            <Tooltip
-              overlay={
-                <>We failed to load the entities, hence search is disabled</>
-              }
-            >
-              <Stack>
-                <StyledSearchInput
-                  autoComplete="off"
-                  placeholder={searchEntityPlaceholder}
-                  {...getInputProps({
-                    ref: (element) => {
-                      if (element) searchInputRef.current = element;
-                    },
-                  })}
-                  onFocus={() => {
-                    openMenu();
-                    setSearchInputIsFocused(true);
-                  }}
-                  onBlur={() => {
-                    setSearchInputIsFocused(false);
-                  }}
-                  disabled={filteredEntities.status === 'error'}
-                />
-                <Loader />
-              </Stack>
-            </Tooltip>
-          ) : (
-            <StyledSearchInput
-              autoComplete="off"
-              placeholder={searchEntityPlaceholder}
-              {...getInputProps({
-                ref: (element) => {
-                  if (element) searchInputRef.current = element;
-                },
-              })}
-              onFocus={() => {
-                openMenu();
-                setSearchInputIsFocused(true);
-              }}
-              onBlur={() => {
-                setSearchInputIsFocused(false);
-              }}
-              $searchInputIsFocused={searchInputIsFocused}
-            />
-          )}
-          <MenuContainer
-            {...getMenuProps()}
-            $isOpen={isOpen}
-            $searchInputIsFocused={searchInputIsFocused}
-          >
-            {isOpen &&
-              filteredEntities.status === 'success' &&
-              filteredEntities.data?.entities.map((item, index) => (
-                <li
-                  key={`${item.id}${index}`}
-                  {...getItemProps({ item, index })}
-                >
-                  <Text>{item.name}</Text>
-                </li>
-              ))}
-            {isOpen && filteredEntities.status === 'loading' && (
-              <li>
-                <Text>Searching...</Text>
-              </li>
+          <SearchAnchor>
+            {filteredEntities.status === 'error' ? (
+              <Tooltip
+                overlay={
+                  <>We failed to load the entities, hence search is disabled</>
+                }
+              >
+                <Stack>
+                  <StyledSearchInput
+                    autoComplete="off"
+                    placeholder={searchEntityPlaceholder}
+                    {...getInputProps({
+                      ref: (element) => {
+                        if (element) searchInputRef.current = element;
+                      },
+                    })}
+                    onFocus={openMenu}
+                    disabled={filteredEntities.status === 'error'}
+                    $isOpen={isOpen}
+                  />
+                  <Loader />
+                </Stack>
+              </Tooltip>
+            ) : (
+              <StyledSearchInput
+                autoComplete="off"
+                placeholder={searchEntityPlaceholder}
+                {...getInputProps({
+                  ref: (element) => {
+                    if (element) searchInputRef.current = element;
+                  },
+                })}
+                onFocus={openMenu}
+                $isOpen={isOpen}
+              />
             )}
-            {isOpen && filteredEntities.status === 'error' && (
-              <li>
-                <Text color="statusCritical">
-                  An error occured while searching
-                </Text>
-              </li>
-            )}
-            {isOpen &&
-              filteredEntities.status === 'success' &&
-              (filteredEntities.data?.number || 0) >
-                filteredEntities.data?.entities.length && (
-                <li>
-                  <Text
-                    isGentleEmphazed={true}
-                    color="textSecondary"
-                    style={{ textAlign: 'right' }}
+            <MenuContainer {...getMenuProps()} $isOpen={isOpen}>
+              {isOpen &&
+                filteredEntities.status === 'success' &&
+                filteredEntities.data?.entities.map((item, index) => (
+                  <li
+                    key={`${item.id}${index}`}
+                    {...getItemProps({ item, index })}
                   >
-                    There{' '}
-                    {(filteredEntities.data?.number || 0) -
-                      filteredEntities.data?.entities.length ===
-                    1
-                      ? 'is'
-                      : 'are'}{' '}
-                    {(filteredEntities.data?.number || 0) -
-                      filteredEntities.data?.entities.length}{' '}
-                    more{' '}
-                    {(filteredEntities.data?.number || 0) -
-                      filteredEntities.data?.entities.length ===
-                    1
-                      ? entityName.singular
-                      : entityName.plural}{' '}
-                    matching your search. Suggestion: try more specific search
-                    expression.
-                  </Text>
-                </li>
-              )}
-            {isOpen &&
-              filteredEntities.status === 'success' &&
-              filteredEntities.data?.entities.length === 0 && (
+                    <Text>{item.name}</Text>
+                  </li>
+                ))}
+              {isOpen && filteredEntities.status === 'loading' && (
                 <li>
-                  <Text isGentleEmphazed={true} color="textSecondary">
-                    No {entityName.plural} found matching your search.
+                  <Text>Searching...</Text>
+                </li>
+              )}
+              {isOpen && filteredEntities.status === 'error' && (
+                <li>
+                  <Text color="statusCritical">
+                    An error occured while searching
                   </Text>
                 </li>
               )}
-          </MenuContainer>
+              {isOpen &&
+                filteredEntities.status === 'success' &&
+                (filteredEntities.data?.number || 0) >
+                  filteredEntities.data?.entities.length && (
+                  <li>
+                    <Text
+                      isGentleEmphazed={true}
+                      color="textSecondary"
+                      style={{ textAlign: 'right' }}
+                    >
+                      There{' '}
+                      {(filteredEntities.data?.number || 0) -
+                        filteredEntities.data?.entities.length ===
+                      1
+                        ? 'is'
+                        : 'are'}{' '}
+                      {(filteredEntities.data?.number || 0) -
+                        filteredEntities.data?.entities.length}{' '}
+                      more{' '}
+                      {(filteredEntities.data?.number || 0) -
+                        filteredEntities.data?.entities.length ===
+                      1
+                        ? entityName.singular
+                        : entityName.plural}{' '}
+                      matching your search. Suggestion: try more specific search
+                      expression.
+                    </Text>
+                  </li>
+                )}
+              {isOpen &&
+                filteredEntities.status === 'success' &&
+                filteredEntities.data?.entities.length === 0 && (
+                  <li>
+                    <Text isGentleEmphazed={true} color="textSecondary">
+                      No {entityName.plural} found matching your search.
+                    </Text>
+                  </li>
+                )}
+            </MenuContainer>
+          </SearchAnchor>
         </SearchBoxContainer>
         <Table.SingleSelectableContent
           rowHeight={rowHeight}

--- a/stories/attachment.stories.tsx
+++ b/stories/attachment.stories.tsx
@@ -140,8 +140,8 @@ export const ConfirmationModal = {
  *
  * Drag `frameWidth` down. At **360px** the row's `Remove` button drops its label for
  * a tooltip; without it the row bleeds out of the panel with nothing to show it,
- * since these panels are `overflow: visible`. The next floor is the search box at
- * **301px**, which is `SearchInput`'s fixed width and not fixable from here.
+ * since these panels are `overflow: visible`. The search box below it now shrinks
+ * with the panel rather than pinning a width of its own.
  */
 export const NarrowPanel = {
   argTypes: {


### PR DESCRIPTION
**TL;DR** — Attachment table: the entity search's suggestion list no longer hangs past the field's edge when the layout narrows, and the field's border and the list now stop being highlighted at the same moment instead of a beat apart.

<!-- SCREENSHOT-MISSING — the before/after pair is captured and measured, but not attached: no browser signed in to GitHub was reachable in this session, and GitHub has no image-upload API. The measurements the pair shows are in the table below. -->

### Context / Why

The suggestion list is anchored to the search box, and until #1201 that box could not change width, so a width measured once was always right. Making the box shrinkable is what exposed the measurement: the field now narrows with its container, and the list did not follow.

### 🧩 Approach

The width came from a DOM measurement held in React state. It is now two CSS insets on a wrapper that is itself exactly as wide as the field, so there is no width to keep in sync at all.

**Before**

```tsx
const [searchWidth, setSearchWidth] = useState('0px');

<SearchBoxContainer
  ref={(element) => {                                                 // ←
    if (element?.firstElementChild) {
      setSearchWidth(
        element.firstElementChild.getBoundingClientRect().width - 2 + 'px',
      );
    }
  }}
>
  <MenuContainer {...getMenuProps()} $width={searchWidth} />          // ←
```

**After**

```tsx
const SearchAnchor = styled.div`
  position: relative;
  width: fit-content;        /* ← the field's width, not the padding box's */
  max-width: 100%;
`;

<SearchBoxContainer>
  <SearchAnchor>
    <StyledSearchInput … />
    <MenuContainer {...getMenuProps()} />   /* left: 0; right: 0 */
  </SearchAnchor>
```

`fit-content` is what makes the insets correct: the field hugs its own content, so a wrapper that stretched would put the list on the padding box and leave it wider than the field it belongs to.

**Measured** — one list held open while the panel is resized underneath it, which is the case the old code could not see, since its measurement only refreshed on render:

| Panel | Field | List before | Overhang before | List after |
|---:|---:|---:|---:|---:|
| 600px | 287px | 287px | 0 | 287px |
| 360px | 287px | 287px | 0 | 287px |
| 300px | 272px | 287px | **+15px** | 272px |
| 260px | 232px | 287px | **+55px** | 232px |
| 220px | 192px | 287px | **+95px** | 192px |

The field only begins to shrink below about 351px, which is why the defect has a floor and stayed unnoticed. Widening back to 600px recovers in both builds, so the stale value was never permanent — just wrong for as long as the panel stayed narrow.

The second change is when the field stops looking active. Its seam with the open list was drawn from `:focus-within`, and the list from its own open state — two different events:

| Clicking outside | Before | After |
|---|---|---|
| `mousedown` | the field drops its seam, because focus has already left | nothing — the list is still open |
| `mouseup` | the list closes, a beat later | seam and list go together |

Keying the seam on the same open state the list uses collapses that into one transition.

### 🔍 Review focus

- 🟡 **Moderate** — `organisms/attachments/AttachmentTable.tsx › StyledSearchInput` — the `&&` in the seam rule is load-bearing, not a habit. `Input` paints its own border from `:hover` and `:focus-within`, both of which carry a pseudo-class and outrank a single-class `& > div`; the old selector won for free because it carried one too. Dropping an `&` leaves the open state silently unstyled.
- 🟡 **Moderate** — same file, the two `StyledSearchInput` call sites — the removed `onBlur` was spread *after* `getInputProps()`, so it had been overriding downshift's own blur handler. Removing it hands that back: tabbing out of the field now closes the list, which it did not before.
- ⚪ **Minor** — same file › `SearchAnchor` — `position: relative` moved off `SearchBoxContainer` onto the new wrapper. The list is the only absolutely positioned element in the file, so nothing else changes containing block.

### 🧪 How to test

1. Open the `NarrowPanel` attachment story in Storybook.
2. Click into the entity search so the suggestion list opens.
3. Keeping it open, narrow the panel **without** using the `frameWidth` control — resize the frame element from devtools, so React does not re-render. The list should stay flush with the field; below ~350px the field shrinks and the list should shrink with it.
4. Click outside. The field's highlight and the list should go at the same moment, not one and then the other.
5. Focus the field again and press <kbd>Tab</kbd>. The list should close.

### Follow-up

- The before/after pair is captured and needs attaching by hand; there is no API for it and no signed-in browser was reachable here. Until it is, the measured table above stands in for it.

### 🔗 References

- #1201 — made the search box shrinkable, which is what made this observable.

<details><summary>What changed</summary>

Two comments claimed the search box was a fixed 287px and that this was the table's narrowest point; neither has been true since #1201, and leaving them would send the next reader looking for a floor that no longer exists. One is in this file, the other in the `NarrowPanel` story.

The `searchInputIsFocused` state goes with them, along with the list's focused-but-closed bottom border that was its only consumer — with the seam now keyed on the open state, the field keeps its own border in that state and already draws that edge.

</details>

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
