### PR TITLE
Form and Checkbox: label markers stay with the last word

### DIFF
--- a/src/lib/components/checkbox/Checkbox.component.test.tsx
+++ b/src/lib/components/checkbox/Checkbox.component.test.tsx
@@ -25,6 +25,25 @@ describe('Checkbox', () => {
     expect(onChange).toHaveBeenCalledTimes(1);
   });
 
+  /**
+   * A trailing space is a soft-wrap opportunity in front of the room reserved for
+   * the help icon, which drops the icon onto a line of its own. jsdom has no
+   * layout, so what is pinned here is the trim itself -- with an identity
+   * normalizer, since the default one would collapse the space away.
+   */
+  it('strips a trailing space from a label that carries a help icon', () => {
+    render(
+      <Checkbox
+        label="Platform Admin "
+        labelHelpTooltip="Can manage users and groups."
+      />,
+    );
+
+    expect(
+      screen.getByText('Platform Admin', { normalizer: (text) => text }),
+    ).toBeInTheDocument();
+  });
+
   it('keeps the help affordance inside the label it annotates', () => {
     render(
       <Checkbox

--- a/src/lib/components/checkbox/Checkbox.component.tsx
+++ b/src/lib/components/checkbox/Checkbox.component.tsx
@@ -8,7 +8,11 @@ import {
 import styled, { css } from 'styled-components';
 import { spacing } from '../../spacing';
 
-import { helpIconReserve, LabelHelpIcon } from '../iconhelper/IconHelper';
+import {
+  helpIconReserve,
+  LabelHelpIcon,
+  trimLabelEnd,
+} from '../iconhelper/IconHelper';
 import { COMPACT_LINE_HEIGHT, Text } from '../text/Text.component';
 import { FocusVisibleStyle } from '../buttonv2/Buttonv2.component';
 
@@ -132,7 +136,7 @@ const Checkbox = forwardRef<HTMLInputElement, Props>(
                 compact
                 $reserveHelpIcon={hasHelpIcon}
               >
-                {label}
+                {trimLabelEnd(label)}
               </LabelText>
               {hasHelpIcon && (
                 <LabelHelpIcon tooltipMessage={labelHelpTooltip} />

--- a/src/lib/components/form/Form.component.tsx
+++ b/src/lib/components/form/Form.component.tsx
@@ -15,6 +15,7 @@ import {
   helpIconReserve,
   IconHelp,
   LabelHelpIcon,
+  trimLabelEnd,
 } from '../iconhelper/IconHelper';
 import { ScrollbarWrapper } from '../scrollbarwrapper/ScrollbarWrapper.component';
 import { HelperText, Text } from '../text/Text.component';
@@ -370,9 +371,11 @@ const FormGroup = ({
         color={disabled ? undefined : 'textSecondary'}
         $reserveHelpIcon={!!labelHelpTooltip}
       >
-        {label}
-        {requireMode !== 'all' && required && ' *'}
-        {requireMode === 'all' && !required && ' (optional)'}
+        {trimLabelEnd(label)}
+        {/* Non-breaking spaces: a marker is an annotation on the label's last
+            word, and a plain space lets it wrap onto a line of its own. */}
+        {requireMode !== 'all' && required && '\u00a0*'}
+        {requireMode === 'all' && !required && '\u00a0(optional)'}
       </LabelText>
       {labelHelpTooltip && <LabelHelpIcon tooltipMessage={labelHelpTooltip} />}
     </label>

--- a/src/lib/components/form/Form.test.tsx
+++ b/src/lib/components/form/Form.test.tsx
@@ -59,13 +59,14 @@ describe('Form', () => {
   /**
    * The marker is appended to the label inside the same `LabelText`, so it is
    * the piece that silently falls out of the accessible name -- or loses the
-   * space before it -- if that composition is restructured. Tone itself is
+   * space before it -- if that composition is restructured. The space is a
+   * non-breaking one, and the accessible name keeps it verbatim. Tone itself is
    * deliberately not asserted: reading a colour declaration back out proves
    * nothing.
    */
   it.each([
-    ['partial', 'User name', true, 'User name *'],
-    ['all', 'Description', false, 'Description (optional)'],
+    ['partial', 'User name', true, 'User name\u00a0*'],
+    ['all', 'Description', false, 'Description\u00a0(optional)'],
   ])(
     'keeps the %s-mode marker in the field accessible name',
     (requireMode, label, required, expected) => {
@@ -88,6 +89,30 @@ describe('Form', () => {
       expect(screen.getByRole('textbox')).toHaveAccessibleName(expected);
     },
   );
+
+  /**
+   * The accessible name above cannot see either half of this: it collapses a
+   * non-breaking space and a plain one to the same thing. Read the rendered text
+   * with an identity normalizer instead.
+   */
+  it('glues the required marker to a label that ends in a space', () => {
+    render(
+      <Form layout={{ kind: 'tab' }}>
+        <FormSection>
+          <FormGroup
+            id="spaced-field"
+            label="User name "
+            required
+            content={<input type="text" id="spaced-field" />}
+          />
+        </FormSection>
+      </Form>,
+    );
+
+    expect(
+      screen.getByText('User name\u00a0*', { normalizer: (text) => text }),
+    ).toBeInTheDocument();
+  });
 
   // jsdom has no layout, so the icon's position is out of reach here. What this pins
   // is that moving the icon out of its old wrapper kept it inside its label.

--- a/src/lib/components/iconhelper/IconHelper.tsx
+++ b/src/lib/components/iconhelper/IconHelper.tsx
@@ -38,6 +38,16 @@ export const helpIconReserve = css`
   padding-right: calc(${HELP_ICON_SIZE} + ${spacing.r8});
 `;
 
+/**
+ * Strips a label's trailing whitespace before `helpIconReserve` is applied to it.
+ * The reserve sits at the end of the label's own inline box, so a trailing space
+ * leaves a soft-wrap opportunity in front of it and the icon lands alone on the
+ * next line -- the one thing the reserve exists to prevent. A label built from a
+ * template literal picks one up easily: `` `${name} ${suffix}` `` with an empty
+ * suffix ends in a space.
+ */
+export const trimLabelEnd = (label: string) => label.trimEnd();
+
 const HelpIconSlot = styled.span`
   display: inline-block;
   margin-left: -${HELP_ICON_SIZE};


### PR DESCRIPTION
**TL;DR** — Form and Checkbox: a required field's `*`, an `(optional)` suffix and a label's help icon could each end up alone on a second line; all three now stay with the label's last word.

<!-- SCREENSHOT-MISSING — the before/after pair belongs here: a narrow form section with one required label wrapping, and a checkbox with a help icon whose label ends in a space. Both browser bridges were unavailable in the session that opened this PR. -->

### Context / Why

All three are annotations on the label's last word, and each is separated from it by something the line breaker is free to break at. Narrow the label column enough — a side panel, a container query — and the marker goes over on its own, reading as though it belongs to nothing.

### 🧩 Approach

Two different separators, so two fixes.

The text markers were joined with an ordinary space, which is a soft-wrap opportunity:

```tsx
// before
{requireMode !== 'all' && required && ' *'}              // ←
{requireMode === 'all' && !required && ' (optional)'}    // ←

// after
{requireMode !== 'all' && required && '\u00a0*'}              // ←
{requireMode === 'all' && !required && '\u00a0(optional)'}    // ←
```

The help icon has no space of its own — `helpIconReserve` pads the end of the label's inline box and the icon sits back in that room, so it costs the last line nothing. What defeats it is a label that *ends* in a space: that leaves a break opportunity in front of the reserve, and the icon orphans anyway. So the label is trimmed before the reserve is applied, in both components that use it:

```tsx
// after — Checkbox and FormGroup
{trimLabelEnd(label)}                                    // ←
```

A label built from a template literal picks up a trailing space easily — `` `${name} ${suffix}` `` with an empty suffix — which is how this shows up in practice rather than in theory. `trimLabelEnd` lives beside `helpIconReserve`, since it is part of that mechanism's contract rather than a general utility.

**One consequence worth knowing about:** `toHaveAccessibleName` does *not* normalise U+00A0 to a plain space, so the marker now reaches the accessible name as a non-breaking space. Screen readers announce it the same way, but an assertion written against `'User name *'` will fail. The two existing marker tests in this repo are updated to expect it.

### 🔧 Usage

No API change. The only thing a consumer may need to touch is a test:

```tsx
// before
expect(screen.getByRole('textbox')).toHaveAccessibleName('User name *');        // ←

// after
expect(screen.getByRole('textbox')).toHaveAccessibleName('User name\u00a0*');   // ←
```

### 🔍 Review focus

- 🟡 **Moderate** — `form/Form.component.tsx › FormGroup` — the non-breaking space is now part of the field's accessible name. Loud failure rather than silent (a consumer's assertion breaks at test time), but it is a contract change and the alternative — keeping a breakable space and accepting the orphan — is a real option to weigh.
- ⚪ **Minor** — `iconhelper/IconHelper.tsx › trimLabelEnd` — a new export, deliberately not added to the package barrel: it exists to be paired with `helpIconReserve` by the two components that use it.

### 🧪 How to test

1. `npx jest src/lib/components/form src/lib/components/checkbox`
2. By hand, in Storybook: open a form story with a required field and narrow the frame until the label wraps. The `*` should stay on the same line as the last word, at every width.
3. Render a `Checkbox` whose `label` ends in a space and which has a `labelHelpTooltip`. The `?` icon should sit at the end of the label's last line, not below it.
4. Confirm the icon is still vertically aligned with that line's text — the misalignment reported alongside this was a consequence of the icon being on a line of its own.

### Follow-up

- A label whose own text ends in a space is now silently trimmed. If a consumer is building labels by concatenation and relies on that space for spacing between the label and something it renders itself, that spacing is gone — no such call site is known in this repo.

### 🔗 References

- #1198 — introduced `helpIconReserve` for the form label's help icon; this closes the trailing-space hole in it.
- #1199 — put `labelHelpTooltip` on `Checkbox`, which is the surface this was reported on.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
