### PR TITLE
Button: an icon-only button no longer loses its hover hint

### DIFF
--- a/src/lib/components/buttonv2/Buttonv2.component.test.tsx
+++ b/src/lib/components/buttonv2/Buttonv2.component.test.tsx
@@ -113,6 +113,31 @@ describe('Button iconOnly', () => {
     );
   });
 
+  it('falls back to the label when a conditional tooltip overlay resolves to false', async () => {
+    // The shape a consumer reaches for to explain why a button is unavailable.
+    // With every guard passing it resolves to `false`, not to `undefined`.
+    const canManage = true;
+    const providerDisabled = false;
+    const unavailableReason =
+      (!canManage && 'You need the manager role') ||
+      (providerDisabled && 'The provider is deactivated');
+
+    render(
+      <Button
+        variant="primary"
+        icon={<span aria-hidden>+</span>}
+        label="Create"
+        iconOnly
+        tooltip={{ overlay: unavailableReason }}
+      />,
+      { wrapper: Wrapper },
+    );
+    await userEvent.hover(screen.getByRole('button', { name: 'Create' }));
+    await waitFor(() =>
+      expect(screen.getAllByText('Create').length).toBeGreaterThan(1),
+    );
+  });
+
   it('warns when a non-string label is collapsed with only a non-string tooltip overlay', () => {
     const warn = jest.spyOn(console, 'warn').mockImplementation(() => {});
     try {

--- a/src/lib/components/buttonv2/Buttonv2.component.tsx
+++ b/src/lib/components/buttonv2/Buttonv2.component.tsx
@@ -373,8 +373,11 @@ function Button({
       : labelDrivenAriaLabel;
 
   // An `iconOnly` button hides its label, so it must always offer a hover hint.
-  // An explicit tooltip wins; otherwise fall back to the label itself.
-  const tooltipOverlay = tooltip?.overlay ?? (iconOnly ? label : undefined);
+  // An explicit tooltip wins; otherwise fall back to the label itself. Guarded
+  // on truthiness, not nullishness: a conditional overlay written as
+  // `(guard && reason) || ...` yields `false` when no guard matches, and a
+  // falsy overlay renders no tooltip at all.
+  const tooltipOverlay = tooltip?.overlay || (iconOnly ? label : undefined);
 
   return (
     <Tooltip


### PR DESCRIPTION
**TL;DR** — Button: a collapsed button could end up with nothing at all on hover — no visible label and no tooltip — and now falls back to showing its label.

![before](https://github.com/user-attachments/assets/5e64ca57-77cd-42c6-be01-195309df8685)
![after](https://github.com/user-attachments/assets/032b078d-5528-4c4f-bdbd-4a220964eeef)

*The same collapsed button, hovered, dark theme at 420×260 — its tooltip conditional on checks that all passed. Left: nothing appears. Right: the button names itself.*

### Context / Why

Collapsing a button hides its label, so `Button` hands the label back as a hover hint. That fallback missed the most natural way a caller builds a conditional tooltip, so those buttons collapsed to a bare icon with no name on hover — the one case the fallback exists for.

### 🧩 Approach

```tsx
// before
const tooltipOverlay = tooltip?.overlay ?? (iconOnly ? label : undefined);   // ←

// after
const tooltipOverlay = tooltip?.overlay || (iconOnly ? label : undefined);   // ←
```

`??` falls through only on `null` and `undefined`. A conditional overlay is normally assembled from guards:

```tsx
const unavailableReason =
  (!canManage && 'You need the manager role') ||
  (providerDisabled && 'The provider is deactivated');
```

With every guard passing, that expression is `false`, not `undefined`. `??` accepted the `false`, `Tooltip` renders nothing for a falsy overlay, and the collapsed button was left with no name. Guarding on truthiness makes any falsy overlay mean "no explicit tooltip" — the only reading under which a value that renders nothing can be meaningful.

### 🔧 Usage

No call site has to change. The shape that was broken, taken from the test this PR adds:

```tsx
<Button
  variant="primary"
  icon={<span aria-hidden>+</span>}
  label="Create"
  iconOnly
  tooltip={{ overlay: unavailableReason }}   // ← `false` when no guard matches
/>
```

### 🔍 Review focus

- 🟡 **Moderate** — `buttonv2/Buttonv2.component.tsx › Button` — the fallback now fires on any falsy overlay, so a collapsed button whose overlay resolves falsy shows its label where it previously showed nothing. One expression, covered by the new test, trivially revertible.
- ⚪ **Minor** — same line — `''` and `0` are swept up with `false`. Neither ever rendered as a tooltip, so a caller passing one already had a collapsed button with no hint *and* no accessible name; reading them as absent fixes that rather than overriding an intent.

Note that the type union already requires a `string` overlay on a button with no `label` at all, so this only ever bit the `iconOnly` + `label` variant — which is what the new test covers.

### 🧪 How to test

1. `npx jest src/lib/components/buttonv2` — the new case is *falls back to the label when a conditional tooltip overlay resolves to false*.
2. Render a `Button` with `iconOnly`, a `label`, an `icon`, and `tooltip={{ overlay: false }}`.
3. Hover it. Before this change nothing appeared; the label should now show.
4. Swap in `tooltip={{ overlay: 'Something else' }}` and confirm an explicit overlay still wins over the label.

### 🔗 References

- #1191 — the Responsive guideline naming what declares the container a button collapses against; the same collapse path this hover hint belongs to.

<details><summary>What changed</summary>

One expression in `Buttonv2.component.tsx`, plus a regression test written in the shape the value actually arises in — a guard chain evaluating to `false`, rather than a literal `false`, since the literal is not how a caller reaches it.

</details>
