### PR TITLE
improvement(charts): an optional logarithmic Y axis on Barchart and LineTimeSerieChart

### DIFF
--- a/src/lib/components/charts/barchart/Barchart.test.tsx
+++ b/src/lib/components/charts/barchart/Barchart.test.tsx
@@ -153,6 +153,117 @@ describe('Barchart', () => {
     });
   });
 
+  describe('Logarithmic Y axis', () => {
+    const spanningBars = [
+      {
+        label: 'Success',
+        data: [
+          ['category1', 2],
+          ['category2', 300],
+          ['category3', 0],
+        ],
+      },
+    ] as const;
+
+    /**
+     * The Y-axis tick labels, whitespace stripped: formatISONumber groups
+     * thousands with a non-breaking space, which is not what a test wants to
+     * pin down.
+     */
+    const yAxisTicks = (container: HTMLElement) =>
+      Array.from(
+        container.querySelectorAll('.recharts-yAxis-tick-labels text'),
+      ).map((tick) => (tick.textContent ?? '').replace(/\s/g, ''));
+
+    const renderBarchart = (props: {
+      yAxisScale?: 'linear' | 'log';
+      stacked?: boolean;
+    }) => {
+      const { Wrapper } = getWrapper();
+      return render(
+        <Wrapper>
+          <ChartLegendWrapper colorSet={testColorSet}>
+            <Barchart
+              title="Test Title"
+              type={{ type: 'category' }}
+              bars={spanningBars}
+              {...props}
+            />
+          </ChartLegendWrapper>
+        </Wrapper>,
+      );
+    };
+
+    it('labels the axis with the decades enclosing the data, plus a zero', () => {
+      const { container } = renderBarchart({ yAxisScale: 'log' });
+
+      // 2..300 gives a 1..1000 scale — a log axis cannot start at zero — and the
+      // dataset holds a zero, so the axis reserves a slot below it for one.
+      expect(yAxisTicks(container)).toEqual(['0', '1', '10', '100', '1000']);
+    });
+
+    it('reserves no zero slot when the data has none', () => {
+      const { Wrapper } = getWrapper();
+      const { container } = render(
+        <Wrapper>
+          <ChartLegendWrapper colorSet={testColorSet}>
+            <Barchart
+              title="Test Title"
+              type={{ type: 'category' }}
+              bars={[
+                {
+                  label: 'Success',
+                  data: [
+                    ['category1', 2],
+                    ['category2', 300],
+                  ],
+                },
+              ]}
+              yAxisScale="log"
+            />
+          </ChartLegendWrapper>
+        </Wrapper>,
+      );
+
+      // An empty band would spend a decade's worth of plot height on nothing.
+      expect(yAxisTicks(container)).toEqual(['1', '10', '100', '1000']);
+    });
+
+    it('keeps the linear ticks when no scale is asked for', () => {
+      const { container } = renderBarchart({});
+
+      // A linear axis starts at zero and tops out at the data, not at a decade.
+      expect(yAxisTicks(container)[0]).toBe('0');
+      expect(yAxisTicks(container)).not.toContain('1000');
+    });
+
+    it('draws a measured zero at the reserved slot rather than hiding it', () => {
+      const { container } = renderBarchart({ yAxisScale: 'log' });
+
+      // category3 is 0. It gets a rectangle like the other two — minPointSize
+      // gives it a visible stub at the `0` tick — so a measured zero stays
+      // distinguishable from an absent bar, which draws nothing at all.
+      expect(screen.getByText('category3')).toBeInTheDocument();
+      const heights = Array.from(
+        container.querySelectorAll('.recharts-bar-rectangle path'),
+      )
+        .map((rect) => Number(rect.getAttribute('height')))
+        .sort((a, b) => a - b);
+
+      expect(heights).toHaveLength(3);
+      // The zero is the shortest bar, at the minPointSize floor.
+      expect(heights[0]).toBe(3);
+      expect(heights[1]).toBeGreaterThan(3);
+    });
+
+    it('falls back to a linear axis when stacked, whose segments log would misplace', () => {
+      const { container } = renderBarchart({ yAxisScale: 'log', stacked: true });
+
+      expect(yAxisTicks(container)[0]).toBe('0');
+      expect(yAxisTicks(container)).not.toContain('1000');
+    });
+  });
+
   describe('Time data', () => {
     it('should render the chart with correct starting days even if the data is missing', async () => {
       const { Wrapper } = getWrapper();

--- a/src/lib/components/charts/barchart/Barchart.tsx
+++ b/src/lib/components/charts/barchart/Barchart.tsx
@@ -13,7 +13,15 @@ import { Stack } from '../../../spacing';
 import { chartColors, ChartColors, fontSize } from '../../../style/theme';
 import { useChartLegend } from '../legend/ChartLegendWrapper';
 import { BarchartTooltip } from './BarchartTooltip';
-import { formatTickValue, getTicks, splitTickLines } from '../common/chartUtils';
+import {
+  formatLogTickValue,
+  formatTickValue,
+  getLogAxis,
+  getTicks,
+  hasZeroValue,
+  placeNonPositiveValues,
+  splitTickLines,
+} from '../common/chartUtils';
 import { useChartData } from './Barchart.utils';
 import {
   ChartHeader,
@@ -55,6 +63,9 @@ const BARCHART_PRESETS: Record<'default' | 'modern', ResolvedBarchartDisplayOpti
   default: { noBackground: false, showHorizontalGridLines: true, noYAxisLine: false, noTickLine: false, noHeader: false },
   modern:  { noBackground: true,  showHorizontalGridLines: true,  noYAxisLine: true,  noTickLine: true,  noHeader: true  },
 };
+
+/** A Recharts row. `null` is a value the axis cannot place — see `dropNonPositiveValues`. */
+type BarchartRow = { [key: string]: string | number | null };
 
 export type Point = {
   key: string | number;
@@ -116,6 +127,32 @@ export type BarchartProps<T extends BarchartBars> = {
    * Only the properties you specify are overridden; the rest come from the preset.
    */
   displayOptions?: BarchartDisplayOptions;
+  /**
+   * Y-axis scale.
+   *
+   * `'log'` is for a dataset whose values span orders of magnitude: on a linear
+   * axis the small bars collapse onto the baseline and only the largest one is
+   * readable, and a log axis gives each decade the same height instead. The
+   * axis is bounded by the decades enclosing the data, and its ticks are the
+   * decades themselves.
+   *
+   * It changes the display and nothing else: no value is rescaled, and the
+   * tooltip, the legend and the unit scaling all keep the numbers the caller
+   * passed in.
+   *
+   * Two things it cannot do:
+   * - A bar whose value is zero or negative is dropped, because a log axis
+   *   has nowhere to put it. It renders as a gap, which is the same thing an
+   *   absent bar renders as — so on a log axis "measured zero" and "no data"
+   *   become indistinguishable. They are not the same fact. Stay linear where
+   *   that difference matters.
+   * - `stacked` falls back to a linear axis. Stacking places each segment at
+   *   a cumulative sum, so on a log axis a segment's height stops matching
+   *   its value and the chart misreads.
+   *
+   * @default 'linear'
+   */
+  yAxisScale?: 'linear' | 'log';
 };
 
 /* ---------------------------------- MAIN COMPONENT ---------------------------------- */
@@ -141,6 +178,7 @@ export const Barchart = <T extends BarchartBars>(props: BarchartProps<T>) => {
     rightTitle,
     isLoading,
     isError,
+    yAxisScale = 'linear',
     displayPreset = 'default',
     displayOptions,
   } = props;
@@ -175,6 +213,8 @@ export const Barchart = <T extends BarchartBars>(props: BarchartProps<T>) => {
     rechartsData,
     topDomain,
     valueBase,
+    minPositiveValue,
+    normalizedMaxValue,
   } = useChartData(
     bars || [],
     type,
@@ -185,6 +225,37 @@ export const Barchart = <T extends BarchartBars>(props: BarchartProps<T>) => {
     stackedBarSort,
   );
   const titleWithUnit = unitLabel ? `${title} (${unitLabel})` : title;
+
+  // Stacking a log axis would put each segment at a cumulative sum, so its
+  // height would no longer match its value. Linear is the honest fallback.
+  const isLogScale = yAxisScale === 'log' && !stacked;
+
+  const logAxis = useMemo(
+    () =>
+      isLogScale
+        ? getLogAxis(minPositiveValue, normalizedMaxValue, {
+            // Only spend a band when there is a zero to put in it.
+            withZeroBand: hasZeroValue(rechartsData, 'category'),
+          })
+        : null,
+    [isLogScale, minPositiveValue, normalizedMaxValue, rechartsData],
+  );
+
+  // A zero would draw towards minus infinity, so it moves to the axis's zero
+  // band, where `minPointSize` gives it a visible stub at the `0` tick. An
+  // absent bar draws nothing at all, so the two stay distinguishable — which
+  // matters here, because `transformCategoryData` fills an absent bar with 0.
+  const chartData = useMemo<BarchartRow[]>(
+    () =>
+      logAxis
+        ? placeNonPositiveValues<BarchartRow>(
+            rechartsData,
+            'category',
+            logAxis.zeroValue,
+          )
+        : rechartsData,
+    [logAxis, rechartsData],
+  );
 
   const tickFormatter = useCallback(
     (value: number) => formatTickValue(value, roundReferenceValue),
@@ -197,11 +268,11 @@ export const Barchart = <T extends BarchartBars>(props: BarchartProps<T>) => {
     if (type.type !== 'category') {
       return 1;
     }
-    return rechartsData.reduce((max, point) => {
+    return chartData.reduce((max, point) => {
       const lineCount = splitTickLines(point.category ?? '').length;
       return Math.max(max, lineCount);
     }, 1);
-  }, [type.type, rechartsData]);
+  }, [type.type, chartData]);
 
   const xAxisHeight = TICK_BASE_HEIGHT + (maxTickLines - 1) * TICK_LINE_HEIGHT;
 
@@ -216,7 +287,7 @@ export const Barchart = <T extends BarchartBars>(props: BarchartProps<T>) => {
     return (
       <StyledResponsiveContainer ref={chartRef} width="100%" height={height}>
         <RechartsBarChart
-          data={rechartsData}
+          data={chartData}
           accessibilityLayer
           barSize={
             type.type === 'category'
@@ -272,9 +343,18 @@ export const Barchart = <T extends BarchartBars>(props: BarchartProps<T>) => {
 
           <YAxis
             interval={0}
-            domain={[0, topDomain]}
-            ticks={getTicks(roundReferenceValue, false)}
-            tickFormatter={tickFormatter}
+            scale={logAxis ? 'log' : 'auto'}
+            domain={logAxis ? logAxis.domain : [0, topDomain]}
+            // A log axis is bounded by whole decades, so a value below the
+            // floor is clipped rather than dragging the axis down to it.
+            allowDataOverflow={logAxis !== null}
+            ticks={logAxis ? logAxis.ticks : getTicks(roundReferenceValue, false)}
+            tickFormatter={
+              logAxis
+                ? (value: number) =>
+                    formatLogTickValue(value, logAxis.zeroValue)
+                : tickFormatter
+            }
             axisLine={resolvedNoYAxisLine ? false : { stroke: theme.border }}
             tickLine={resolvedNoTickLine ? false : { stroke: theme.border }}
             tick={{
@@ -312,6 +392,7 @@ export const Barchart = <T extends BarchartBars>(props: BarchartProps<T>) => {
                 unitLabel={unitLabel}
                 unitRange={unitRange}
                 valueBase={valueBase}
+                logZeroValue={logAxis?.zeroValue ?? null}
                 chartContainerRef={chartRef}
               />
             )}

--- a/src/lib/components/charts/barchart/Barchart.tsx
+++ b/src/lib/components/charts/barchart/Barchart.tsx
@@ -64,7 +64,7 @@ const BARCHART_PRESETS: Record<'default' | 'modern', ResolvedBarchartDisplayOpti
   modern:  { noBackground: true,  showHorizontalGridLines: true,  noYAxisLine: true,  noTickLine: true,  noHeader: true  },
 };
 
-/** A Recharts row. `null` is a value the axis cannot place — see `dropNonPositiveValues`. */
+/** A Recharts row. `null` is a value the axis cannot place — see `placeNonPositiveValues`. */
 type BarchartRow = { [key: string]: string | number | null };
 
 export type Point = {
@@ -140,12 +140,15 @@ export type BarchartProps<T extends BarchartBars> = {
    * tooltip, the legend and the unit scaling all keep the numbers the caller
    * passed in.
    *
-   * Two things it cannot do:
-   * - A bar whose value is zero or negative is dropped, because a log axis
-   *   has nowhere to put it. It renders as a gap, which is the same thing an
-   *   absent bar renders as — so on a log axis "measured zero" and "no data"
-   *   become indistinguishable. They are not the same fact. Stay linear where
-   *   that difference matters.
+   * A zero has no logarithm, so the axis reserves one slot below its first
+   * decade, labels it `0`, and draws zeros there as a stub bar. A measured
+   * zero stays distinguishable from an absent one, which are different facts
+   * and which a gap would render identically. The slot costs a decade's worth
+   * of height, so it is only reserved when the data actually holds a zero.
+   *
+   * Two things it will not do:
+   * - A negative bar is dropped and leaves a gap. A dataset that goes negative
+   *   does not belong on a log axis at all.
    * - `stacked` falls back to a linear axis. Stacking places each segment at
    *   a cumulative sum, so on a log axis a segment's height stops matching
    *   its value and the chart misreads.

--- a/src/lib/components/charts/barchart/Barchart.utils.ts
+++ b/src/lib/components/charts/barchart/Barchart.utils.ts
@@ -2,7 +2,11 @@ import { BarchartProps, BarchartBars } from './Barchart';
 import { TooltipContentProps } from 'recharts';
 import { chartColors, ChartColors } from '../../../style/theme';
 import { useChartLegend } from '../legend/ChartLegendWrapper';
-import { normalizeChartDataWithUnits } from '../common/chartUtils';
+import {
+  getMinPositiveValue,
+  normalizeChartDataWithUnits,
+  readLogPlottedValue,
+} from '../common/chartUtils';
 import { UnitRange } from '../types';
 
 export const getMaxBarValue = (
@@ -410,12 +414,25 @@ export const useChartData = <T extends BarchartBars>(
     rechartsData,
     topDomain,
     valueBase,
+    // Read off the normalized data, like topDomain: a log axis is bounded by
+    // the smallest bar it has to show, and that bound has to be in the same
+    // units as the axis.
+    minPositiveValue: getMinPositiveValue(rechartsData, 'category'),
+    // maxValue is pre-normalization; the log axis needs the value the axis will
+    // actually plot.
+    normalizedMaxValue: valueBase === 0 ? maxValue : maxValue / valueBase,
   };
 };
 
+/**
+ * @param logZeroValue - A log axis's reserved zero band, so a bar drawn there is
+ *   reported as the 0 it actually is — to the default tooltip and to a caller's
+ *   own `tooltip` renderer alike.
+ */
 export const getCurrentPoint = <T extends BarchartBars>(
   props: TooltipContentProps<number, string>,
   hoveredValue: string | undefined,
+  logZeroValue: number | null = null,
 ) => {
   const { payload, label } = props;
 
@@ -425,7 +442,7 @@ export const getCurrentPoint = <T extends BarchartBars>(
     isHovered: boolean;
   }[] = payload.map((item) => ({
     label: item.name,
-    value: item.value,
+    value: readLogPlottedValue(item.value, logZeroValue),
     isHovered: item.name === hoveredValue,
   }));
 

--- a/src/lib/components/charts/barchart/BarchartTooltip.test.tsx
+++ b/src/lib/components/charts/barchart/BarchartTooltip.test.tsx
@@ -170,3 +170,46 @@ describe('ChartTooltip', () => {
     expect(screen.getByText('20 kB')).toBeInTheDocument();
   });
 });
+
+describe('BarchartTooltip on a logarithmic axis', () => {
+  it('reports a bar drawn at the reserved zero band as the 0 it is', () => {
+    // 0.1 is where getLogAxis put the band; the bar is drawn there, and the
+    // tooltip must not report the position as if it were the measurement.
+    render(
+      <BarchartTooltip
+        type={{ type: 'category' }}
+        tooltipProps={{
+          ...testTooltipProps,
+          payload: [
+            { name: 'Success', value: 0.1 },
+            { name: 'Failed', value: 42 },
+          ],
+        }}
+        hoveredValue={undefined}
+        logZeroValue={0.1}
+        chartContainerRef={mockChartContainerRef}
+      />,
+    );
+
+    expect(screen.getByText('0')).toBeInTheDocument();
+    expect(screen.queryByText('0.1')).not.toBeInTheDocument();
+    // Every other value is untouched.
+    expect(screen.getByText(/42/)).toBeInTheDocument();
+  });
+
+  it('leaves the value alone with no band in play', () => {
+    render(
+      <BarchartTooltip
+        type={{ type: 'category' }}
+        tooltipProps={{
+          ...testTooltipProps,
+          payload: [{ name: 'Success', value: 0.1 }],
+        }}
+        hoveredValue={undefined}
+        chartContainerRef={mockChartContainerRef}
+      />,
+    );
+
+    expect(screen.getByText('0.1')).toBeInTheDocument();
+  });
+});

--- a/src/lib/components/charts/barchart/BarchartTooltip.tsx
+++ b/src/lib/components/charts/barchart/BarchartTooltip.tsx
@@ -21,6 +21,7 @@ export const BarchartTooltip = <T extends BarchartBars>({
   unitLabel,
   unitRange,
   valueBase = 1,
+  logZeroValue = null,
   chartContainerRef,
 }: {
   type: TimeType | CategoryType;
@@ -31,6 +32,8 @@ export const BarchartTooltip = <T extends BarchartBars>({
   unitLabel?: string;
   unitRange?: UnitRange;
   valueBase?: number;
+  /** A log axis's reserved zero band, reported as 0 rather than as its position. */
+  logZeroValue?: number | null;
   chartContainerRef: React.RefObject<HTMLDivElement>;
 }) => {
   const { active, coordinate } = tooltipProps;
@@ -39,7 +42,7 @@ export const BarchartTooltip = <T extends BarchartBars>({
     return null;
   }
 
-  const currentPoint = getCurrentPoint(tooltipProps, hoveredValue);
+  const currentPoint = getCurrentPoint(tooltipProps, hoveredValue, logZeroValue);
 
   const duration =
     type.type === 'time'

--- a/src/lib/components/charts/common/chartUtils.test.ts
+++ b/src/lib/components/charts/common/chartUtils.test.ts
@@ -1,4 +1,10 @@
 import {
+  formatLogTickValue,
+  getLogAxis,
+  getMinPositiveValue,
+  hasZeroValue,
+  placeNonPositiveValues,
+  readLogPlottedValue,
   getRoundReferenceValue,
   getTicks,
   getUnitLabel,
@@ -511,5 +517,187 @@ describe('formatTooltipValueWithUnit', () => {
         '20 kB',
       );
     });
+  });
+});
+
+describe('getMinPositiveValue', () => {
+  it('ignores the excluded key, zeros, negatives and non-numbers', () => {
+    const data = [
+      { category: 'a', up: 0, down: 40 },
+      { category: 'b', up: 3, down: -10 },
+      { category: 'c', up: null, down: 'NAN' },
+    ];
+
+    // 'category' would sort as NaN, 0 and -10 have no logarithm, 'NAN' is a gap
+    // marker.
+    expect(getMinPositiveValue(data, 'category')).toBe(3);
+  });
+
+  it('returns null when nothing is positive', () => {
+    expect(getMinPositiveValue([{ category: 'a', up: 0, down: -1 }], 'category')).toBeNull();
+    expect(getMinPositiveValue([], 'category')).toBeNull();
+  });
+
+  it('reads a numeric string, because that is how prometheus data arrives', () => {
+    expect(getMinPositiveValue([{ timestamp: 1, load: '0.25' }], 'timestamp')).toBe(0.25);
+  });
+});
+
+describe('getLogAxis', () => {
+  it('bounds the axis with the decades enclosing the data', () => {
+    // 3..400 is not 0..400: a log axis cannot start at zero.
+    expect(getLogAxis(3, 400)).toMatchObject({
+      domain: [1, 1000],
+      ticks: [1, 10, 100, 1000],
+    });
+  });
+
+  it('keeps a max that already sits on a decade as its own bound', () => {
+    expect(getLogAxis(1, 1000).domain).toEqual([1, 1000]);
+  });
+
+  it('handles values below one', () => {
+    expect(getLogAxis(0.004, 0.5)).toMatchObject({
+      domain: [0.001, 1],
+      ticks: [0.001, 0.01, 0.1, 1],
+    });
+  });
+
+  it('still gives a decade of height when every value shares a magnitude', () => {
+    // Without this the domain would be [10, 10] and the plot would have no
+    // height.
+    expect(getLogAxis(20, 30)).toMatchObject({
+      domain: [10, 100],
+      ticks: [10, 100],
+    });
+  });
+
+  it('skips whole decades rather than crowding the axis, keeping both bounds', () => {
+    const { domain, ticks } = getLogAxis(1, 1e9, { maxTicks: 4 });
+
+    expect(domain).toEqual([1, 1e9]);
+    expect(ticks.length).toBeLessThanOrEqual(5);
+    expect(ticks[0]).toBe(1);
+    expect(ticks[ticks.length - 1]).toBe(1e9);
+    // Every tick is a decade — a log axis is never subdivided linearly.
+    ticks.forEach((tick) => expect(Number.isInteger(Math.log10(tick))).toBe(true));
+  });
+
+  it('falls back to one empty decade when there is nothing positive to plot', () => {
+    expect(getLogAxis(null, 0)).toMatchObject({ domain: [1, 10], ticks: [1, 10] });
+    expect(getLogAxis(0, 100)).toMatchObject({ domain: [1, 10], ticks: [1, 10] });
+  });
+
+  it('reserves a slot below the first decade for a measured zero', () => {
+    const axis = getLogAxis(3, 400, { withZeroBand: true });
+
+    // The scale still runs 1..1000; the slot sits one position below it.
+    expect(axis.zeroValue).toBe(0.1);
+    expect(axis.domain).toEqual([0.1, 1000]);
+    expect(axis.ticks).toEqual([0.1, 1, 10, 100, 1000]);
+  });
+
+  it('reserves nothing when not asked, so no height is spent on an empty band', () => {
+    const axis = getLogAxis(3, 400);
+
+    expect(axis.zeroValue).toBeNull();
+    expect(axis.domain).toEqual([1, 1000]);
+  });
+
+  it('puts the band below the first decade whatever the magnitude', () => {
+    expect(getLogAxis(0.004, 0.5, { withZeroBand: true })).toMatchObject({
+      zeroValue: 0.0001,
+      domain: [0.0001, 1],
+    });
+  });
+});
+
+describe('formatLogTickValue', () => {
+  it('takes its decimals from the tick, not from the axis maximum', () => {
+    // The same axis has to render both of these legibly.
+    expect(formatLogTickValue(0.001)).toBe('0.001');
+    expect(formatLogTickValue(1)).toBe('1');
+    expect(formatLogTickValue(100)).toBe('100');
+  });
+
+  it('goes compact past ten thousand, in the same ISO style as the linear axis', () => {
+    // formatISONumber separates the suffix with a non-breaking space, so match
+    // the shape rather than pinning the exact whitespace character.
+    expect(formatLogTickValue(1000000)).toMatch(/^1\sM$/);
+  });
+
+  it('renders nothing for a value a log axis has no place for', () => {
+    expect(formatLogTickValue(0)).toBe('');
+    expect(formatLogTickValue(-5)).toBe('');
+  });
+
+  it('labels the reserved band 0, not by the position it occupies', () => {
+    expect(formatLogTickValue(0.1, 0.1)).toBe('0');
+    // Without the band, the same position is just a tick like any other.
+    expect(formatLogTickValue(0.1)).toBe('0.1');
+  });
+});
+
+describe('hasZeroValue', () => {
+  it('is true only for a measured zero, not for a gap or a negative', () => {
+    expect(hasZeroValue([{ category: 'a', up: 0 }], 'category')).toBe(true);
+    expect(hasZeroValue([{ category: 'a', up: '0' }], 'category')).toBe(true);
+    expect(hasZeroValue([{ category: 'a', up: null }], 'category')).toBe(false);
+    expect(hasZeroValue([{ category: 'a', up: -1 }], 'category')).toBe(false);
+    expect(hasZeroValue([{ category: 'a', up: 3 }], 'category')).toBe(false);
+  });
+
+  it('never counts the excluded key, whose zero is not a value', () => {
+    expect(hasZeroValue([{ timestamp: 0, load: 2 }], 'timestamp')).toBe(false);
+  });
+});
+
+describe('placeNonPositiveValues', () => {
+  it('moves a zero to the reserved band, where the axis can draw it', () => {
+    const data = [
+      { category: 'a', up: 0, down: 40 },
+      { category: 'b', up: 0.5, down: 0 },
+    ];
+
+    expect(placeNonPositiveValues(data, 'category', 0.1)).toEqual([
+      { category: 'a', up: 0.1, down: 40 },
+      { category: 'b', up: 0.5, down: 0.1 },
+    ]);
+  });
+
+  it('drops a negative, which has no band and no logarithm', () => {
+    expect(
+      placeNonPositiveValues([{ category: 'a', up: -3 }], 'category', 0.1),
+    ).toEqual([{ category: 'a', up: null }]);
+  });
+
+  it('drops zeros when no band was reserved', () => {
+    expect(
+      placeNonPositiveValues([{ category: 'a', up: 0 }], 'category', null),
+    ).toEqual([{ category: 'a', up: null }]);
+  });
+
+  it('never touches the excluded key, even when it is zero', () => {
+    // A timestamp of 0 is a valid instant, not a value to move.
+    expect(
+      placeNonPositiveValues([{ timestamp: 0, load: 2 }], 'timestamp', 0.1),
+    ).toEqual([{ timestamp: 0, load: 2 }]);
+  });
+
+  it('leaves a gap marker as it found it', () => {
+    expect(
+      placeNonPositiveValues([{ timestamp: 1, load: null }], 'timestamp', 0.1),
+    ).toEqual([{ timestamp: 1, load: null }]);
+  });
+});
+
+describe('readLogPlottedValue', () => {
+  it('reports a value sitting at the band as the zero it is', () => {
+    expect(readLogPlottedValue(0.1, 0.1)).toBe(0);
+  });
+
+  it('leaves every other value alone', () => {
+    expect(readLogPlottedValue(0.5, 0.1)).toBe(0.5);
+    expect(readLogPlottedValue(0.1, null)).toBe(0.1);
   });
 });

--- a/src/lib/components/charts/common/chartUtils.ts
+++ b/src/lib/components/charts/common/chartUtils.ts
@@ -111,6 +111,236 @@ export const getTicks = (
   return ticks;
 };
 
+/* -------------------------------------------------------------------------- */
+/*                             logarithmic Y axis                             */
+/* -------------------------------------------------------------------------- */
+
+/**
+ * Smallest strictly positive value in a chart dataset, or `null` when there is
+ * none.
+ *
+ * A log axis is bounded from below by the data, not by zero, so it needs this
+ * where a linear axis only ever needs the maximum.
+ *
+ * @param data - Recharts rows @param excludeKey - Row key that is not a value
+ * (e.g. 'category', 'timestamp')
+ */
+export const getMinPositiveValue = (
+  // Read-only and shape-agnostic: it is called on both charts' row types, which
+  // differ in whether a value may be null.
+  data: readonly Readonly<Record<string, unknown>>[],
+  excludeKey: string,
+): number | null => {
+  let min: number | null = null;
+  data.forEach((row) => {
+    Object.entries(row).forEach(([key, value]) => {
+      if (key === excludeKey) return;
+      const numberValue = typeof value === 'string' ? Number(value) : value;
+      if (typeof numberValue !== 'number' || !Number.isFinite(numberValue)) {
+        return;
+      }
+      if (numberValue > 0 && (min === null || numberValue < min)) {
+        min = numberValue;
+      }
+    });
+  });
+  return min;
+};
+
+/**
+ * A logarithmic Y axis: its domain, its ticks, and where a measured zero goes.
+ *
+ * Three things make a log axis unlike the linear one built by
+ * `getRoundReferenceValue` + `getTicks`:
+ *
+ * - **It cannot start at zero.** Zero has no logarithm, so the scale is
+ *   bounded by the decades that enclose the data — values from 3 to 400 give
+ *   a 1..1000 scale — and `allowDataOverflow` clips anything below rather than
+ *   letting the axis chase it.
+ * - **Its ticks are the decades.** Evenly spaced linear ticks on a log axis
+ *   crowd into the top of the plot and read as a broken chart. When the data
+ *   spans more decades than `maxTicks`, whole decades are skipped at a
+ *   regular stride — never subdivided.
+ * - **A measured zero needs somewhere to go.** With `withZeroBand`, the axis
+ *   reserves one slot below its first decade and returns it as `zeroValue`.
+ *   Zeros are drawn there and the tick is labelled `0`, so "the metric read
+ *   zero" stops being indistinguishable from "no data" — which is what
+ *   dropping them made it. The slot is a reserved position, not a decade:
+ *   nothing is ever plotted between it and the first decade.
+ *
+ * @param minPositive - Smallest positive value, from `getMinPositiveValue`
+ * @param max - Largest value in the dataset
+ * @param options.maxTicks - Upper bound on the number of decade ticks
+ * @param options.withZeroBand - Reserve a slot for measured zeros. Pass it only
+ *   when the data actually holds one, or the axis spends height on nothing.
+ */
+export const getLogAxis = (
+  minPositive: number | null,
+  max: number,
+  options: { maxTicks?: number; withZeroBand?: boolean } = {},
+): {
+  domain: [number, number];
+  ticks: number[];
+  /** Axis position standing in for a measured zero, or `null` when unused. */
+  zeroValue: number | null;
+} => {
+  const { maxTicks = 6, withZeroBand = false } = options;
+
+  const withBand = (decades: number[]) => {
+    const firstDecade = decades[0];
+    const top = decades[decades.length - 1];
+    const stride = Math.ceil(decades.length / maxTicks);
+    const decadeTicks =
+      stride <= 1
+        ? decades
+        : // Keep both ends: the axis must state its own bounds even when
+          // decades are skipped.
+          [
+            ...decades.filter((_, index) => index % stride === 0),
+            top,
+          ].filter((value, index, all) => all.indexOf(value) === index);
+
+    if (!withZeroBand) {
+      return {
+        domain: [firstDecade, top] as [number, number],
+        ticks: decadeTicks,
+        zeroValue: null,
+      };
+    }
+
+    // One decade's worth of height, below the scale, standing in for zero.
+    const zeroValue = firstDecade / 10;
+    return {
+      domain: [zeroValue, top] as [number, number],
+      ticks: [zeroValue, ...decadeTicks],
+      zeroValue,
+    };
+  };
+
+  // Nothing positive to plot: a single empty decade, so the axis still draws.
+  if (
+    minPositive === null ||
+    minPositive <= 0 ||
+    !Number.isFinite(max) ||
+    max <= 0
+  ) {
+    return withBand([1, 10]);
+  }
+
+  const lowExponent = Math.floor(Math.log10(minPositive));
+  // A max sitting exactly on a decade is already its own bound; anything else
+  // rounds up to the next.
+  const highExponent = Math.ceil(Math.log10(max));
+  // Guarantee at least one decade of height even when every value shares a
+  // magnitude.
+  const topExponent =
+    highExponent > lowExponent ? highExponent : lowExponent + 1;
+
+  return withBand(
+    Array.from(
+      { length: topExponent - lowExponent + 1 },
+      (_, index) => 10 ** (lowExponent + index),
+    ),
+  );
+};
+
+/**
+ * Formats one tick of a logarithmic axis.
+ *
+ * Unlike `formatTickValue`, the number of decimals comes from the tick's own
+ * magnitude rather than from the axis maximum: a 0.01..1000 axis has to render
+ * `0.01` and `1k` on the same axis, and a single decimal count cannot serve
+ * both.
+ *
+ * @param zeroValue - The reserved zero band from `getLogAxis`. It is labelled
+ *   `0`, not by the position it happens to occupy.
+ */
+export const formatLogTickValue = (
+  value: number,
+  zeroValue: number | null = null,
+): string => {
+  if (zeroValue !== null && value === zeroValue) return '0';
+  if (!Number.isFinite(value) || value <= 0) return '';
+  const exponent = Math.log10(value);
+  return formatISONumber(value, {
+    decimals: exponent < 0 ? Math.ceil(-exponent) : 0,
+    fixedDecimals: exponent < 0,
+    compact: value >= 10000,
+  });
+};
+
+/**
+ * Whether any value in the data is a measured zero.
+ *
+ * `getLogAxis` only reserves a zero band when asked, and asking costs a
+ * decade's worth of plot height — so ask only when there is a zero to show.
+ *
+ * @param data - Recharts rows
+ * @param excludeKey - Row key that is not a value (e.g. 'category', 'timestamp')
+ */
+export const hasZeroValue = (
+  data: readonly Readonly<Record<string, unknown>>[],
+  excludeKey: string,
+): boolean =>
+  data.some((row) =>
+    Object.entries(row).some(([key, value]) => {
+      if (key === excludeKey) return false;
+      const numberValue = typeof value === 'string' ? Number(value) : value;
+      return numberValue === 0;
+    }),
+  );
+
+/**
+ * Moves the values a log axis cannot plot to where the axis can show them.
+ *
+ * `log(0)` is minus infinity, so a zero left in the data draws a bar or a line
+ * segment reaching off the bottom of the plot. Given a `zeroValue` from
+ * `getLogAxis`, a zero is moved to that reserved band instead, where the axis
+ * labels it `0` — so a measured zero stays visible, and stays distinguishable
+ * from a missing sample. Dropping it could not do either.
+ *
+ * Negatives have no band and no logarithm, so they are dropped. A series that
+ * goes negative does not belong on a log axis at all.
+ *
+ * With no `zeroValue`, zeros are dropped too — the fallback for a caller that
+ * did not reserve a band.
+ *
+ * @param data - Recharts rows
+ * @param excludeKey - Row key that is not a value (e.g. 'category', 'timestamp')
+ * @param zeroValue - The reserved zero band, or `null` to drop zeros
+ */
+export const placeNonPositiveValues = <T extends Record<string, unknown>>(
+  data: readonly T[],
+  excludeKey: string,
+  zeroValue: number | null,
+): T[] =>
+  data.map((row) => {
+    const placed: Record<string, unknown> = { ...row };
+    Object.entries(row).forEach(([key, value]) => {
+      if (key === excludeKey) return;
+      const numberValue = typeof value === 'string' ? Number(value) : value;
+      if (typeof numberValue !== 'number') return;
+      if (numberValue === 0) {
+        placed[key] = zeroValue;
+      } else if (!(numberValue > 0)) {
+        placed[key] = null;
+      }
+    });
+    return placed as T;
+  });
+
+/**
+ * Turns a plotted value back into the value the caller gave, for display.
+ *
+ * A zero sits at its reserved band in the Recharts data so the axis can draw
+ * it; a tooltip must still say `0`. No real value can collide with the band —
+ * `getLogAxis` puts it below the smallest positive value in the data.
+ */
+export const readLogPlottedValue = (
+  value: number,
+  zeroValue: number | null,
+): number => (zeroValue !== null && value === zeroValue ? 0 : value);
+
 /**
  * Return the unit label based on the current dataset, and the valueBase which is used to convert the data
  * Used by LineTimeSerieChart

--- a/src/lib/components/charts/linetimeseries/LineTimeSerieChart.test.tsx
+++ b/src/lib/components/charts/linetimeseries/LineTimeSerieChart.test.tsx
@@ -5,6 +5,22 @@ import { ChartLegendWrapper } from '../legend/ChartLegendWrapper';
 import { ThemeProvider } from 'styled-components';
 import { coreUIAvailableThemes } from '../../../style/theme';
 
+// ResponsiveContainer measures its parent, which has no size in jsdom, so the
+// chart would render an empty SVG. Give it a fixed box — the same trick
+// Barchart.test.tsx uses — so the axes exist and their ticks can be asserted.
+jest.mock('recharts', () => {
+  const actual = jest.requireActual('recharts');
+
+  return {
+    ...actual,
+    ResponsiveContainer: ({ children }: { children: React.ReactNode }) => (
+      <actual.ResponsiveContainer aspect={3} height={300}>
+        {children}
+      </actual.ResponsiveContainer>
+    ),
+  };
+});
+
 const TestSeries = [
   {
     resource: 'Series 1',
@@ -54,6 +70,99 @@ const renderLineTimeSerieChart = (props: Partial<LineChartProps> = {}) => {
     </ThemeProvider>,
   );
 };
+
+
+describe('LineTimeSerieChart logarithmic Y axis', () => {
+  /**
+   * The Y-axis tick labels, whitespace stripped: formatISONumber groups
+   * thousands with a non-breaking space, which is not what a test wants to pin
+   * down.
+   */
+  const yAxisTicks = (container: HTMLElement) =>
+    Array.from(
+      container.querySelectorAll('.recharts-yAxis-tick-labels text'),
+    ).map((tick) => (tick.textContent ?? '').replace(/\s/g, ''));
+
+  // Two decades apart, with a zero sample a log axis has no place for.
+  const SpanningSeries = [
+    {
+      resource: 'Series 1',
+      getTooltipLabel: () => 'Series 1',
+      data: [
+        [1622505600, 4],
+        [1622509200, 0],
+        [1622512800, 700],
+      ] as [number, number][],
+    },
+  ];
+
+  const renderChart = (props: Record<string, unknown>) =>
+    render(
+      <ThemeProvider theme={coreUIAvailableThemes.artescaLight}>
+        <ChartLegendWrapper colorSet={{ 'Series 1': '#FF0000' }}>
+          <LineTimeSerieChart
+            {...({
+              title: 'Test Chart',
+              series: SpanningSeries,
+              height: 400,
+              startingTimeStamp: 1622505600,
+              interval: 3600,
+              duration: 7200,
+              ...props,
+            } as LineChartProps)}
+          />
+        </ChartLegendWrapper>
+      </ThemeProvider>,
+    );
+
+  it('labels the axis with the decades enclosing the data, plus a zero', () => {
+    const { container } = renderChart({ yAxisScale: 'log' });
+
+    // 4..700 gives a 1..1000 scale — a log axis cannot start at zero — and the
+    // series holds a zero sample, so the axis reserves a slot below it for one.
+    expect(yAxisTicks(container)).toEqual(['0', '1', '10', '100', '1000']);
+  });
+
+  it('reserves no zero slot when the series has none', () => {
+    const { container } = renderChart({
+      yAxisScale: 'log',
+      series: [
+        {
+          resource: 'Series 1',
+          getTooltipLabel: () => 'Series 1',
+          data: [
+            [1622505600, 4],
+            [1622509200, 40],
+            [1622512800, 700],
+          ] as [number, number][],
+        },
+      ],
+    });
+
+    expect(yAxisTicks(container)).toEqual(['1', '10', '100', '1000']);
+  });
+
+  it('keeps the linear ticks when no scale is asked for', () => {
+    const { container } = renderChart({});
+
+    // A linear axis starts at zero and tops out at the data, not at a decade.
+    expect(yAxisTicks(container)[0]).toBe('0');
+    expect(yAxisTicks(container)).not.toContain('1000');
+  });
+
+  it('ignores the scale on a symmetrical chart, whose axis goes negative', () => {
+    // The prop type forbids this pairing; the cast is a plain-JS caller
+    // reaching past it.
+    const { container } = renderChart({
+      yAxisType: 'symmetrical',
+      yAxisScale: 'log',
+      series: { above: SpanningSeries, below: [] },
+    });
+
+    // A negative tick is proof the axis stayed linear.
+    expect(yAxisTicks(container).some((tick) => tick.startsWith('-'))).toBe(true);
+  });
+});
 
 describe('LineTimeSerieChart', () => {
   it('should render when with basic parameters', async () => {

--- a/src/lib/components/charts/linetimeseries/LineTimeSerieChart.tsx
+++ b/src/lib/components/charts/linetimeseries/LineTimeSerieChart.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useRef } from 'react';
+import React, { useCallback, useMemo, useRef } from 'react';
 import {
   Area,
   CartesianGrid,
@@ -13,7 +13,14 @@ import {
 import styled, { useTheme } from 'styled-components';
 import { fontSize } from '../../../style/theme';
 import { ChartHeader, StyledResponsiveContainer } from '../common/SharedComponents';
-import { formatTickValue, getTicks } from '../common/chartUtils';
+import {
+  formatLogTickValue,
+  formatTickValue,
+  getLogAxis,
+  getTicks,
+  hasZeroValue,
+  placeNonPositiveValues,
+} from '../common/chartUtils';
 import { formatXAxisLabel } from './LineTimeSerieChart.utils';
 import { LineChartProps, CHART_PRESETS } from './LineTimeSerieChart.types';
 import { LineTimeSerieChartTooltip } from './LineTimeSerieChartTooltip';
@@ -53,6 +60,7 @@ export function LineTimeSerieChart({
   unitRange,
   isLoading = false,
   yAxisType = 'default',
+  yAxisScale = 'linear',
   yAxisTitle,
   helpText,
   rightTitle,
@@ -79,6 +87,7 @@ export function LineTimeSerieChart({
     rechartsData,
     topDomain,
     topValue,
+    minPositiveValue,
     unitLabel,
     valueBase,
     xAxisTicks,
@@ -92,6 +101,33 @@ export function LineTimeSerieChart({
     yAxisType,
     unitRange,
   });
+
+  // The type keeps 'log' off symmetrical charts; the guard keeps a plain JS
+  // caller from getting a half-drawn axis out of one.
+  const isLogScale = yAxisScale === 'log' && yAxisType !== 'symmetrical';
+
+  const logAxis = useMemo(
+    () =>
+      isLogScale
+        ? getLogAxis(minPositiveValue, topDomain, {
+            // Only spend a band when there is a zero to put in it.
+            withZeroBand: hasZeroValue(rechartsData, 'timestamp'),
+          })
+        : null,
+    [isLogScale, minPositiveValue, topDomain, rechartsData],
+  );
+
+  // A zero sample would draw the line towards minus infinity, so it moves to the
+  // axis's zero band, where the tick reads `0`. Dropping it instead would leave
+  // the same gap `addMissingDataPoint` leaves for a missing sample, and a
+  // measured zero is not missing data.
+  const chartData = useMemo(
+    () =>
+      logAxis
+        ? placeNonPositiveValues(rechartsData, 'timestamp', logAxis.zeroValue)
+        : rechartsData,
+    [logAxis, rechartsData],
+  );
 
   // Format X-axis labels based on duration
   const formatXAxisLabelCallback = useCallback(
@@ -119,7 +155,7 @@ export function LineTimeSerieChart({
       <StyledResponsiveContainer width="100%" height={height}>
         <ComposedChart
           ref={chartRef}
-          data={rechartsData}
+          data={chartData}
           margin={{ top: 0, right: 0, bottom: 0, left: 0 }}
           aria-label={`Time series chart for ${title}`}
           syncId={syncId}
@@ -173,10 +209,13 @@ export function LineTimeSerieChart({
                 fontSize: fontSize.smaller,
               },
             }}
+            scale={logAxis ? 'log' : 'auto'}
             domain={
-              yAxisType === 'symmetrical'
-                ? [-topDomain, topDomain]
-                : [0, topDomain]
+              logAxis
+                ? logAxis.domain
+                : yAxisType === 'symmetrical'
+                  ? [-topDomain, topDomain]
+                  : [0, topDomain]
             }
             allowDataOverflow={true}
             axisLine={resolvedNoYAxisLine ? false : { stroke: theme.border }}
@@ -185,8 +224,15 @@ export function LineTimeSerieChart({
               fill: theme.textSecondary,
               fontSize: fontSize.smaller,
             }}
-            tickFormatter={tickFormatter}
-            ticks={getTicks(topValue, yAxisType === 'symmetrical')}
+            tickFormatter={
+              logAxis
+                ? (value: number) =>
+                    formatLogTickValue(value, logAxis.zeroValue)
+                : tickFormatter
+            }
+            ticks={
+              logAxis ? logAxis.ticks : getTicks(topValue, yAxisType === 'symmetrical')
+            }
             interval={0}
           />
           <Tooltip
@@ -198,6 +244,7 @@ export function LineTimeSerieChart({
                 duration={duration}
                 renderTooltip={renderTooltip}
                 isSymmetrical={yAxisType === 'symmetrical'}
+                logZeroValue={logAxis?.zeroValue ?? null}
                 belowSeriesLabels={belowSeriesLabels}
                 tooltipProps={props}
                 chartContainerRef={chartRef}

--- a/src/lib/components/charts/linetimeseries/LineTimeSerieChart.types.ts
+++ b/src/lib/components/charts/linetimeseries/LineTimeSerieChart.types.ts
@@ -18,6 +18,32 @@ export type Serie = {
 export type NonSymmetricalChartSerie = {
   yAxisType?: 'default' | 'percentage';
   series: Serie[] | undefined;
+  /**
+   * Y-axis scale.
+   *
+   * `'log'` is for a metric whose values span orders of magnitude: on a linear
+   * axis the quiet periods flatten onto the baseline and only the spikes are
+   * readable, and a log axis gives each decade the same height instead. The
+   * axis is bounded by the decades enclosing the data, and its ticks are the
+   * decades themselves.
+   *
+   * It changes the display and nothing else: no value is rescaled, and the
+   * tooltip, the legend and the unit scaling all keep the numbers the caller
+   * passed in.
+   *
+   * One thing to know before reaching for it. Zero has no logarithm, so a
+   * sample of zero or less is dropped and leaves a gap — which is exactly what
+   * a missing sample leaves. On a log axis "measured zero" and "no data" become
+   * indistinguishable, and they are different facts: a zero is a measurement,
+   * missing data is the absence of one. A metric that legitimately reads zero
+   * belongs on a linear axis.
+   *
+   * The negative half of a `'symmetrical'` axis has no logarithm either, which
+   * is why the option does not exist there.
+   *
+   * @default 'linear'
+   */
+  yAxisScale?: 'linear' | 'log';
 };
 
 /**
@@ -26,6 +52,11 @@ export type NonSymmetricalChartSerie = {
  */
 export type SymmetricalChartSerie = {
   yAxisType: 'symmetrical';
+  /**
+   * Not available on a symmetrical chart: its axis spans negative values, which
+   * have no logarithm.
+   */
+  yAxisScale?: never;
   series:
     | {
         above: Serie[] | undefined;
@@ -131,6 +162,11 @@ export type LineTimeSerieChartTooltipProps = {
     duration?: number,
   ) => React.ReactNode;
   isSymmetrical?: boolean;
+  /**
+   * A log axis's reserved zero band. A value drawn there is reported as the 0 it
+   * actually is, not as the position it occupies.
+   */
+  logZeroValue?: number | null;
   belowSeriesLabels?: Set<string>;
   chartContainerRef: React.RefObject<HTMLDivElement>;
   /** The unique ID of this chart instance */

--- a/src/lib/components/charts/linetimeseries/LineTimeSerieChart.types.ts
+++ b/src/lib/components/charts/linetimeseries/LineTimeSerieChart.types.ts
@@ -31,15 +31,15 @@ export type NonSymmetricalChartSerie = {
    * tooltip, the legend and the unit scaling all keep the numbers the caller
    * passed in.
    *
-   * One thing to know before reaching for it. Zero has no logarithm, so a
-   * sample of zero or less is dropped and leaves a gap — which is exactly what
-   * a missing sample leaves. On a log axis "measured zero" and "no data" become
-   * indistinguishable, and they are different facts: a zero is a measurement,
-   * missing data is the absence of one. A metric that legitimately reads zero
-   * belongs on a linear axis.
+   * A zero has no logarithm, so the axis reserves one slot below its first
+   * decade, labels it `0`, and runs zeros along it. A sample that measured zero
+   * stays distinguishable from a missing one — different facts, which a gap
+   * would render identically. The slot costs a decade's worth of height, so it
+   * is only reserved when the series actually holds a zero.
    *
-   * The negative half of a `'symmetrical'` axis has no logarithm either, which
-   * is why the option does not exist there.
+   * A negative sample is dropped and leaves a gap: a metric that goes negative
+   * does not belong on a log axis. The negative half of a `'symmetrical'` axis
+   * has no logarithm either, which is why the option does not exist there.
    *
    * @default 'linear'
    */

--- a/src/lib/components/charts/linetimeseries/LineTimeSerieChartTooltip.test.tsx
+++ b/src/lib/components/charts/linetimeseries/LineTimeSerieChartTooltip.test.tsx
@@ -1,0 +1,105 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { LineTimeSerieChartTooltip } from './LineTimeSerieChartTooltip';
+
+const CHART_ID = 'test-chart';
+
+// The tooltip only renders for the chart the pointer is actually over, which is
+// tracked module-side rather than in props.
+jest.mock('./useChartHover', () => ({
+  getCurrentlyHoveredChartId: () => 'test-chart',
+}));
+
+const mockChartContainer = document.createElement('div');
+const mockChartContainerRef = { current: mockChartContainer };
+
+const testTooltipProps = {
+  payload: [
+    { name: 'storage-node-1', value: 42, color: '#fff' },
+    { name: 'storage-node-2', value: 7, color: '#000' },
+  ],
+  label: new Date('2024-07-01T00:00:00').getTime(),
+  coordinate: { x: 10, y: 10 },
+  active: true,
+  accessibilityLayer: false,
+};
+
+const renderTooltip = (
+  props: Partial<
+    React.ComponentProps<typeof LineTimeSerieChartTooltip>
+  > = {},
+) =>
+  render(
+    <LineTimeSerieChartTooltip
+      tooltipProps={testTooltipProps}
+      duration={0}
+      chartContainerRef={mockChartContainerRef}
+      chartId={CHART_ID}
+      {...props}
+    />,
+  );
+
+describe('LineTimeSerieChartTooltip', () => {
+  it('should render a series and its value', () => {
+    renderTooltip();
+
+    expect(screen.getByText('storage-node-1')).toBeInTheDocument();
+    expect(screen.getByText('42.00')).toBeInTheDocument();
+  });
+
+  it('should hand the payload to a custom renderer', () => {
+    renderTooltip({
+      renderTooltip: (props) => (
+        <div>{props.payload?.map((entry) => entry.value).join(' / ')}</div>
+      ),
+    });
+
+    expect(screen.getByText('42 / 7')).toBeInTheDocument();
+  });
+});
+
+describe('LineTimeSerieChartTooltip on a logarithmic axis', () => {
+  // 0.001 is where getLogAxis put the reserved band: a measured zero is drawn
+  // there because zero has no place on a log scale.
+  const AT_THE_BAND = {
+    ...testTooltipProps,
+    payload: [
+      { name: 'storage-node-1', value: 0.001, color: '#fff' },
+      { name: 'storage-node-2', value: 7, color: '#000' },
+    ],
+  };
+
+  it('should report a sample drawn at the reserved band as the 0 it is', () => {
+    renderTooltip({ tooltipProps: AT_THE_BAND, logZeroValue: 0.001 });
+
+    expect(screen.getByText('0')).toBeInTheDocument();
+    expect(screen.queryByText('0.001')).not.toBeInTheDocument();
+    // Every other value is untouched.
+    expect(screen.getByText('7.00')).toBeInTheDocument();
+  });
+
+  it('should report that same 0 to a custom renderer', () => {
+    renderTooltip({
+      tooltipProps: AT_THE_BAND,
+      logZeroValue: 0.001,
+      renderTooltip: (props) => (
+        <div>{props.payload?.map((entry) => entry.value).join(' / ')}</div>
+      ),
+    });
+
+    // Not '0.001 / 7' — a caller reading the band position would report the
+    // axis's placement as if the metric had measured it.
+    expect(screen.getByText('0 / 7')).toBeInTheDocument();
+  });
+
+  it('should leave the payload alone with no band in play', () => {
+    renderTooltip({
+      tooltipProps: AT_THE_BAND,
+      renderTooltip: (props) => (
+        <div>{props.payload?.map((entry) => entry.value).join(' / ')}</div>
+      ),
+    });
+
+    expect(screen.getByText('0.001 / 7')).toBeInTheDocument();
+  });
+});

--- a/src/lib/components/charts/linetimeseries/LineTimeSerieChartTooltip.tsx
+++ b/src/lib/components/charts/linetimeseries/LineTimeSerieChartTooltip.tsx
@@ -10,7 +10,10 @@ import {
 } from '../common/ChartTooltip';
 import { LineTimeSerieChartTooltipProps } from './LineTimeSerieChart.types';
 import { getCurrentlyHoveredChartId } from './useChartHover';
-import { formatTooltipValueWithUnit } from '../common/chartUtils';
+import {
+  formatTooltipValueWithUnit,
+  readLogPlottedValue,
+} from '../common/chartUtils';
 
 /**
  * Custom tooltip component for LineTimeSerieChart
@@ -26,6 +29,7 @@ export const LineTimeSerieChartTooltip: React.FC<
   tooltipProps,
   renderTooltip,
   isSymmetrical,
+  logZeroValue = null,
   belowSeriesLabels,
   chartContainerRef,
   chartId,
@@ -88,7 +92,9 @@ export const LineTimeSerieChartTooltip: React.FC<
               );
 
               const formattedValue = formatTooltipValueWithUnit(
-                entry.value,
+                // A zero is plotted at the axis's reserved band so it can be
+                // drawn; the tooltip has to report the 0 that was measured.
+                readLogPlottedValue(entry.value, logZeroValue),
                 valueBase,
                 unitRange,
                 unitLabel,

--- a/src/lib/components/charts/linetimeseries/LineTimeSerieChartTooltip.tsx
+++ b/src/lib/components/charts/linetimeseries/LineTimeSerieChartTooltip.tsx
@@ -43,8 +43,27 @@ export const LineTimeSerieChartTooltip: React.FC<
     if (!active || !payload || !payload.length || !label || !isActiveChart)
       return null;
 
+    /**
+     * A zero is plotted at the axis's reserved band so it can be drawn, and
+     * every reader of the payload has to see the 0 that was measured instead.
+     * Mapping the payload once, here, is what keeps the default tooltip and a
+     * caller's `renderTooltip` reporting the same number — the same thing
+     * `getCurrentPoint` does for the Barchart's two paths.
+     */
+    const plottedPayload =
+      logZeroValue === null
+        ? payload
+        : payload.map((entry) => ({
+            ...entry,
+            value: readLogPlottedValue(entry.value, logZeroValue),
+          }));
+
     const tooltipContent = renderTooltip ? (
-      renderTooltip(tooltipProps, unitLabel, duration)
+      renderTooltip(
+        { ...tooltipProps, payload: plottedPayload },
+        unitLabel,
+        duration,
+      )
     ) : (
       <>
         <ChartTooltipHeader>
@@ -53,7 +72,7 @@ export const LineTimeSerieChartTooltip: React.FC<
         <ChartTooltipItemsContainer>
           {(() => {
             // Sort payload: above series first (descending), then below series (ascending by absolute value)
-            const sortedPayload = [...payload].sort((a, b) => {
+            const sortedPayload = [...plottedPayload].sort((a, b) => {
               const aIsBelow = belowSeriesLabels?.has(a.name) ?? false;
               const bIsBelow = belowSeriesLabels?.has(b.name) ?? false;
 
@@ -92,9 +111,7 @@ export const LineTimeSerieChartTooltip: React.FC<
               );
 
               const formattedValue = formatTooltipValueWithUnit(
-                // A zero is plotted at the axis's reserved band so it can be
-                // drawn; the tooltip has to report the 0 that was measured.
-                readLogPlottedValue(entry.value, logZeroValue),
+                entry.value,
                 valueBase,
                 unitRange,
                 unitLabel,

--- a/src/lib/components/charts/linetimeseries/useChartData.ts
+++ b/src/lib/components/charts/linetimeseries/useChartData.ts
@@ -2,6 +2,7 @@ import { useMemo } from 'react';
 import { useChartLegend } from '../legend/ChartLegendWrapper';
 import {
   addMissingDataPoint,
+  getMinPositiveValue,
   normalizeChartDataWithUnits,
 } from '../common/chartUtils';
 import { Serie, isSymmetricalSeries } from './LineTimeSerieChart.types';
@@ -30,6 +31,12 @@ type ChartDataOutput = {
   topDomain: number;
   /** Value used for tick calculation */
   topValue: number;
+  /**
+   * Smallest positive value in the normalized data, or `null` when there is
+   * none. A log axis is bounded from below by the data; a linear one never
+   * needs this.
+   */
+  minPositiveValue: number | null;
   /** Unit label (e.g., "KiB/s", "%") */
   unitLabel: string | undefined;
   /** Factor the dataset was divided by during normalization (for tooltip re-scaling) */
@@ -316,10 +323,16 @@ export function useChartData({
     return labels;
   }, [series, yAxisType]);
 
+  const minPositiveValue = useMemo(
+    () => getMinPositiveValue(rechartsData, 'timestamp'),
+    [rechartsData],
+  );
+
   return {
     rechartsData,
     topDomain,
     topValue,
+    minPositiveValue,
     unitLabel,
     valueBase,
     xAxisTicks,

--- a/src/lib/utils.test.ts
+++ b/src/lib/utils.test.ts
@@ -1,4 +1,4 @@
-import { getContrastText } from './utils';
+import { formatISONumber, getContrastText } from './utils';
 
 const LIGHT_TEXT = '#EAEAEA';
 const DARK_TEXT = '#000000';
@@ -34,8 +34,12 @@ describe('getContrastText', () => {
   });
 
   it('handles rgb color format', () => {
-    expect(getContrastText('rgb(0, 0, 0)', LIGHT_TEXT, DARK_TEXT)).toBe(LIGHT_TEXT);
-    expect(getContrastText('rgb(255, 255, 255)', LIGHT_TEXT, DARK_TEXT)).toBe(DARK_TEXT);
+    expect(getContrastText('rgb(0, 0, 0)', LIGHT_TEXT, DARK_TEXT)).toBe(
+      LIGHT_TEXT,
+    );
+    expect(getContrastText('rgb(255, 255, 255)', LIGHT_TEXT, DARK_TEXT)).toBe(
+      DARK_TEXT,
+    );
   });
 
   it('returns null for unparseable values', () => {
@@ -47,5 +51,38 @@ describe('getContrastText', () => {
       ),
     ).toBeNull();
     expect(getContrastText('not-a-color', LIGHT_TEXT, DARK_TEXT)).toBeNull();
+  });
+});
+
+describe('formatISONumber', () => {
+  /** How the chart tooltips call it. */
+  const tooltip = (value: number) =>
+    formatISONumber(value, { fixedDecimals: true, compact: true });
+
+  it('should never render a non-zero value as zero', () => {
+    expect(tooltip(0.002)).toBe('0.002');
+    expect(tooltip(0.013)).toBe('0.013');
+    expect(tooltip(-0.002)).toBe('-0.002');
+  });
+
+  it('should keep two significant digits below one', () => {
+    expect(tooltip(0.0025)).toBe('0.0025');
+    expect(tooltip(0.00123)).toBe('0.0012');
+  });
+
+  it('should leave values from 0.01 up exactly as they were', () => {
+    expect(tooltip(0.09)).toBe('0.09');
+    expect(tooltip(0.5)).toBe('0.50');
+    expect(tooltip(42.5)).toBe('42.50');
+    // the compact separator is a narrow no-break space, hence the regex
+    expect(tooltip(40000)).toMatch(/^40\.00\sk$/);
+  });
+
+  it('should still reserve 0 for the value zero', () => {
+    expect(tooltip(0)).toBe('0');
+  });
+
+  it('should still fall back to exponential below the 0.001 floor', () => {
+    expect(tooltip(0.0009)).toBe('9e-4');
   });
 });

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -104,6 +104,7 @@ type FormatISONumberOptions = {
  * - Space as thousands separator
  * - Dot as decimal separator
  * - Optional compact notation (10K, 1M, etc.)
+ * - Fractional values: enough decimals to keep two significant digits
  * - Very small values (< 0.001): scientific notation
  */
 export const formatISONumber = (
@@ -120,11 +121,24 @@ export const formatISONumber = (
     return value.toExponential();
   }
 
+  /**
+   * Below 1, `decimals` alone swallows the value: two decimals render 0.002 as
+   * "0.00", which reads as a zero the caller never measured — and on a chart
+   * that reserves a slot for measured zeros, the two are indistinguishable.
+   * The ceiling is raised to whatever keeps two significant digits, which is
+   * the rule `formatLogTickValue` already applies to a log axis tick. It only
+   * ever raises the ceiling, so values from 0.01 up are formatted as before.
+   */
+  const maximumFractionDigits =
+    absValue < 1
+      ? Math.max(decimals, Math.ceil(-Math.log10(absValue)) + 1)
+      : decimals;
+
   // ISO format: space as thousands separator, dot as decimal separator
   // With optional compact notation (10K, 1M, etc.)
   return new Intl.NumberFormat('fr-FR', {
     minimumFractionDigits: fixedDecimals ? decimals : undefined,
-    maximumFractionDigits: decimals,
+    maximumFractionDigits,
     notation: compact ? 'compact' : 'standard',
   })
     .format(value)

--- a/stories/BarChart/barchart.stories.tsx
+++ b/stories/BarChart/barchart.stories.tsx
@@ -1332,3 +1332,61 @@ export const LogarithmicScaleIgnoredWhenStacked: Story = {
     );
   },
 };
+
+/**
+ * The scale as a control, for poking at it against your own numbers.
+ *
+ * `stacked` is here on purpose: turn it on and the axis snaps back to linear, because a stack
+ * places each segment at a cumulative sum and its height would stop matching its value.
+ */
+export const LogarithmicScalePlayground: StoryObj<{
+  yAxisScale: 'linear' | 'log';
+  stacked: boolean;
+  height: number;
+  spread: number;
+}> = {
+  argTypes: {
+    yAxisScale: { control: { type: 'radio' }, options: ['linear', 'log'] },
+    stacked: {
+      control: 'boolean',
+      description: 'Forces the axis back to linear — a log stack misreads',
+    },
+    height: { control: { type: 'range', min: 120, max: 480, step: 20 } },
+    spread: {
+      control: { type: 'range', min: 1, max: 6, step: 1 },
+      description: 'Orders of magnitude between the smallest and largest bar',
+    },
+  },
+  args: { yAxisScale: 'log', stacked: false, height: 240, spread: 4 },
+  render: (args) => {
+    const theme = useTheme() as CoreUITheme;
+    // One bar per decade, so the spread control is exactly what it says.
+    const bars = [
+      {
+        label: 'Requests',
+        data: Array.from(
+          { length: args.spread + 1 },
+          (_, index) => [`1e${index}`, 10 ** index * 2] as [string, number],
+        ),
+      },
+    ] as const;
+
+    return (
+      <div style={{ width: '60%', padding: spacing.r16 }}>
+        <ChartLegendWrapper colorSet={{ Requests: theme.statusHealthy }}>
+          <Stack direction="vertical" gap="r16">
+            <Barchart
+              type={{ type: 'category' }}
+              bars={bars}
+              title="Requests per endpoint"
+              height={args.height}
+              stacked={args.stacked}
+              yAxisScale={args.yAxisScale}
+            />
+            <ChartLegend shape="rectangle" direction="horizontal" />
+          </Stack>
+        </ChartLegendWrapper>
+      </div>
+    );
+  },
+};

--- a/stories/BarChart/barchart.stories.tsx
+++ b/stories/BarChart/barchart.stories.tsx
@@ -1194,3 +1194,141 @@ export const StackedHistogram: Story = {
     );
   },
 };
+
+/**
+ * The same dataset on both scales.
+ *
+ * Values spanning four orders of magnitude are the case a linear axis cannot serve: the axis is
+ * sized by the largest bar, so everything below one thousandth of it lands on the baseline and
+ * reads as zero. A log axis gives every decade the same height, so "2" and "40 000" are both
+ * legible — at the cost of no longer being able to compare bars by eye, which is the trade-off to
+ * make consciously.
+ *
+ * Note that the scale is a display choice only: no value is rescaled, and the tooltips still read
+ * 2, 45, 1200 and 40000.
+ *
+ * `category5` is 0. Zero has no logarithm, so the axis reserves a slot below its first decade,
+ * labels it `0`, and draws the bar there as a stub — visible, and distinct from an absent bar,
+ * which draws nothing at all. The tooltip still reads 0.
+ */
+export const LogarithmicScale: Story = {
+  render: () => {
+    const theme = useTheme() as CoreUITheme;
+    const spanningData = [
+      {
+        label: 'Requests',
+        data: [
+          ['category1', 2],
+          ['category2', 45],
+          ['category3', 1200],
+          ['category4', 40000],
+          ['category5', 0],
+        ],
+      },
+    ] as const;
+
+    return (
+      <div style={{ width: '60%', padding: spacing.r16 }}>
+        <ChartLegendWrapper colorSet={{ Requests: theme.statusHealthy }}>
+          <Stack direction="vertical" gap="r24">
+            <Stack direction="vertical" gap="r8">
+              <Text variant="Basic" isEmphazed>
+                Linear — only the tallest bar is readable
+              </Text>
+              <Barchart
+                type={{ type: 'category' }}
+                bars={spanningData}
+                title="Requests per endpoint"
+                height={200}
+              />
+            </Stack>
+            <Stack direction="vertical" gap="r8">
+              <Text variant="Basic" isEmphazed>
+                Logarithmic — one decade per step; category5 (0) sits at the
+                reserved 0
+              </Text>
+              <Barchart
+                type={{ type: 'category' }}
+                bars={spanningData}
+                title="Requests per endpoint"
+                height={200}
+                yAxisScale="log"
+              />
+            </Stack>
+            <ChartLegend shape="rectangle" direction="horizontal" />
+          </Stack>
+        </ChartLegendWrapper>
+      </div>
+    );
+  },
+};
+
+/**
+ * A log axis and a stack do not combine, so `yAxisScale="log"` is ignored here and the axis stays
+ * linear.
+ *
+ * Stacking places each segment at a running total, so on a log axis a segment's height would be
+ * `log(cumulative) - log(previous cumulative)` — unrelated to the value it represents. The chart
+ * would still draw, and it would be wrong. Compare the two: the ticks are identical.
+ */
+export const LogarithmicScaleIgnoredWhenStacked: Story = {
+  render: () => {
+    const theme = useTheme() as CoreUITheme;
+    const stackedData = [
+      {
+        label: 'Test 1',
+        data: [
+          ['category1', 5],
+          ['category2', 500],
+        ],
+      },
+      {
+        label: 'Test 2',
+        data: [
+          ['category1', 3000],
+          ['category2', 40],
+        ],
+      },
+    ] as const;
+
+    return (
+      <div style={{ width: '60%', padding: spacing.r16 }}>
+        <ChartLegendWrapper
+          colorSet={{
+            'Test 1': theme.statusHealthy,
+            'Test 2': theme.statusWarning,
+          }}
+        >
+          <Stack direction="vertical" gap="r24">
+            <Stack direction="vertical" gap="r8">
+              <Text variant="Basic" isEmphazed>
+                stacked with yAxisScale="log" — falls back to linear
+              </Text>
+              <Barchart
+                type={{ type: 'category' }}
+                bars={stackedData}
+                title="Stacked"
+                height={200}
+                stacked
+                yAxisScale="log"
+              />
+            </Stack>
+            <Stack direction="vertical" gap="r8">
+              <Text variant="Basic" isEmphazed>
+                stacked with no scale asked for
+              </Text>
+              <Barchart
+                type={{ type: 'category' }}
+                bars={stackedData}
+                title="Stacked"
+                height={200}
+                stacked
+              />
+            </Stack>
+            <ChartLegend shape="rectangle" direction="horizontal" />
+          </Stack>
+        </ChartLegendWrapper>
+      </div>
+    );
+  },
+};

--- a/stories/linetimeseriechart.stories.tsx
+++ b/stories/linetimeseriechart.stories.tsx
@@ -1563,3 +1563,57 @@ export const LogarithmicScaleBelowOne: Story = {
     );
   },
 };
+
+/**
+ * The scale as a control, for poking at it against your own shape of data.
+ *
+ * `zeros` is the one worth trying: it drops a stretch of zero samples into the series, and on the
+ * log axis they land on the reserved `0` at the bottom rather than disappearing.
+ */
+export const LogarithmicScalePlayground: StoryObj<{
+  yAxisScale: 'linear' | 'log';
+  baseline: number;
+  spikeTo: number;
+  zeros: boolean;
+}> = {
+  argTypes: {
+    yAxisScale: { control: { type: 'radio' }, options: ['linear', 'log'] },
+    baseline: {
+      control: { type: 'range', min: 0.001, max: 10, step: 0.001 },
+      description: 'Where the series idles',
+    },
+    spikeTo: {
+      control: { type: 'range', min: 1, max: 10000, step: 1 },
+      description:
+        'Peak value — pull it far from the baseline to see what linear cannot show',
+    },
+    zeros: {
+      control: 'boolean',
+      description:
+        'Insert a stretch of measured zeros, which a log axis has to place somewhere',
+    },
+  },
+  args: { yAxisScale: 'log', baseline: 2, spikeTo: 4000, zeros: true },
+  render: (args) => {
+    const data = Array.from({ length: 120 }, (_, index) => {
+      const isZero = args.zeros && index >= 60 && index < 72;
+      const value = isZero
+        ? 0
+        : index % 41 === 0
+          ? args.spikeTo
+          : args.baseline * (1 + (index % 7) * 0.2);
+      return [LOG_START + index * SAMPLE_FREQUENCY_LAST_ONE_HOUR, value] as [
+        number,
+        number,
+      ];
+    });
+
+    return (
+      <ChartWithProviders
+        {...logChartArgs(data)}
+        title={`Request latency — ${args.yAxisScale}`}
+        yAxisScale={args.yAxisScale}
+      />
+    );
+  },
+};

--- a/stories/linetimeseriechart.stories.tsx
+++ b/stories/linetimeseriechart.stories.tsx
@@ -980,7 +980,10 @@ export const EmptyDataExample: Story = {
     return (
       <ChartLegendWrapper
         // @ts-ignore
-        colorSet={{ Success: theme.statusHealthy, Failed: theme.statusCritical }}
+        colorSet={{
+          Success: theme.statusHealthy,
+          Failed: theme.statusCritical,
+        }}
         sortOrder="status"
       >
         <LineTimeSerieChart
@@ -999,7 +1002,6 @@ export const EmptyDataExample: Story = {
   },
 };
 
-
 // Generate 1-hour data with 30s intervals, all zeros
 const generateAllZeroValuesData = (): [number, string][] => {
   const baseTimestamp = 1740405600;
@@ -1016,9 +1018,25 @@ const allZeroValuesData = generateAllZeroValuesData();
 export const AllZeroValuesExample: Story = {
   render: () => {
     return (
-      <ChartLegendWrapper colorSet={{ 'server-1': lineTimeSeriesColorRange[0] }}>
-        <LineTimeSerieChart yAxisType='default' startingTimeStamp={allZeroValuesData[0][0]} interval={SAMPLE_FREQUENCY_LAST_ONE_HOUR} duration={SAMPLE_DURATION_LAST_ONE_HOUR}
-          series={[{ data: allZeroValuesData, resource: 'server-1', metricPrefix: 'bandwidth', getTooltipLabel: (prefix, resource) => `${resource}-${prefix}` }]} title="All Zero Values" height={200} />
+      <ChartLegendWrapper
+        colorSet={{ 'server-1': lineTimeSeriesColorRange[0] }}
+      >
+        <LineTimeSerieChart
+          yAxisType="default"
+          startingTimeStamp={allZeroValuesData[0][0]}
+          interval={SAMPLE_FREQUENCY_LAST_ONE_HOUR}
+          duration={SAMPLE_DURATION_LAST_ONE_HOUR}
+          series={[
+            {
+              data: allZeroValuesData,
+              resource: 'server-1',
+              metricPrefix: 'bandwidth',
+              getTooltipLabel: (prefix, resource) => `${resource}-${prefix}`,
+            },
+          ]}
+          title="All Zero Values"
+          height={200}
+        />
       </ChartLegendWrapper>
     );
   },
@@ -1113,8 +1131,6 @@ const verySmallValuesData: [number, string][] = [
   [1740422880, '0.00000435'],
   [1740423600, '0.00000367'],
 ];
-
-
 
 export const SmallValuesExample: Story = {
   render: () => {
@@ -1254,7 +1270,9 @@ const mixedMagnitudeOpsData: [number, string][] = [
 export const TooltipUnitRangeExample: Story = {
   render: () => {
     return (
-      <ChartLegendWrapper colorSet={{ 'operations': lineTimeSeriesColorRange[0] }}>
+      <ChartLegendWrapper
+        colorSet={{ operations: lineTimeSeriesColorRange[0] }}
+      >
         <LineTimeSerieChart
           series={[
             {
@@ -1370,7 +1388,7 @@ export const BigValuesExample: Story = {
           ]}
           title="Big Values"
           height={200}
-          yAxisTitle='Big Number Example '
+          yAxisTitle="Big Number Example "
           startingTimeStamp={bigValuesData2[0][0]}
           isLoading={false}
           yAxisType={'default'}
@@ -1388,7 +1406,7 @@ export const BigValuesExample: Story = {
           ]}
           title="Big Values"
           height={200}
-          yAxisTitle='Big Number Example '
+          yAxisTitle="Big Number Example "
           startingTimeStamp={bigValuesData2[0][0]}
           isLoading={false}
           unitRange={UNIT_RANGE_BS}
@@ -1401,8 +1419,147 @@ export const BigValuesExample: Story = {
   },
 };
 
+/* -------------------------------------------------------------------------- */
+/*                            logarithmic Y axis                              */
+/* -------------------------------------------------------------------------- */
 
+const LOG_START = 1740405600;
 
+/**
+ * A latency-shaped series: a quiet baseline around 2 ms with occasional spikes into the seconds.
+ * Deterministic, so the two scales below are always compared on the same data.
+ */
+const spikyData = Array.from({ length: 120 }, (_, index) => {
+  const isSpike = index % 17 === 0;
+  const isBigSpike = index % 41 === 0;
+  const value = isBigSpike ? 4200 : isSpike ? 180 : 1.5 + (index % 7) * 0.4;
+  return [LOG_START + index * SAMPLE_FREQUENCY_LAST_ONE_HOUR, value] as [
+    number,
+    number,
+  ];
+});
 
+/** The same series with a stretch of zeros — the values a log axis has no place for. */
+const spikyDataWithZeros = spikyData.map(
+  ([timestamp, value], index) =>
+    [timestamp, index >= 60 && index < 72 ? 0 : value] as [number, number],
+);
 
+const logSerie = (data: [number, number][]): Serie[] => [
+  {
+    data,
+    resource: 'ip-10-160-122-207.eu-north-1.compute.internal',
+    getTooltipLabel: (prefix, resource) => `${resource}`,
+  },
+];
 
+const logChartArgs = (data: [number, number][]) => ({
+  series: logSerie(data),
+  height: 200,
+  startingTimeStamp: LOG_START,
+  interval: SAMPLE_FREQUENCY_LAST_ONE_HOUR,
+  duration: SAMPLE_DURATION_LAST_ONE_HOUR,
+  yAxisTitle: 'ms',
+});
+
+/**
+ * The same series on both scales.
+ *
+ * A metric that idles at 2 ms and spikes to 4 s is the case a linear axis cannot serve: the axis is
+ * sized by the spike, so the baseline — where the metric spends nearly all its time — is pressed
+ * flat against zero and its variation is invisible. A log axis gives every decade the same height,
+ * so the quiet periods and the spikes are both readable.
+ *
+ * The scale is a display choice only: no value is rescaled, and the tooltip still reads the
+ * milliseconds the series carries.
+ *
+ * What you give up: distances no longer read as differences. Two points twice as far apart
+ * vertically are ten times apart in value, not twice. Use it to see shape across magnitudes, not
+ * to compare magnitudes by eye.
+ */
+export const LogarithmicScaleExample: Story = {
+  render: () => (
+    <div>
+      <ChartWithProviders
+        {...logChartArgs(spikyData)}
+        title="Request latency — linear"
+      />
+      <ChartWithProviders
+        {...logChartArgs(spikyData)}
+        title="Request latency — logarithmic"
+        yAxisScale="log"
+      />
+    </div>
+  ),
+};
+
+/**
+ * Zero has no logarithm, so the axis reserves one slot below its first decade and labels it `0`.
+ * The zero samples are drawn there. Note that the step from `0` to the first decade is that single
+ * reserved slot and not one more tenfold step — it is the one place on the axis where the spacing
+ * does not mean a factor of ten.
+ *
+ * This is what keeps "the metric read zero for twelve minutes" from looking like "we have no data
+ * for twelve minutes". Dropping the zeros would leave the same gap a missing sample leaves, and
+ * those are not the same fact; clamping them to the first decade would draw them as the smallest
+ * measured value, a number the reader would believe. The tooltip reports 0 either way.
+ *
+ * A negative sample has neither a logarithm nor a slot, so it is still dropped: a series that goes
+ * negative does not belong on a log axis at all.
+ */
+export const LogarithmicScaleWithZeros: Story = {
+  render: () => (
+    <div>
+      <ChartWithProviders
+        {...logChartArgs(spikyDataWithZeros)}
+        title="With a stretch of zeros — linear"
+      />
+      <ChartWithProviders
+        {...logChartArgs(spikyDataWithZeros)}
+        title="With a stretch of zeros — logarithmic, the zeros sit at the reserved 0"
+        yAxisScale="log"
+      />
+    </div>
+  ),
+};
+
+/**
+ * The axis follows the data's own decades — it is not anchored to 1.
+ *
+ * Here everything sits between 0.001 and 0.1 with occasional spikes to 32 and 50, and the axis
+ * comes out 0.001..100: six decades, one tick each, decimals on the low ones and none on the high
+ * ones. Nothing had to be configured for that; `getLogAxis` reads the smallest positive value and
+ * the largest, and rounds each outwards to a decade.
+ *
+ * On the linear chart above, the entire baseline is a flat line on zero — the axis is sized by the
+ * 50 spike, and 0.002 against 50 is 1/25000 of the plot height.
+ */
+export const LogarithmicScaleBelowOne: Story = {
+  render: () => {
+    // Baseline in the milli range, two spikes four decades above it. Deterministic.
+    const data = Array.from({ length: 120 }, (_, index) => {
+      const value =
+        index === 30 ? 32 : index === 78 ? 50 : 0.002 + (index % 9) * 0.011;
+      return [LOG_START + index * SAMPLE_FREQUENCY_LAST_ONE_HOUR, value] as [
+        number,
+        number,
+      ];
+    });
+
+    return (
+      <div>
+        <ChartWithProviders
+          {...logChartArgs(data)}
+          title="Error rate — linear, the baseline is unreadable"
+          yAxisTitle="/s"
+        />
+        <ChartWithProviders
+          {...logChartArgs(data)}
+          title="Error rate — logarithmic, 0.001 to 100"
+          yAxisTitle="/s"
+          yAxisScale="log"
+        />
+      </div>
+    );
+  },
+};

--- a/stories/linetimeseriechart.stories.tsx
+++ b/stories/linetimeseriechart.stories.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { Meta, StoryObj } from '@storybook/react-webpack5';
 import {
   LineTimeSerieChart,
+  LineChartProps,
   Serie,
   ChartLegendWrapper,
   ChartLegend,
@@ -1445,13 +1446,25 @@ const spikyDataWithZeros = spikyData.map(
     [timestamp, index >= 60 && index < 72 ? 0 : value] as [number, number],
 );
 
+const LOG_RESOURCE = 'storage-node-1';
+
 const logSerie = (data: [number, number][]): Serie[] => [
   {
     data,
-    resource: 'ip-10-160-122-207.eu-north-1.compute.internal',
+    resource: LOG_RESOURCE,
     getTooltipLabel: (prefix, resource) => `${resource}`,
   },
 ];
+
+/** Own legend, so the generic resource label still resolves to a colour. */
+const LogChart = (props: LineChartProps) => (
+  <ChartLegendWrapper
+    colorSet={{ [LOG_RESOURCE]: lineTimeSeriesColorRange[0] }}
+  >
+    <LineTimeSerieChart {...props} />
+    <ChartLegend shape="line" />
+  </ChartLegendWrapper>
+);
 
 const logChartArgs = (data: [number, number][]) => ({
   series: logSerie(data),
@@ -1480,11 +1493,8 @@ const logChartArgs = (data: [number, number][]) => ({
 export const LogarithmicScaleExample: Story = {
   render: () => (
     <div>
-      <ChartWithProviders
-        {...logChartArgs(spikyData)}
-        title="Request latency — linear"
-      />
-      <ChartWithProviders
+      <LogChart {...logChartArgs(spikyData)} title="Request latency — linear" />
+      <LogChart
         {...logChartArgs(spikyData)}
         title="Request latency — logarithmic"
         yAxisScale="log"
@@ -1510,11 +1520,11 @@ export const LogarithmicScaleExample: Story = {
 export const LogarithmicScaleWithZeros: Story = {
   render: () => (
     <div>
-      <ChartWithProviders
+      <LogChart
         {...logChartArgs(spikyDataWithZeros)}
         title="With a stretch of zeros — linear"
       />
-      <ChartWithProviders
+      <LogChart
         {...logChartArgs(spikyDataWithZeros)}
         title="With a stretch of zeros — logarithmic, the zeros sit at the reserved 0"
         yAxisScale="log"
@@ -1548,12 +1558,12 @@ export const LogarithmicScaleBelowOne: Story = {
 
     return (
       <div>
-        <ChartWithProviders
+        <LogChart
           {...logChartArgs(data)}
           title="Error rate — linear, the baseline is unreadable"
           yAxisTitle="/s"
         />
-        <ChartWithProviders
+        <LogChart
           {...logChartArgs(data)}
           title="Error rate — logarithmic, 0.001 to 100"
           yAxisTitle="/s"
@@ -1609,7 +1619,7 @@ export const LogarithmicScalePlayground: StoryObj<{
     });
 
     return (
-      <ChartWithProviders
+      <LogChart
         {...logChartArgs(data)}
         title={`Request latency — ${args.yAxisScale}`}
         yAxisScale={args.yAxisScale}


### PR DESCRIPTION
**Component**: `charts` — Barchart, LineTimeSerieChart

**TL;DR** — Adds an opt-in logarithmic Y axis to `Barchart` and `LineTimeSerieChart`.

Split out of #1190, which carried this plus a heatmap. The heatmap is in its own PR now; this one is the axis and nothing else.

### Context / Why

A metric that idles at 2 ms and spikes to 4 s cannot be read on a linear axis: the axis is sized by the spike, so the baseline where the metric spends nearly all its time is pressed flat against zero.

### 🧩 Approach

`yAxisScale="log"`, defaulting to `linear`. It is a display option and nothing more: no value is rescaled, and tooltips, legend and unit scaling all keep the numbers the caller passed in. Only the axis and where the marks land on it change.

Three things a log axis has to do differently, all in `charts/common` so both charts share them:

| | Why |
|---|---|
| The scale cannot start at zero | Bounded by the decades enclosing the data, read off the smallest positive value and the largest — so it follows the data rather than being anchored to 1. Values between 0.001 and 0.1 with spikes to 50 give a 0.001..100 axis. |
| Its ticks are the decades | Evenly spaced linear ticks on a log axis crowd into the top of the plot and read as a broken chart. Past six decades, whole decades are skipped — never subdivided. |
| A measured zero needs somewhere to go | It has no logarithm and no place on the scale, so the axis reserves one slot below its first decade, labels it `0`, and draws zeros there. |

That last one is the part worth arguing about. Without the reserved slot a zero has to be dropped, and a dropped zero leaves exactly the gap a missing sample leaves — making "the metric read zero" indistinguishable from "we have no data", which are not the same fact. Clamping to the first decade is worse, not better: it draws the zero as the smallest measured value, a number the reader will believe. The slot costs a decade's worth of height, so it is only reserved when the data actually holds a zero.

Two pairings are refused rather than drawn wrong. **Stacked bars fall back to linear**, since stacking places each segment at a cumulative sum and a segment's height would stop matching its value. **A symmetrical line chart refuses the scale at the type level** — half its axis is negative by construction.

### 📷 Screenshots

**Barchart — `LogarithmicScale`.** Linear on top: only the 40 000 bar is legible. Log below: every decade gets the same height, and `category5` (value `0`) is the stub at the reserved `0`.

<img width="668" height="589" alt="Barchart logarithmic scale story, linear and log side by side" src="https://github.com/user-attachments/assets/9c4112f4-3e38-4e72-bf18-224c1a36a47d" />

**LineTimeSerieChart — `LogarithmicScaleExample`.** Same series twice. On the linear axis the baseline is a flat line on zero; on the log axis its variation and both spike tiers are readable.

<img width="1094" height="512" alt="LineTimeSerieChart logarithmic scale story, linear and log side by side" src="https://github.com/user-attachments/assets/5a06da2a-9d01-44cd-946b-b34b242724b1" />

### 🔍 Review focus

- 🟡 **Moderate** — `charts/common/chartUtils.ts › getLogAxis`, `placeNonPositiveValues` — the domain, the decade ticks and the reserved zero slot. The zero handling is the design decision in this PR; if you disagree with reserving a slot, this is the place to say so.
- 🟡 **Moderate** — `utils.ts › formatISONumber` — the raised decimal ceiling, and the only change outside `charts/`. `formatISONumber` is exported from the package root, so every caller sees it; it can only ever add decimals to a value below `1`, never remove any.
- 🟡 **Moderate** — `barchart/Barchart.utils.ts › getCurrentPoint` and `LineTimeSerieChartTooltip` — a zero is plotted at the reserved slot, so both tooltips map it back before formatting, including a caller's own Barchart `tooltip` renderer. No real value can collide with the slot: it sits below the smallest positive value in the data.

### 🧪 How to test

```bash
npm run storybook
```

*Charts → Barchartv2* and *Charts → LineTimeSerieChart*:

1. Open `Logarithmic scale` on either chart and compare the two stacked charts. Same data, only the axis differs.
2. Open `Logarithmic scale playground` and use the Controls panel — `yAxisScale` flips the axis live.
3. On the Barchart playground, tick **`stacked`**. The axis snaps back to linear: that is the documented refusal, not a bug.
4. On the LineTimeSerieChart playground, tick **`zeros`**. The zeros land on the reserved `0` at the bottom; untick and the axis loses that slot.
5. `Logarithmic scale below one` shows the axis following data between 0.001 and 0.1 with spikes to 50 — nothing is anchored to 1.
6. Still on that story, hover the baseline: the tooltip reads `0.002 /s`, not the `0.00 /s` it used to round to.

Theme switching is worth a pass: the reserved `0` and the tick colours come from tokens.

```bash
npm test -- src/lib/components/charts src/lib/utils.test.ts
```

### 🔗 References

**Breaking Changes**: none on the charts — `yAxisScale` is optional and defaults to `linear`, so every existing caller renders exactly as before. The one output change is `formatISONumber` on values below `0.01`, which is the bug fix itself: a caller that was getting `0.00` for `0.002` now gets `0.002`.

**Also fixes a tooltip rounding bug this PR surfaced.** On `LogarithmicScaleBelowOne` the tooltip printed `0.00 /s` for a measured `0.002`: `formatISONumber` capped the fraction at two decimals, while the axis derives its decimals from each tick's own magnitude. A rounded `0.00` is indistinguishable from the `0` the reserved slot legitimately reports — which is the exact confusion this PR exists to remove, so it is fixed here rather than deferred.

Below `1`, `formatISONumber` now raises its decimal ceiling to whatever keeps **two significant digits** — `0.002`, `0.0012`, `0.0025` — the same rule `formatLogTickValue` already applies to a tick, so a tooltip and the tick beside it agree. It only ever raises the ceiling, never lowers it, so every value from `0.01` up formats exactly as before. Two things it does *not* change: `0` still renders as `0`, and the `0.001` floor below which a value switches to scientific notation (`0.0009` → `9e-4`) is pre-existing and untouched — the notation switch is keyed on the value's magnitude, not on a digit count.

No issue or ticket for this one.

<details><summary>What changed</summary>

`charts/common/chartUtils.ts` carries the whole log-axis vocabulary — `getLogAxis`, `getMinPositiveValue`, `hasZeroValue`, `placeNonPositiveValues`, `formatLogTickValue`, `readLogPlottedValue` — next to `getRoundReferenceValue`/`getTicks`, which do the same job for the linear axis. Both charts wire it the same way, which is why the two diffs read almost identically.

`utils.ts` is the only file outside `charts/` — `formatISONumber`'s decimal ceiling, with `utils.test.ts` gaining a `formatISONumber` describe alongside the existing `getContrastText` one.

</details>

