### PR TITLE
ScrollbarWrapper: scope the dead WebKit rules to engines that use them

### DIFF
--- a/src/lib/components/scrollbarwrapper/ScrollbarWrapper.component.tsx
+++ b/src/lib/components/scrollbarwrapper/ScrollbarWrapper.component.tsx
@@ -75,21 +75,38 @@ const GlobalStyle = createGlobalStyle`
   }
 
 ${(props) => {
-    const brand = props.theme;
-    return css`
-    // Custom scrollbar
+  const brand = props.theme;
+  return css`
+    /*
+     * The scrollbar's appearance, in the two standard properties. This is what
+     * every current engine renders, and 'thin' is a keyword rather than a length:
+     * the engine picks the pixels, so nothing here can promise a width.
+     */
     * {
-      // Chrome / Safari / Edge
-      ::-webkit-scrollbar {
+      scrollbar-color: ${brand.border} ${brand.backgroundLevel3}; // fallback for gradient themes
+      scrollbar-color: ${brand.buttonSecondary} ${brand.backgroundLevel3};
+      scrollbar-width: thin;
+    }
+
+    /*
+     * The legacy WebKit pseudo-elements, as a fallback only. Setting either standard
+     * property on an element makes Chromium ignore its ::-webkit-scrollbar rules, and
+     * the block above sets both on every element -- so outside this guard the rules
+     * below never take effect, and the 8px they name is not the bar anyone sees.
+     * Selectors are written flat: nested under the universal selector they compile
+     * to a descendant combinator, which can never match the root scroller.
+     */
+    @supports not (scrollbar-width: thin) {
+      *::-webkit-scrollbar {
         width: 8px;
         height: 8px;
       }
 
-      ::-webkit-scrollbar-track {
+      *::-webkit-scrollbar-track {
         background: ${brand.backgroundLevel3};
       }
 
-      ::-webkit-scrollbar-thumb {
+      *::-webkit-scrollbar-thumb {
         width: 4px;
         height: 4px;
         min-height: 20px;
@@ -101,27 +118,23 @@ ${(props) => {
         border: 2px solid rgba(0, 0, 0, 0);
       }
 
-      ::-webkit-scrollbar-thumb:vertical:hover,
-      ::-webkit-scrollbar-thumb:horizontal:hover {
+      *::-webkit-scrollbar-thumb:vertical:hover,
+      *::-webkit-scrollbar-thumb:horizontal:hover {
         background-color: rgba(89, 90, 120, 0.5);
       }
 
-      ::-webkit-scrollbar-button {
+      *::-webkit-scrollbar-button {
         width: 0;
         height: 0;
         display: none;
       }
-      ::-webkit-scrollbar-corner {
+
+      *::-webkit-scrollbar-corner {
         background-color: transparent;
       }
-
-      // Firefox
-      scrollbar-color: ${brand.border} ${brand.backgroundLevel3}; // fallback for gradient themes
-      scrollbar-color: ${brand.buttonSecondary} ${brand.backgroundLevel3};
-      scrollbar-width: thin;
     }
   `;
-  }}
+}}
 `;
 
 function ScrollbarWrapper({ children }: Props) {

--- a/stories/ScrollbarWrapper/scrollbar.guideline.mdx
+++ b/stories/ScrollbarWrapper/scrollbar.guideline.mdx
@@ -10,6 +10,9 @@ import * as ScrollbarWrapperStories from './scrollbar.stories';
 It provides two things:
 
 - **Custom scrollbar styles** — a thin, themed scrollbar across Chrome, Safari, and Firefox.
+  The bar's width is the browser's own rendering of `scrollbar-width: thin`, not a length this
+  component sets: it differs per engine, per platform, and if a consumer overrides the property.
+  Reserve room for it with `scrollbar-gutter: stable`, never with a hard-coded pixel value.
 - **`scroll-fade` utility class** — an opt-in bottom fade on any scrollable element (see below).
 
 ## Setup


### PR DESCRIPTION
**TL;DR** — ScrollbarWrapper: the forty lines of WebKit scrollbar styling have had no effect in any current browser, and the 8px they name is not the bar anyone sees; they are now scoped to the engines that would actually use them, with no change to what renders today.

### Context / Why

The component styles scrollbars two ways at once: the two standard properties (`scrollbar-color`, `scrollbar-width`) and a block of `::-webkit-scrollbar` pseudo-element rules. Only the first pair is doing anything. This came up because a hard-coded `8px` read off this file was about to be published as a constant for other components to compensate against — and the real bar is 11px.

### 🧩 Approach

Two independent reasons the WebKit block cannot apply, one of them measured:

| Probe, on a running page with this component mounted | Bar width |
|---|---|
| A scroller inheriting the global `scrollbar-width: thin` | 11px |
| The same probe forced to `scrollbar-width: auto` | 15px |
| What `::-webkit-scrollbar { width: 8px }` would give | never observed |

Chromium ignores an element's `::-webkit-scrollbar` rules once that element has author-specified standard scrollbar properties — and this component sets `scrollbar-width` on `*`, so every element qualifies, always. The second reading is what makes this conclusive rather than inferred: under `scrollbar-width: auto` the WebKit `width: 8px` would still win if the pseudo-elements were being consulted at all, and it measured the platform default instead.

Separately, the rules were authored nested inside the universal selector:

```
// before — compiles to `* ::-webkit-scrollbar`, a descendant selector
* {
  ::-webkit-scrollbar { width: 8px; }      // ←
  scrollbar-width: thin;
}

// after — flat, so it can also reach the root scroller
@supports not (scrollbar-width: thin) {    // ←
  *::-webkit-scrollbar { width: 8px; }     // ←
}
* { scrollbar-width: thin; }
```

`html` has no ancestor element, so the old form could never have matched the page's own scrollbar in any engine, WebKit included.

So the block goes behind `@supports not (scrollbar-width: thin)`, which is what it has effectively been all along: a fallback for engines without the standard properties. Nothing changes for any engine that has them, which is every current one. The guideline gains a line saying the bar's width belongs to the engine — it is a keyword, not a length, and differs per engine, per platform and under a consumer override — so room for it is reserved with `scrollbar-gutter: stable` rather than a pixel value.

### 🔍 Review focus

- 🟡 **Moderate** — `scrollbarwrapper/ScrollbarWrapper.component.tsx` — the behaviour change, if any, is confined to a browser that supports `::-webkit-scrollbar` but *not* `scrollbar-width` (Safari below 18.2, Chromium below 121). There the rules now apply where they previously matched only non-root elements, so such a browser gets *more* of the intended styling, not less. Worth a second opinion on whether that window matters.
- ⚪ **Minor** — same file — the thumb, track, hover, button and corner rules move with the width rule; none of them was reachable either.

### 🧪 How to test

1. Open any Storybook story with a scrollable area in Chrome. The scrollbar should look exactly as it does on `development/1.0` — thin and themed, not the platform default.
2. Repeat in Firefox: unchanged there too, since Firefox never supported the WebKit pseudo-elements.
3. In devtools, measure a scroller's `offsetWidth - clientWidth`. It should read the same before and after this change (11px on a standard Chromium setup, not 8px).
4. To exercise the fallback branch, disable `scrollbar-width` support — easiest in a browser that lacks it rather than by simulation.

### Follow-up

- The same component is implicated in a separate, unrelated defect: its rules are cleared document-wide after a navigation when more than one copy of the library renders it. That has its own diagnosis and is not touched here.

### 🔗 References

- #1196 — reserved the scrollbar gutter on the form's scroll area with `scrollbar-gutter: stable`, which is the mechanism the guideline now points consumers at.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
