### PR TITLE
Tabs: stop insetting a tab's content twice on the right

### DIFF
--- a/src/lib/components/tabsv2/StyledTabs.ts
+++ b/src/lib/components/tabsv2/StyledTabs.ts
@@ -90,7 +90,17 @@ export const TabContent = styled.div<{
   $withoutPadding?: boolean;
 }>`
   margin: 0;
-  padding: ${(props) => (props.$withoutPadding ? '0' : spacing.r16)};
+  /*
+   * No right padding: the right gutter belongs to whatever the tab renders. A tab
+   * form already carries one of its own -- its layout's padding plus the room it
+   * reserves for its scrollbar -- and a second one here lands on top of it, which
+   * is what put the form's scrollbar in the middle of a gap instead of near the
+   * edge. Content that wants a right inset and has none of its own has to supply it.
+   */
+  padding: ${(props) =>
+    props.$withoutPadding
+      ? '0'
+      : `${spacing.r16} 0 ${spacing.r16} ${spacing.r16}`};
   display: block;
   width: 100%;
   height: calc(100% - ${spacing.r40});


### PR DESCRIPTION
> **Do not merge yet.** This is one half of an alignment change; on its own it makes a tab form's action buttons overhang its fields by the width of a scrollbar. The other half is undecided — see *Follow-up*.

**TL;DR** — Tabs: a tab's content was inset on the right twice when the content already had a gutter of its own, leaving a form's scrollbar floating in the middle of a gap instead of near the edge; the tab no longer adds that side.

<!-- SCREENSHOT-MISSING — the before/after pair belongs here: a tab-layout form's right edge, showing the scrollbar's distance from the tab border. Both browser bridges were unavailable in the session that opened this PR. -->

### Context / Why

`TabContent` insets its content by 1rem on all four sides. A tab-layout `Form` carries a right gutter of its own — its layout's `padding-right` plus the room reserved for its scrollbar — so on that side the two stack up.

### 🧩 Approach

```
// before
padding: 1rem;                 // ←

// after
padding: 1rem 0 1rem 1rem;     // ←
```

The right gutter belongs to whatever the tab renders, since only the content knows whether it has already paid for one. Left, top and bottom stay — nothing else supplies those.

**What this changes for content that has no gutter of its own**, which is the reason this is worth a look rather than a rubber stamp. Every `<Tab>` call site across the consuming applications:

| | Call sites | Already pass `withoutPadding` |
|---|---|---|
| One application's identity surfaces | 24 | 8 |
| One application's monitoring panels | 3 | 1 |
| Everything else searched (six repos) | 0 | — |

The nine that already opt out of padding entirely are unaffected. The remaining eighteen lose a 1rem right inset unless their content brings one — and none of them has a `Form` as its *direct* child: every one renders a repo-local wrapper component, so the change cannot be conditioned on what the child turns out to be.

That leaves two shapes for this, and this PR takes the first:

1. **Make it the default**, as here: the tab stops claiming a side it cannot reason about, and the ~18 call sites that want a right inset add one. Simple rule, some fallout to clean up in the consumers.
2. **A per-`Tab` opt-in** beside the existing `withoutPadding`, so nothing changes until a call site asks. No fallout, one more prop on an API whose padding story is already two props wide.

### 🔍 Review focus

- 🟡 **Moderate** — `tabsv2/StyledTabs.ts › TabContent` — every tab in every product renders through this. The blast radius is cosmetic and uniform (one edge, 1rem), but it is not zero, and option 2 above avoids it entirely.

### 🧪 How to test

1. Open a tab whose body is a `layout={{ kind: 'tab' }}` form.
2. The form's scrollbar should now sit near the tab's right border rather than a gap away from it.
3. Open a tab whose body is a plain block or table with no gutter of its own, and confirm whether losing the 1rem reads as wrong there. That judgement is what decides between the two options above.

### Follow-up

- **The other half of the alignment.** With the doubled inset gone, a tab form's `Cancel` / `Save` / `Delete` row is left ending further right than the fields below it, by exactly the scrollbar's width. That row is not a scroll container, so `scrollbar-gutter` is inert on it, and the bar's width is a keyword rather than a length — there is no constant to compensate with. It has its own diagnosis and three candidate fixes, none chosen. **This PR should not merge before that is settled**, or the visible result is a worse misalignment than the one it fixes.

### 🔗 References

- #1196 — reserved the scrollbar gutter inside the form's scroll area. That reserve is the right-side inset this change stops doubling.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
